### PR TITLE
[feat] 게시글 API 연결

### DIFF
--- a/src/app/(main)/community/[id]/page.tsx
+++ b/src/app/(main)/community/[id]/page.tsx
@@ -188,8 +188,7 @@ export default function PostDetailPage({
                 <Image src="/postEdit.svg" alt="수정" width={30} height={30} />
               </button>
               <button
-                // 클릭시 실제 supabase 데이터가 삭제됨으로 테스트를 위해 주석 처리
-                // onClick={handleDeletePost}
+                onClick={handleDeletePost}
                 className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-red-50 transition-colors text-red-400 cursor-pointer"
                 title="삭제"
               >

--- a/src/app/(main)/community/[id]/page.tsx
+++ b/src/app/(main)/community/[id]/page.tsx
@@ -188,7 +188,8 @@ export default function PostDetailPage({
                 <Image src="/postEdit.svg" alt="수정" width={30} height={30} />
               </button>
               <button
-                onClick={handleDeletePost}
+                // 클릭시 실제 supabase 데이터가 삭제됨으로 테스트를 위해 주석 처리
+                // onClick={handleDeletePost}
                 className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-red-50 transition-colors text-red-400 cursor-pointer"
                 title="삭제"
               >

--- a/src/app/(main)/community/write/page.tsx
+++ b/src/app/(main)/community/write/page.tsx
@@ -26,7 +26,10 @@ export default function WritePage() {
   };
 
   const handleSubmit = async () => {
-    if (!title.trim() || !content.trim()) return;
+    if (!title.trim() || !content.trim()) {
+      alert('제목과 내용을 모두 입력해주세요.');
+      return;
+    }
     setIsLoading(true);
     try {
       // const {

--- a/src/app/(main)/community/write/page.tsx
+++ b/src/app/(main)/community/write/page.tsx
@@ -5,6 +5,8 @@ import { useRouter } from 'next/navigation';
 import type { PostCategory } from '@/types/community';
 import Image from 'next/image';
 import LoadingSpinner from '@/components/common/LoadingSpinner';
+import { supabase } from '@/lib/supabase';
+import { createPost, uploadPostImage } from '@/services/communityService';
 
 export default function WritePage() {
   const router = useRouter();
@@ -13,18 +15,43 @@ export default function WritePage() {
   const [content, setContent] = useState('');
   const [preview, setPreview] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [imageFile, setImageFile] = useState<File | null>(null);
 
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    if (file) setPreview(URL.createObjectURL(file));
+    if (file) {
+      setImageFile(file);
+      setPreview(URL.createObjectURL(file));
+    }
   };
 
   const handleSubmit = async () => {
+    if (!title.trim() || !content.trim()) return;
     setIsLoading(true);
     try {
-      // TODO: API 연동
-      console.log({ category, title, content });
+      // const {
+      //   data: { user },
+      // } = await supabase.auth.getUser();
+      // if (!user) throw new Error('로그인이 필요합니다.');
+
+      const user = { id: 'a374f29b-158d-4835-b213-7df0d8915b4b' }; // TODO: 로그인 구현 후 제거
+
+      let image_url: string | undefined;
+      if (imageFile) {
+        image_url = await uploadPostImage(imageFile);
+      }
+
+      await createPost({
+        category,
+        title,
+        content,
+        image_url,
+        user_id: user.id,
+      });
       router.push('/community');
+    } catch (e) {
+      console.error(e);
+      alert('게시글 작성에 실패했습니다.');
     } finally {
       setIsLoading(false);
     }

--- a/src/services/communityService.ts
+++ b/src/services/communityService.ts
@@ -7,8 +7,6 @@ export async function getPosts() {
     // .select('*, profiles(nickname, avatar_url, belt_level)')
     .select('*')
     .order('created_at', { ascending: false });
-  console.log('data:', data);
-  console.log('error:', error);
 
   if (error) throw error;
   return data as Post[];
@@ -76,7 +74,8 @@ export async function deletePost(id: string) {
 }
 
 export async function uploadPostImage(file: File): Promise<string> {
-  const fileName = `${Date.now()}_${file.name}`;
+  const ext = file.name.split('.').pop();
+  const fileName = `${Date.now()}.${ext}`; // 한글 파일명 제거
   const { error } = await supabase.storage
     .from('post-images')
     .upload(fileName, file);


### PR DESCRIPTION
## 📌 개요

- 게시글 작성페이지에서 작성한 데이터를 supabase API에 연결

## 💻 작업 사항

아직 로그인 기능이 없기 때문에 id 강제 부여
<img width="963" height="320" alt="image" src="https://github.com/user-attachments/assets/ac6d8c8f-6732-4032-b7b6-1a959fd916b8" />

---

이미지를 올리기 위해 Supabase Storage에 post-images 버킷 추가

<img width="1637" height="464" alt="image" src="https://github.com/user-attachments/assets/a6b94c4f-ed3f-4b18-8901-dad75b1eeaf9" />

업로드되는 파일의 파일명이 한글일 경우를 대비해 파일명 제거하는 함수 작성

<img width="858" height="292" alt="image" src="https://github.com/user-attachments/assets/21000897-666d-4d46-bc84-59419edd2e0d" />


---

- 게시글 작성페이지에서 작성한 데이터를 supabase API에 연결(handleSubmit과 이미지 관련 state 부분 수정)
- 게시글 유형 별로 아이콘 표시 확인 (일반 / 도장)

<img width="1396" height="795" alt="image" src="https://github.com/user-attachments/assets/7adb7eb7-a5dc-4543-b684-7cd3ad1b818f" />

---

- 내용이 비어있을시 경고 알람창 표시

<img width="1018" height="893" alt="image" src="https://github.com/user-attachments/assets/cbb3bd5c-de55-4879-81dc-0629577dc1e3" />


---

## 💡 관련 Issue

Closes #27 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #27 )
- [x] 불필요한 console.log를 제거했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
