### PR TITLE
[feat] 게시글 댓글 수정 기능 추가, 임시 로그인 코드 삭제, 댓글 작성자 프로필 연동

### DIFF
--- a/src/app/(main)/community/[id]/page.tsx
+++ b/src/app/(main)/community/[id]/page.tsx
@@ -36,6 +36,8 @@ export default function PostDetailPage({
   const [comment, setComment] = useState('');
   const [userId, setUserId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [editingCommentId, setEditingCommentId] = useState<string | null>(null);
+  const [editingContent, setEditingContent] = useState('');
 
   useEffect(() => {
     const load = async () => {
@@ -89,6 +91,25 @@ export default function PostDetailPage({
     }
   };
 
+  const handleEditComment = async (commentId: string) => {
+    if (!editingContent.trim()) return;
+    try {
+      await supabase
+        .from('comments')
+        .update({ content: editingContent })
+        .eq('id', commentId);
+      setComments((prev) =>
+        prev.map((c) =>
+          c.id === commentId ? { ...c, content: editingContent } : c,
+        ),
+      );
+      setEditingCommentId(null);
+      setEditingContent('');
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
   const handleDeleteComment = async (commentId: string) => {
     try {
       await deleteComment(commentId);
@@ -111,8 +132,7 @@ export default function PostDetailPage({
       </div>
     );
 
-  const isOwner = true; // TODO: 개발 테스트용 - 배포 전 아래 코드로 교체
-  // const isOwner = userId === post.user_id;
+  const isOwner = userId === post.user_id;
 
   return (
     <div className="max-w-2xl mx-auto p-4 space-y-4">
@@ -190,8 +210,7 @@ export default function PostDetailPage({
                 <Image src="/postEdit.svg" alt="수정" width={30} height={30} />
               </button>
               <button
-                // 클릭시 실제 supabase 데이터가 삭제됨으로 테스트를 위해 주석 처리
-                // onClick={handleDeletePost}
+                onClick={handleDeletePost}
                 className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-red-50 transition-colors text-red-400 cursor-pointer"
                 title="삭제"
               >
@@ -318,9 +337,36 @@ export default function PostDetailPage({
                       </span>
                     )}
                   </div>
-                  <p className="text-sm text-gray-700 leading-relaxed">
-                    {c.content}
-                  </p>
+                  {editingCommentId === c.id ? (
+                    <div className="flex items-center gap-2 mt-1">
+                      <input
+                        type="text"
+                        value={editingContent}
+                        onChange={(e) => setEditingContent(e.target.value)}
+                        onKeyDown={(e) =>
+                          e.key === 'Enter' && handleEditComment(c.id)
+                        }
+                        className="flex-1 bg-gray-50 border border-gray-200 rounded-xl px-3 py-1.5 text-sm outline-none focus:border-gray-400"
+                        autoFocus
+                      />
+                      <button
+                        onClick={() => handleEditComment(c.id)}
+                        className="text-xs text-blue-500 font-medium"
+                      >
+                        저장
+                      </button>
+                      <button
+                        onClick={() => setEditingCommentId(null)}
+                        className="text-xs text-gray-400"
+                      >
+                        취소
+                      </button>
+                    </div>
+                  ) : (
+                    <p className="text-sm text-gray-700 leading-relaxed">
+                      {c.content}
+                    </p>
+                  )}
                   <div className="flex items-center gap-3 mt-1.5">
                     <span className="flex items-center gap-1 text-xs text-gray-400">
                       <Image
@@ -333,25 +379,29 @@ export default function PostDetailPage({
                       {timeAgo(c.created_at)}
                     </span>
                     {userId === c.user_id && (
-                      <button
-                        onClick={() => handleDeleteComment(c.id)}
-                        className="flex items-center gap-1 text-xs text-red-400 hover:text-red-600 transition-colors"
-                      >
-                        <Image
-                          src="/postDelete.svg"
-                          alt="삭제"
-                          width={12}
-                          height={12}
-                        />
-                        삭제
-                      </button>
+                      <>
+                        <button
+                          onClick={() => {
+                            setEditingCommentId(c.id);
+                            setEditingContent(c.content);
+                          }}
+                          className="text-xs text-gray-400 hover:text-gray-600 transition-colors"
+                        >
+                          수정
+                        </button>
+                        <button
+                          onClick={() => handleDeleteComment(c.id)}
+                          className="flex items-center gap-1 text-xs text-red-400 hover:text-red-600 transition-colors"
+                        >
+                          삭제
+                        </button>
+                      </>
                     )}
                   </div>
                 </div>
               </div>
             </div>
           ))}
-
           {comments.length === 0 && (
             <p className="text-center text-sm text-gray-400 py-4">
               첫 번째 댓글을 남겨보세요!

--- a/src/app/(main)/community/[id]/page.tsx
+++ b/src/app/(main)/community/[id]/page.tsx
@@ -111,6 +111,7 @@ export default function PostDetailPage({
   };
 
   const handleDeleteComment = async (commentId: string) => {
+    if (!confirm('댓글을 삭제하시겠습니까?')) return;
     try {
       await deleteComment(commentId);
       setComments((prev) => prev.filter((c) => c.id !== commentId));

--- a/src/app/(main)/community/write/page.tsx
+++ b/src/app/(main)/community/write/page.tsx
@@ -32,12 +32,10 @@ export default function WritePage() {
     }
     setIsLoading(true);
     try {
-      // const {
-      //   data: { user },
-      // } = await supabase.auth.getUser();
-      // if (!user) throw new Error('로그인이 필요합니다.');
-
-      const user = { id: 'a374f29b-158d-4835-b213-7df0d8915b4b' }; // TODO: 로그인 구현 후 제거
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) throw new Error('로그인이 필요합니다.');
 
       let image_url: string | undefined;
       if (imageFile) {

--- a/src/services/communityService.ts
+++ b/src/services/communityService.ts
@@ -17,20 +17,18 @@ export async function getPosts() {
 export async function getPost(id: string) {
   const { data, error } = await supabase
     .from('posts')
-    // .select('*, profiles(nickname, avatar_url, belt_level)')
-    .select('*')
+    .select('*, profiles!posts_user_id_fkey(nickname, avatar_url, belt_level)')
     .eq('id', id)
     .single();
   if (error) throw error;
-  return data as Post;
 
-  // return {
-  //   ...data,
-  //   nickname: data.profiles?.nickname,
-  //   avatar_url: data.profiles?.avatar_url,
-  //   belt_level: data.profiles?.belt_level,
-  //   profiles: undefined,
-  // } as Post;
+  return {
+    ...data,
+    nickname: data.profiles?.nickname,
+    avatar_url: data.profiles?.avatar_url,
+    belt_level: data.profiles?.belt_level,
+    profiles: undefined,
+  } as Post;
 }
 
 export async function createPost({
@@ -82,23 +80,20 @@ export async function uploadPostImage(file: File): Promise<string> {
 export async function getComments(postId: string) {
   const { data, error } = await supabase
     .from('comments')
-    // .select('*, profiles(nickname, avatar_url, belt_level)')
-    .select('*')
+    .select('*, profiles(nickname, avatar_url, belt_level, role)')
     .eq('post_id', postId)
     .order('created_at', { ascending: true });
-  console.log('comments data:', data);
-  console.log('comments error:', error);
 
   if (error) throw error;
-  return data as Comment[];
 
-  // return data.map((comment: any) => ({
-  //   ...comment,
-  //   nickname: comment.profiles?.nickname,
-  //   avatar_url: comment.profiles?.avatar_url,
-  //   belt_level: comment.profiles?.belt_level,
-  //   profiles: undefined,
-  // })) as Comment[];
+  return data.map((comment: any) => ({
+    ...comment,
+    nickname: comment.profiles?.nickname,
+    avatar_url: comment.profiles?.avatar_url,
+    belt_level: comment.profiles?.belt_level,
+    role: comment.profiles?.role,
+    profiles: undefined,
+  })) as Comment[];
 }
 
 export async function createComment({
@@ -113,19 +108,18 @@ export async function createComment({
   const { data, error } = await supabase
     .from('comments')
     .insert({ post_id, user_id, content })
-    // .select('*, profiles(nickname, avatar_url, belt_level)')
-    .select('*')
+    .select('*, profiles(nickname, avatar_url, belt_level, role)')
     .single();
   if (error) throw error;
-  return data as Comment;
 
-  // return {
-  //   ...data,
-  //   nickname: data.profiles?.nickname,
-  //   avatar_url: data.profiles?.avatar_url,
-  //   belt_level: data.profiles?.belt_level,
-  //   profiles: undefined,
-  // } as Comment;
+  return {
+    ...data,
+    nickname: data.profiles?.nickname,
+    avatar_url: data.profiles?.avatar_url,
+    belt_level: data.profiles?.belt_level,
+    role: data.profiles?.role,
+    profiles: undefined,
+  } as Comment;
 }
 
 export async function deleteComment(id: string) {


### PR DESCRIPTION
## 📌 개요

- 댓글 수정 기능 추가, 임시 로그인 코드 제거, 댓글 작성자 프로필 연동

## 💻 작업 사항

댓글 수정 기능 추가
<img width="271" height="98" alt="image" src="https://github.com/user-attachments/assets/3816ad31-be1f-40de-9d66-9908a9cfe08f" />
<img width="634" height="100" alt="image" src="https://github.com/user-attachments/assets/e72d7a03-01c7-4c3a-a626-88898af214f8" />

- 본인 댓글에 수정 버튼 노출
- 수정 클릭 시 인라인 입력창으로 전환, 저장/취소 버튼 제공
- Enter 키로도 저장 가능

---

임시 로그인 코드 제거

- write/page.tsx에서 하드코딩된 user id 제거
- supabase.auth.getUser()로 실제 로그인 유저 사용하도록 복구

---

댓글 작성자 프로필 연동

- getComments, createComment에서 profiles join 추가
- 댓글 목록에 작성자 닉네임, 프로필 이미지, belt_level 표시

## 💡 관련 Issue

Closes #31 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #31 )
- [x] 불필요한 console.log를 제거했습니다.
- [x] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
