### PR TITLE
[Feat]: 로그인 시 사이드바 구현 및 조회수 기능 추가

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -4,11 +4,27 @@ import React, { useState } from 'react';
 import Image from 'next/image';
 import { Mail, Lock } from 'lucide-react';
 import Link from 'next/link';
+import { supabase } from '@/lib/supabase';
+import { useRouter } from 'next/navigation';
 
 export default function LoginPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [stayLoggedIn, setStayLoggedIn] = useState(false);
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const { error } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+    if (error) {
+      alert(error.message);
+      return;
+    }
+    router.back();
+  };
 
   return (
     <>
@@ -34,7 +50,7 @@ export default function LoginPage() {
           로그인
         </h2>
 
-        <form className="space-y-5">
+        <form className="space-y-5" onSubmit={handleSubmit}>
           <div>
             {/* 이메일 입력 */}
             <label
@@ -92,7 +108,6 @@ export default function LoginPage() {
                 로그인 상태 유지
               </span>
             </label>
-            {/* 비밀번호 찾기 - Next.js에서는 a태그 대신 Link 사용 권장*/}
             <Link
               href="/forgot-password"
               className="text-sm font-bold hover:underline"
@@ -110,7 +125,6 @@ export default function LoginPage() {
           </button>
           <p className="text-center text-sm text-text-secondary">
             아직 회원이 아니신가요?{' '}
-            {/* 회원가입 - Next.js에서는 a태그 대신 Link 사용 권장*/}
             <Link
               href="/register"
               className="font-bold hover:underline"

--- a/src/app/(main)/community/[id]/page.tsx
+++ b/src/app/(main)/community/[id]/page.tsx
@@ -8,6 +8,7 @@ import {
   createComment,
   deletePost,
   deleteComment,
+  incrementViewCount,
 } from '@/services/communityService';
 import { supabase } from '@/lib/supabase';
 import type { Post, Comment } from '@/types/community';
@@ -53,6 +54,7 @@ export default function PostDetailPage({
         setPost(postData);
         setComments(commentsData);
         setUserId(user?.id ?? null);
+        await incrementViewCount(id);
       } catch (e) {
         console.error(e);
       } finally {

--- a/src/app/(main)/competitions/page.tsx
+++ b/src/app/(main)/competitions/page.tsx
@@ -3,9 +3,9 @@ import { useState, useRef, useEffect } from 'react';
 import Pageheader from '@/components/layout/PageHeader';
 import CompetitionCard from '@/components/competition/CompetitionCard';
 import { useDebounce } from '@/hooks/useDebounce';
-import { useUserRole } from '../../../hooks/useUserRole';
 import LoadingSpinner from '@/components/common/LoadingSpinner';
 import { useCompetiton } from '@/hooks/useCompetition';
+import { useAuth } from '@/hooks/useAuth';
 
 export default function CompetitionsPage() {
   const [activeTab, setActiveTab] = useState('전체');
@@ -13,9 +13,10 @@ export default function CompetitionsPage() {
   const [headerHeight, setHeaderHeight] = useState(0);
   const headerRef = useRef<HTMLDivElement>(null);
   const debouncedSearch = useDebounce(searchQuery, 300);
-  // const userRole = useUserRole();
-  const userRole: string = 'admin'; // 임시 테스트용
   const { data, isLoading } = useCompetiton();
+  const { user } = useAuth();
+  const isAdmin = user?.role === 'admin';
+  const isManager = user?.role === 'manager';
 
   useEffect(() => {
     if (headerRef.current) {
@@ -46,11 +47,7 @@ export default function CompetitionsPage() {
             setActiveTab={setActiveTab}
             searchQuery={searchQuery}
             setSearchQuery={setSearchQuery}
-            writeLink={
-              userRole === 'manager' || userRole === 'admin'
-                ? '/competitions/write'
-                : undefined
-            }
+            writeLink={isManager || isAdmin ? '/competitions/write' : undefined}
             writeLinkText="일정추가"
           />
         </div>

--- a/src/components/community/Postcard.tsx
+++ b/src/components/community/Postcard.tsx
@@ -39,13 +39,16 @@ export default function PostCard({ post }: PostCardProps) {
         {/* 썸네일 + 배지 */}
         <div className="relative shrink-0">
           {post.image_url ? (
-            <Image
-              src={post.image_url}
-              alt={post.title}
-              width={400}
-              height={200}
-              className="w-full h-50 object-cover"
-            />
+            <div className="relative w-full h-50">
+              <Image
+                src={post.image_url}
+                alt={post.title}
+                fill
+                sizes="(max-width: 768px) 100vw, 50vw"
+                loading="eager"
+                className="object-cover"
+              />
+            </div>
           ) : (
             <div className="w-full h-50 bg-btn-basic flex items-center justify-center">
               <span className="text-text-secondary text-sm">이미지 없음</span>
@@ -83,13 +86,15 @@ export default function PostCard({ post }: PostCardProps) {
           {/* 프로필 + 좋아요 */}
           <div className="flex items-center justify-between pt-2">
             <div className="flex items-center gap-2">
-              <Image
-                src={post.avatar_url || '/basic.svg'}
-                alt={post.nickname}
-                width={24}
-                height={24}
-                className="rounded-full object-cover"
-              />
+              <div className="relative w-6 h-6 shrink-0">
+                <Image
+                  src={post.avatar_url || '/basic.svg'}
+                  alt={post.nickname}
+                  fill
+                  sizes="24px"
+                  className="rounded-full object-cover"
+                />
+              </div>
               <span className="text-sm">{post.nickname}</span>
             </div>
 

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -108,30 +108,32 @@ export default function Sidebar() {
           <div className="h-12" />
         ) : user ? (
           <div className="flex flex-col gap-2">
-            <div className="flex items-center gap-3 px-2 py-1">
-              <div className="w-9 h-9 rounded-full bg-btn-basic flex items-center justify-center overflow-hidden shrink-0">
-                {user.image ? (
-                  <Image
-                    src={user.image}
-                    alt={user.name}
-                    width={36}
-                    height={36}
-                  />
-                ) : (
-                  <span className="text-sm font-medium text-btn-text">
-                    {user.name[0]}
+            <Link href="/mypage">
+              <div className="flex items-center gap-3 px-2 py-1 rounded-lg hover:bg-btn-basic transition-colors cursor-pointer">
+                <div className="w-9 h-9 rounded-full bg-btn-basic flex items-center justify-center overflow-hidden shrink-0">
+                  {user.image ? (
+                    <Image
+                      src={user.image}
+                      alt={user.name ?? '프로필 이미지'}
+                      width={36}
+                      height={36}
+                    />
+                  ) : (
+                    <span className="text-sm font-medium text-btn-text">
+                      {user.name?.[0] ?? '?'}
+                    </span>
+                  )}
+                </div>
+                <div className="flex flex-col overflow-hidden">
+                  <span className="text-sm font-medium text-text-primary truncate">
+                    {user.name ?? '이름 없음'}
                   </span>
-                )}
+                  <span className="text-xs text-text-secondary">
+                    {isAdmin ? 'Admin' : (user.belt ?? '')}
+                  </span>
+                </div>
               </div>
-              <div className="flex flex-col overflow-hidden">
-                <span className="text-sm font-medium text-text-primary truncate">
-                  {user.name}
-                </span>
-                <span className="text-xs text-text-secondary">
-                  {isAdmin ? 'Admin' : user.belt}
-                </span>
-              </div>
-            </div>
+            </Link>
             <Button
               variant="ghost"
               className="w-full h-10 gap-2 text-text-secondary hover:text-text-primary"

--- a/src/services/communityService.ts
+++ b/src/services/communityService.ts
@@ -132,3 +132,6 @@ export async function deleteComment(id: string) {
   const { error } = await supabase.from('comments').delete().eq('id', id);
   if (error) throw error;
 }
+export async function incrementViewCount(id: string) {
+  await supabase.rpc('increment_view_count', { post_id: id });
+}


### PR DESCRIPTION
## 📌 개요

- 로그인 시 사이드바 구현
- 조회수 기능 추가

## 💻 작업 사항

- 로그인 시 사이드바 구현 (도장 회원 시 대회일정 일정추가 버튼 가시화)
<img width="1209" height="883" alt="스크린샷 2026-04-28 시간: 12 43 55" src="https://github.com/user-attachments/assets/56edbd0b-a2a7-4cf5-b4fc-7ab30821ccd1" />
<img width="1213" height="884" alt="스크린샷 2026-04-28 시간: 12 44 11" src="https://github.com/user-attachments/assets/fb8a5cd0-b63c-47ca-9cf1-6e5725ccd683" />

- 조회수 기능 추가
<img width="472" height="391" alt="스크린샷 2026-04-28 시간: 12 44 26" src="https://github.com/user-attachments/assets/30dd6dbd-4ccf-4b8e-9e99-6e9dc7238b40" />


## 💡 관련 Issue
- 조회 시 카운트가 2씩 증가함 -> 중간배포 후 재확인 필요
Closes #35 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #35)
- [x] 기능이 정상 동작하는지 확인했습니다.
