### PR TITLE
[Feat] 게시글 작성페이지에서 role에 따라서 유형 다르게 표시

### DIFF
--- a/src/app/(main)/community/write/page.tsx
+++ b/src/app/(main)/community/write/page.tsx
@@ -7,15 +7,22 @@ import Image from 'next/image';
 import LoadingSpinner from '@/components/common/LoadingSpinner';
 import { supabase } from '@/lib/supabase';
 import { createPost, uploadPostImage } from '@/services/communityService';
+import { useAuth } from '@/hooks/useAuth';
 
 export default function WritePage() {
   const router = useRouter();
-  const [category, setCategory] = useState<PostCategory>('personal');
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [preview, setPreview] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [imageFile, setImageFile] = useState<File | null>(null);
+  const { user } = useAuth();
+  const category: PostCategory =
+    user?.role === 'manager'
+      ? 'promo'
+      : user?.role === 'admin'
+        ? 'notice'
+        : 'personal';
 
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -68,20 +75,12 @@ export default function WritePage() {
 
       <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
         <p className="text-sm text-gray-500 mb-2">게시글 유형</p>
-        <div className="flex gap-2">
-          {(['personal', 'promo'] as PostCategory[]).map((type) => (
-            <button
-              key={type}
-              onClick={() => setCategory(type)}
-              className={`flex-1 active:bg-gray-200 py-2 rounded-lg text-sm font-medium cursor-pointer transition-colors ${
-                category === type
-                  ? 'bg-black text-white'
-                  : 'bg-gray-100 text-gray-600'
-              }`}
-            >
-              {type === 'personal' ? '일반 게시글' : '도장 홍보'}
-            </button>
-          ))}
+        <div className="py-2 px-3 rounded-lg text-sm font-medium bg-black text-white text-center">
+          {user?.role === 'manager'
+            ? '도장 홍보'
+            : user?.role === 'admin'
+              ? '공지'
+              : '일반 게시글'}
         </div>
       </div>
 

--- a/src/app/(main)/community/write/page.tsx
+++ b/src/app/(main)/community/write/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import type { PostCategory } from '@/types/community';
 import Image from 'next/image';
@@ -16,13 +16,21 @@ export default function WritePage() {
   const [preview, setPreview] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [imageFile, setImageFile] = useState<File | null>(null);
-  const { user } = useAuth();
+  const { user, loading } = useAuth();
   const category: PostCategory =
     user?.role === 'manager'
       ? 'promo'
       : user?.role === 'admin'
         ? 'notice'
         : 'personal';
+
+  useEffect(() => {
+    if (!loading && !user) {
+      router.push('/login');
+    }
+  }, [user, loading, router]);
+
+  if (loading || isLoading) return <LoadingSpinner />;
 
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -64,8 +72,6 @@ export default function WritePage() {
       setIsLoading(false);
     }
   };
-
-  if (isLoading) return <LoadingSpinner />;
 
   return (
     <div className="max-w-5xl mx-auto p-6">

--- a/src/types/community.ts
+++ b/src/types/community.ts
@@ -1,4 +1,4 @@
-export type PostCategory = 'promo' | 'personal';
+export type PostCategory = 'promo' | 'personal' | 'notice';
 
 export interface Post {
   id: string;


### PR DESCRIPTION
## 📌 개요

- 게시글 작성페이지에서 role에 따라서 유형 다르게 표시

## 💻 작업 사항

- 로그인한 role 종류에 따라서 게시글 작성 페이지에서 유형 구분
<img width="359" height="178" alt="image" src="https://github.com/user-attachments/assets/9dcecba6-d7a5-45f7-9388-5b2c15b54b79" />

일반 유저
<img width="991" height="105" alt="image" src="https://github.com/user-attachments/assets/34fb7289-b091-44fc-a5c2-839bd305bc1e" />

도장(매니저) 유저
<img width="994" height="120" alt="image" src="https://github.com/user-attachments/assets/96918a67-ac02-4cd9-bd3e-869333337374" />

관리자(admin)유저
<img width="999" height="107" alt="image" src="https://github.com/user-attachments/assets/7078f9f5-c3e5-47db-ac8a-e7e45e9aef7c" />

---

- 로그인하지 않은 상태에서는 게시글 작성페이지로의 이동을 차단하는 코드 추가
<img width="335" height="151" alt="image" src="https://github.com/user-attachments/assets/49cb0c97-b4ee-4e8c-8837-f4fa32bfb2b8" />

- 커뮤니티 타입에서 카테고리에 notice 추가

## 💡 관련 Issue

Closes #28 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #28 )
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
