### PR TITLE
[feat] 공통 타입 정의

### DIFF
--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,21 +1,20 @@
 import type { Role, BeltLevel } from './user';
 
-export type SignInForm = {
+export interface SignInForm {
   email: string;
   password: string;
-};
+}
 
-export type SignUpForm = {
+export interface SignUpForm {
   role: Role;
   name: string;
   email: string;
   password: string;
   passwordConfirm: string;
   belt_level: BeltLevel;
-  // 도장 회원 전용
   business_number?: string;
   representative?: string;
   contact?: string;
   address?: string;
   business_file?: File;
-};
+}

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,21 @@
+import type { Role, BeltLevel } from './user';
+
+export type SignInForm = {
+  email: string;
+  password: string;
+};
+
+export type SignUpForm = {
+  role: Role;
+  name: string;
+  email: string;
+  password: string;
+  passwordConfirm: string;
+  belt_level: BeltLevel;
+  // 도장 회원 전용
+  business_number?: string;
+  representative?: string;
+  contact?: string;
+  address?: string;
+  business_file?: File;
+};

--- a/src/types/community.ts
+++ b/src/types/community.ts
@@ -1,8 +1,6 @@
-import type { Profile } from './user';
-
 export type PostCategory = '일반 게시글' | '도장 홍보';
 
-export type Post = {
+export interface Post {
   id: string;
   user_id: string;
   title: string;
@@ -13,14 +11,20 @@ export type Post = {
   report_count: number;
   created_at: string;
   updated_at?: string;
-  profiles?: Profile;
-};
+  // profiles join (flat)
+  nickname?: string;
+  avatar_url?: string;
+  belt_level?: string;
+}
 
-export type Comment = {
+export interface Comment {
   id: string;
   post_id: string;
   user_id: string;
   content: string;
   created_at: string;
-  profiles?: Profile;
-};
+  // profiles join (flat)
+  nickname?: string;
+  avatar_url?: string;
+  belt_level?: string;
+}

--- a/src/types/community.ts
+++ b/src/types/community.ts
@@ -1,0 +1,26 @@
+import type { Profile } from './user';
+
+export type PostCategory = '일반 게시글' | '도장 홍보';
+
+export type Post = {
+  id: string;
+  user_id: string;
+  title: string;
+  content: string;
+  category: PostCategory;
+  image_url?: string;
+  view_count: number;
+  report_count: number;
+  created_at: string;
+  updated_at?: string;
+  profiles?: Profile;
+};
+
+export type Comment = {
+  id: string;
+  post_id: string;
+  user_id: string;
+  content: string;
+  created_at: string;
+  profiles?: Profile;
+};

--- a/src/types/competition.ts
+++ b/src/types/competition.ts
@@ -1,6 +1,6 @@
 export type CompetitionStatus = '모집중' | '마감임박' | '모집 완료';
 
-export type Competition = {
+export interface Competition {
   id: string;
   name: string;
   location: string;
@@ -8,4 +8,4 @@ export type Competition = {
   category?: string;
   status: CompetitionStatus;
   created_at: string;
-};
+}

--- a/src/types/competition.ts
+++ b/src/types/competition.ts
@@ -1,0 +1,11 @@
+export type CompetitionStatus = '모집중' | '마감임박' | '모집 완료';
+
+export type Competition = {
+  id: string;
+  name: string;
+  location: string;
+  event_date: string;
+  category?: string;
+  status: CompetitionStatus;
+  created_at: string;
+};

--- a/src/types/dojang.ts
+++ b/src/types/dojang.ts
@@ -1,0 +1,10 @@
+export type Dojang = {
+  id: string;
+  name: string;
+  address: string;
+  lat?: number;
+  lng?: number;
+  phone?: string;
+  style_tags?: string[];
+  created_at: string;
+};

--- a/src/types/dojang.ts
+++ b/src/types/dojang.ts
@@ -1,4 +1,4 @@
-export type Dojang = {
+export interface Dojang {
   id: string;
   name: string;
   address: string;
@@ -7,4 +7,4 @@ export type Dojang = {
   phone?: string;
   style_tags?: string[];
   created_at: string;
-};
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,22 @@
+export type Role = 'user' | 'dojang' | 'admin';
+
+export type BeltLevel = 'White' | 'Blue' | 'Purple' | 'Brown' | 'Black';
+
+export type Profile = {
+  id: string;
+  nickname: string;
+  avatar_url?: string;
+  bio?: string;
+  belt_level: BeltLevel;
+  role: Role;
+  phone_value?: string;
+  email_value?: string;
+  created_at: string;
+  // 도장 회원 추가 필드
+  name?: string;
+  business_number?: string;
+  representative?: string;
+  contact?: string;
+  address?: string;
+  business_file_url?: string;
+};

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -2,7 +2,7 @@ export type Role = 'user' | 'dojang' | 'admin';
 
 export type BeltLevel = 'White' | 'Blue' | 'Purple' | 'Brown' | 'Black';
 
-export type Profile = {
+export interface Profile {
   id: string;
   nickname: string;
   avatar_url?: string;
@@ -12,11 +12,10 @@ export type Profile = {
   phone_value?: string;
   email_value?: string;
   created_at: string;
-  // 도장 회원 추가 필드
   name?: string;
   business_number?: string;
   representative?: string;
   contact?: string;
   address?: string;
   business_file_url?: string;
-};
+}


### PR DESCRIPTION
## 📌 개요

- 프로젝트 개발에 사용할 공통 타입 정의

## 💻 작업 사항

- 정의한 타입-auth, community, competition, dojang, user
- supabase에 dojang, competition - DB 컬럼명 통일
- supabase profiles 테이블에 아래 목록 추가

name - 실명 (회원가입 때 이름 입력)
business_number - 사업자등록번호 (도장 회원만)
representative - 대표자명 (도장 회원만)
Phone_value - 연락처 (도장 회원만)
address - 주소 (도장 회원만)
business_file_url - 사업자등록증 파일 URL (도장 회원만)

<img width="1020" height="516" alt="image" src="https://github.com/user-attachments/assets/77d847fc-46bf-4b96-821b-e02b9ceb8524" />

## 💡 관련 Issue

Closes #17 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #)
