### PR TITLE
[Refactor]: 41 csr 구조에서 ssr 구조로 변경 및 비회원일 경우 글쓰기 버튼 비활성화, 공지탭 추가

### DIFF
--- a/src/app/(main)/community/page.tsx
+++ b/src/app/(main)/community/page.tsx
@@ -1,103 +1,38 @@
-'use client';
-import { useState, useRef, useEffect } from 'react';
-import Pageheader from '@/components/layout/PageHeader';
-import Postcard from '../../../components/community/Postcard';
-import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
-import { useDebounce } from '@/hooks/useDebounce';
-import LoadingSpinner from '@/components/common/LoadingSpinner';
-import { usePosts } from '@/hooks/useCommunity';
+// app/(main)/community/page.tsx - 서버 컴포넌트
+import CommunityClient from '@/components/community/CommunityClient';
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+import type { Post } from '@/types/community';
 
-const PAGE_SIZE = 10;
-
-export default function CommunityPage() {
-  const [activeTab, setActiveTab] = useState('전체');
-  const [searchQuery, setSearchQuery] = useState('');
-  const [page, setPage] = useState(1);
-  const [headerHeight, setHeaderHeight] = useState(0);
-  const headerRef = useRef<HTMLDivElement>(null);
-  const debouncedSearch = useDebounce(searchQuery, 300);
-  const { data: posts = [], isLoading } = usePosts(); // ✅ 교체
-
-  useEffect(() => {
-    if (headerRef.current) {
-      setHeaderHeight(headerRef.current.offsetHeight);
-    }
-  }, []);
-
-  const filteredPosts = posts.filter((post) => {
-    const matchTab =
-      activeTab === '전체' ||
-      (activeTab === '도장 홍보' && post.category === 'promo') ||
-      (activeTab === '일반 게시글' && post.category === 'personal');
-    const matchSearch = post.title
-      .toLowerCase()
-      .includes(debouncedSearch.toLowerCase());
-    return matchTab && matchSearch;
-  });
-
-  const visiblePosts = filteredPosts.slice(0, page * PAGE_SIZE);
-  const hasMore = visiblePosts.length < filteredPosts.length;
-
-  const observerRef = useInfiniteScroll(() => {
-    if (hasMore) setPage((prev) => prev + 1);
-  });
-
-  return (
-    <main className="w-full min-h-screen">
-      <div
-        ref={headerRef}
-        className="fixed top-0 left-50 right-0 z-10 bg-white shadow-md flex justify-center"
-      >
-        <div className="w-full max-w-7xl px-6">
-          <Pageheader
-            title="커뮤니티"
-            description="주짓수에 대한 모든 이야기"
-            tabs={['전체', '도장 홍보', '일반 게시글']}
-            activeTab={activeTab}
-            setActiveTab={(tab) => {
-              setActiveTab(tab);
-              setPage(1);
-            }}
-            searchQuery={searchQuery}
-            setSearchQuery={(query) => {
-              setSearchQuery(query);
-              setPage(1);
-            }}
-            writeLink="/community/write"
-          />
-        </div>
-      </div>
-
-      <div
-        style={{ paddingTop: `${headerHeight + 24}px` }}
-        className="pb-6 flex justify-center"
-      >
-        <div className="w-full max-w-7xl px-6">
-          <div className="grid grid-cols-2 gap-4">
-            {isLoading ? (
-              <LoadingSpinner />
-            ) : visiblePosts.length > 0 ? (
-              visiblePosts.map((post) => (
-                <Postcard
-                  key={post.id}
-                  post={{
-                    ...post,
-                    nickname: post.nickname ?? '알 수 없음',
-                    avatar_url: post.avatar_url ?? '',
-                    image_url: post.image_url ?? '',
-                  }}
-                />
-              ))
-            ) : (
-              <div className="col-span-2 flex flex-col items-center justify-center py-20 text-gray-400">
-                <p className="text-lg">게시글이 없습니다</p>
-                <p className="text-sm mt-2">첫 번째 게시글을 작성해보세요!</p>
-              </div>
-            )}
-          </div>
-          {hasMore && <div ref={observerRef} className="h-10" />}
-        </div>
-      </div>
-    </main>
+async function getPosts(): Promise<Post[]> {
+  const cookieStore = await cookies();
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+      },
+    },
   );
+
+  const { data, error } = await supabase
+    .from('posts')
+    .select('*, comments(count)')
+    .order('created_at', { ascending: false });
+
+  if (error) return [];
+
+  return data.map((post) => ({
+    ...post,
+    comment_count: post.comments?.[0]?.count ?? 0,
+  })) as Post[];
+}
+
+export default async function CommunityPage() {
+  const initialPosts = await getPosts();
+
+  return <CommunityClient initialPosts={initialPosts} />;
 }

--- a/src/app/(main)/competitions/page.tsx
+++ b/src/app/(main)/competitions/page.tsx
@@ -1,81 +1,25 @@
-'use client';
-import { useState, useRef, useEffect } from 'react';
-import Pageheader from '@/components/layout/PageHeader';
-import CompetitionCard from '@/components/competition/CompetitionCard';
-import { useDebounce } from '@/hooks/useDebounce';
-import LoadingSpinner from '@/components/common/LoadingSpinner';
-import { useCompetiton } from '@/hooks/useCompetition';
-import { useAuth } from '@/hooks/useAuth';
+import CompetitionClient from '@/components/competition/CompetitionClient';
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
 
-export default function CompetitionsPage() {
-  const [activeTab, setActiveTab] = useState('전체');
-  const [searchQuery, setSearchQuery] = useState('');
-  const [headerHeight, setHeaderHeight] = useState(0);
-  const headerRef = useRef<HTMLDivElement>(null);
-  const debouncedSearch = useDebounce(searchQuery, 300);
-  const { data, isLoading } = useCompetiton();
-  const { user } = useAuth();
-  const isAdmin = user?.role === 'admin';
-  const isManager = user?.role === 'manager';
-
-  useEffect(() => {
-    if (headerRef.current) {
-      setHeaderHeight(headerRef.current.offsetHeight);
-    }
-  }, []);
-
-  const filteredCompetitions = (data ?? []).filter((competition) => {
-    const matchTab = activeTab === '전체' || competition.status === activeTab;
-    const matchSearch = competition.name
-      .toLowerCase()
-      .includes(debouncedSearch.toLowerCase());
-    return matchTab && matchSearch;
-  });
-
-  return (
-    <div className="w-full min-h-screen">
-      <div
-        ref={headerRef}
-        className="fixed top-0 left-50 right-0 z-10 bg-white shadow-md flex justify-center"
-      >
-        <div className="w-full max-w-7xl px-6">
-          <Pageheader
-            title="대회일정"
-            description="전국 주짓수 대회 일정"
-            tabs={['전체', '모집중', '마감임박', '모집완료']}
-            activeTab={activeTab}
-            setActiveTab={setActiveTab}
-            searchQuery={searchQuery}
-            setSearchQuery={setSearchQuery}
-            writeLink={isManager || isAdmin ? '/competitions/write' : undefined}
-            writeLinkText="일정추가"
-          />
-        </div>
-      </div>
-
-      <div
-        style={{ paddingTop: `${headerHeight + 24}px` }}
-        className="pb-6 flex justify-center"
-      >
-        <div className="w-full max-w-7xl px-6">
-          <div className="grid grid-cols-2 gap-4">
-            {isLoading ? (
-              <LoadingSpinner />
-            ) : filteredCompetitions.length > 0 ? (
-              filteredCompetitions.map((competition) => (
-                <CompetitionCard
-                  key={competition.id}
-                  competition={competition}
-                />
-              ))
-            ) : (
-              <div className="col-span-2 flex flex-col items-center justify-center py-20 text-gray-400">
-                <p className="text-lg">대회 일정이 없습니다</p>
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
-    </div>
+export default async function CompetitionsPage() {
+  const cookieStore = await cookies();
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+      },
+    },
   );
+
+  const { data: initialCompetitions } = await supabase
+    .from('competition')
+    .select('*')
+    .order('event_data', { ascending: true });
+
+  return <CompetitionClient initialCompetitions={initialCompetitions ?? []} />;
 }

--- a/src/app/(main)/dojangs/page.tsx
+++ b/src/app/(main)/dojangs/page.tsx
@@ -1,188 +1,23 @@
-'use client';
-import { useState, useRef, useEffect } from 'react';
-import Script from 'next/script';
-import DojangCard from '@/components/dojang/DojangCard';
-import Pageheader from '@/components/layout/PageHeader';
-import { useDebounce } from '@/hooks/useDebounce';
-import { supabase } from '@/lib/supabase';
+import DojangClient from '@/components/dojang/DojangClient';
+import { cookies } from 'next/headers';
+import { createServerClient } from '@supabase/ssr';
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-declare global {
-  interface Window {
-    naver: any;
-  }
-}
-
-interface KakaoPlace {
-  id: string;
-  place_name: string;
-  address_name: string;
-  phone: string;
-  place_url: string;
-  category_name: string;
-  x: string;
-  y: string;
-}
-
-export default function DojangsPage() {
-  const [searchQuery, setSearchQuery] = useState('');
-  const [dojangs, setDojangs] = useState<KakaoPlace[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const [mapLoaded, setMapLoaded] = useState(false);
-  const [headerHeight, setHeaderHeight] = useState(0);
-  const [verifiedDojangs, setVerifiedDojangs] = useState<string[]>([]);
-  const headerRef = useRef<HTMLDivElement>(null);
-  const mapRef = useRef<HTMLDivElement>(null);
-  const mapInstance = useRef<any>(null);
-  const markersRef = useRef<any[]>([]);
-  const debouncedSearch = useDebounce(searchQuery, 500);
-
-  useEffect(() => {
-    if (headerRef.current) {
-      setHeaderHeight(headerRef.current.offsetHeight);
-    }
-  }, []);
-
-  useEffect(() => {
-    const fetchVerifiedDojangs = async () => {
-      const { data } = await supabase.from('dojang').select('name');
-      if (data) {
-        setVerifiedDojangs(data.map((d: { name: string }) => d.name));
-      }
-    };
-    fetchVerifiedDojangs();
-  }, []);
-
-  const initMap = () => {
-    if (mapRef.current && window.naver) {
-      mapInstance.current = new window.naver.maps.Map(mapRef.current, {
-        center: new window.naver.maps.LatLng(37.5665, 126.978),
-        zoom: 12,
-      });
-      setMapLoaded(true);
-    }
-  };
-
-  useEffect(() => {
-    if (window.naver && window.naver.maps) {
-      initMap();
-    }
-  }, []);
-
-  const clearMarkers = () => {
-    markersRef.current.forEach((marker) => marker.setMap(null));
-    markersRef.current = [];
-  };
-
-  useEffect(() => {
-    if (!debouncedSearch.trim()) return;
-
-    const fetchDojangs = async () => {
-      setIsLoading(true);
-      try {
-        const res = await fetch(
-          `https://dapi.kakao.com/v2/local/search/keyword.json?query=${debouncedSearch} 주짓수&size=15`,
-          {
-            headers: {
-              Authorization: `KakaoAK ${process.env.NEXT_PUBLIC_KAKAO_LOCAL_API_KEY}`,
-            },
-          },
-        );
-        const data = await res.json();
-        setDojangs(data.documents);
-        clearMarkers();
-
-        if (data.documents.length > 0 && mapInstance.current) {
-          const firstPlace = data.documents[0];
-          mapInstance.current.setCenter(
-            new window.naver.maps.LatLng(firstPlace.y, firstPlace.x),
-          );
-          mapInstance.current.setZoom(13);
-
-          data.documents.forEach((place: KakaoPlace) => {
-            const marker = new window.naver.maps.Marker({
-              position: new window.naver.maps.LatLng(place.y, place.x),
-              map: mapInstance.current,
-              title: place.place_name,
-            });
-            markersRef.current.push(marker);
-          });
-        }
-      } catch {
-        // 검색 실패 시 무시
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchDojangs();
-  }, [debouncedSearch]);
+export default async function DojangsPage() {
+  const cookieStore = await cookies();
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+      },
+    },
+  );
+  const { data } = await supabase.from('dojang').select('name');
 
   return (
-    <>
-      <Script
-        src={`https://openapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=${process.env.NEXT_PUBLIC_NAVER_MAP_CLIENT_ID}`}
-        onLoad={initMap}
-      />
-
-      <div className="w-full min-h-screen">
-        <div
-          ref={headerRef}
-          className="fixed top-0 left-50 right-0 z-10 bg-bg-white shadow-md flex justify-center"
-        >
-          <div className="w-full max-w-7xl px-6">
-            <Pageheader
-              title="도장찾기"
-              description="전국의 주짓수 도장"
-              searchQuery={searchQuery}
-              setSearchQuery={setSearchQuery}
-              searchPlaceholder="도장 이름이나 지역으로 검색..."
-            />
-          </div>
-        </div>
-
-        <div
-          style={{ paddingTop: `${headerHeight + 24}px` }}
-          className="pb-6 flex justify-center"
-        >
-          <div className="w-full max-w-7xl px-6 flex flex-col gap-4">
-            <div className="relative">
-              {!mapLoaded && (
-                <div className="absolute inset-0 bg-btn-basic rounded-lg flex items-center justify-center z-10">
-                  <div className="w-8 h-8 border-4 border-gray-200 border-t-btn-focus rounded-full animate-spin" />
-                </div>
-              )}
-              <div
-                ref={mapRef}
-                className="w-full h-100 rounded-lg overflow-hidden border border-gray-200"
-              />
-            </div>
-
-            {isLoading ? (
-              <div className="flex items-center justify-center py-20">
-                <div className="w-8 h-8 border-4 border-gray-200 border-t-btn-focus rounded-full animate-spin" />
-              </div>
-            ) : dojangs.length > 0 ? (
-              <div className="grid grid-cols-2 gap-4">
-                {dojangs.map((dojang) => (
-                  <DojangCard
-                    key={dojang.id}
-                    dojang={dojang}
-                    isVerified={verifiedDojangs.includes(dojang.place_name)}
-                  />
-                ))}
-              </div>
-            ) : (
-              <div className="flex flex-col items-center justify-center py-20 text-text-secondary">
-                <p className="text-lg">검색어를 입력해주세요</p>
-                <p className="text-sm mt-2">
-                  지역명이나 도장 이름으로 검색해보세요
-                </p>
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
-    </>
+    <DojangClient initialVerifiedDojangs={data?.map((d) => d.name) ?? []} />
   );
 }

--- a/src/components/community/CommunityClient.tsx
+++ b/src/components/community/CommunityClient.tsx
@@ -1,0 +1,114 @@
+'use client';
+import { useState, useRef, useEffect } from 'react';
+import Pageheader from '@/components/layout/PageHeader';
+import Postcard from '@/components/community/Postcard';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+import { useDebounce } from '@/hooks/useDebounce';
+import { usePosts } from '@/hooks/useCommunity';
+import { useAuth } from '@/hooks/useAuth';
+import type { Post } from '@/types/community';
+
+const PAGE_SIZE = 10;
+
+interface CommunityClientProps {
+  initialPosts: Post[];
+}
+
+export default function CommunityClient({
+  initialPosts,
+}: CommunityClientProps) {
+  const [activeTab, setActiveTab] = useState('전체');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [page, setPage] = useState(1);
+  const [headerHeight, setHeaderHeight] = useState(0);
+  const headerRef = useRef<HTMLDivElement>(null);
+  const debouncedSearch = useDebounce(searchQuery, 300);
+  const { user } = useAuth();
+  // const isAdmin = user?.role === 'admin';
+
+  const { data: posts = initialPosts } = usePosts();
+
+  useEffect(() => {
+    if (headerRef.current) {
+      setHeaderHeight(headerRef.current.offsetHeight);
+    }
+  }, []);
+
+  const filteredPosts = posts.filter((post) => {
+    const matchTab =
+      activeTab === '전체' ||
+      (activeTab === '공지' && post.category === 'notice') ||
+      (activeTab === '도장 홍보' && post.category === 'promo') ||
+      (activeTab === '일반 게시글' && post.category === 'personal');
+    const matchSearch = post.title
+      .toLowerCase()
+      .includes(debouncedSearch.toLowerCase());
+    return matchTab && matchSearch;
+  });
+
+  const visiblePosts = filteredPosts.slice(0, page * PAGE_SIZE);
+  const hasMore = visiblePosts.length < filteredPosts.length;
+
+  const observerRef = useInfiniteScroll(() => {
+    if (hasMore) setPage((prev) => prev + 1);
+  });
+
+  return (
+    <main className="w-full min-h-screen">
+      <div
+        ref={headerRef}
+        className="fixed top-0 left-50 right-0 z-10 bg-white shadow-md flex justify-center"
+      >
+        <div className="w-full max-w-7xl px-6">
+          <Pageheader
+            title="커뮤니티"
+            description="주짓수에 대한 모든 이야기"
+            tabs={['전체', '공지', '도장 홍보', '일반 게시글']}
+            activeTab={activeTab}
+            setActiveTab={(tab) => {
+              setActiveTab(tab);
+              setPage(1);
+            }}
+            searchQuery={searchQuery}
+            setSearchQuery={(query) => {
+              setSearchQuery(query);
+              setPage(1);
+            }}
+            writeLink="/community/write"
+            // 관리자만 글쓰기 버튼 표시 - 필요시 주석 해제
+            // writeLink={isAdmin ? '/community/write' : undefined}
+          />
+        </div>
+      </div>
+
+      <div
+        style={{ paddingTop: `${headerHeight + 24}px` }}
+        className="pb-6 flex justify-center"
+      >
+        <div className="w-full max-w-7xl px-6">
+          <div className="grid grid-cols-2 gap-4">
+            {visiblePosts.length > 0 ? (
+              visiblePosts.map((post) => (
+                <Postcard
+                  key={post.id}
+                  post={{
+                    ...post,
+                    nickname: post.nickname ?? '알 수 없음',
+                    avatar_url: post.avatar_url ?? '',
+                    image_url: post.image_url ?? '',
+                  }}
+                />
+              ))
+            ) : (
+              <div className="col-span-2 flex flex-col items-center justify-center py-20 text-gray-400">
+                <p className="text-lg">게시글이 없습니다</p>
+                <p className="text-sm mt-2">첫 번째 게시글을 작성해보세요!</p>
+              </div>
+            )}
+          </div>
+          {hasMore && <div ref={observerRef} className="h-10" />}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/community/CommunityClient.tsx
+++ b/src/components/community/CommunityClient.tsx
@@ -23,7 +23,7 @@ export default function CommunityClient({
   const [headerHeight, setHeaderHeight] = useState(0);
   const headerRef = useRef<HTMLDivElement>(null);
   const debouncedSearch = useDebounce(searchQuery, 300);
-  const { user } = useAuth();
+  const { user, loading } = useAuth();
   // const isAdmin = user?.role === 'admin';
 
   const { data: posts = initialPosts } = usePosts();
@@ -74,7 +74,9 @@ export default function CommunityClient({
               setSearchQuery(query);
               setPage(1);
             }}
-            writeLink="/community/write"
+            writeLink={
+              loading ? undefined : user ? '/community/write' : undefined
+            }
             // 관리자만 글쓰기 버튼 표시 - 필요시 주석 해제
             // writeLink={isAdmin ? '/community/write' : undefined}
           />
@@ -97,6 +99,7 @@ export default function CommunityClient({
                     avatar_url: post.avatar_url ?? '',
                     image_url: post.image_url ?? '',
                   }}
+                  userId={user?.id ?? ''}
                 />
               ))
             ) : (

--- a/src/components/community/Postcard.tsx
+++ b/src/components/community/Postcard.tsx
@@ -1,7 +1,6 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { useLike } from '@/hooks/useLike';
-import { useAuth } from '@/hooks/useAuth';
 import { formatDate } from '@/utils/formatDate';
 import { Heart, MessageCircle } from 'lucide-react';
 
@@ -18,6 +17,7 @@ interface PostCardProps {
     created_at: string;
     comment_count: number;
   };
+  userId: string;
 }
 
 const categoryMap: Record<string, { label: string; color: string }> = {
@@ -26,14 +26,14 @@ const categoryMap: Record<string, { label: string; color: string }> = {
   personal: { label: '일반', color: 'bg-[#364153]' },
 };
 
-export default function PostCard({ post }: PostCardProps) {
-  const { user } = useAuth();
-  const { likeCount, isLiked, toggle } = useLike(post.id, user?.id ?? '');
+export default function PostCard({ post, userId }: PostCardProps) {
+  // const { user } = useAuth();
+  const { likeCount, isLiked, toggle } = useLike(post.id, userId);
   const categoryInfo = categoryMap[post.category] ?? categoryMap.personal;
 
   const handleLike = (e: React.MouseEvent) => {
     e.preventDefault();
-    if (!user) return;
+    if (!userId) return;
     toggle();
   };
 

--- a/src/components/community/Postcard.tsx
+++ b/src/components/community/Postcard.tsx
@@ -20,9 +20,16 @@ interface PostCardProps {
   };
 }
 
+const categoryMap: Record<string, { label: string; color: string }> = {
+  promo: { label: '도장', color: 'bg-[#155DFC]' },
+  notice: { label: '공지', color: 'bg-[#e7000b]' },
+  personal: { label: '일반', color: 'bg-[#364153]' },
+};
+
 export default function PostCard({ post }: PostCardProps) {
   const { user } = useAuth();
   const { likeCount, isLiked, toggle } = useLike(post.id, user?.id ?? '');
+  const categoryInfo = categoryMap[post.category] ?? categoryMap.personal;
 
   const handleLike = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -55,10 +62,9 @@ export default function PostCard({ post }: PostCardProps) {
             </div>
           )}
           <span
-            className={`absolute top-2 right-2 px-2 py-1 text-xs text-white rounded-full
-            ${post.category === 'promo' ? 'bg-[#155DFC]' : 'bg-[#364153]'}`}
+            className={`absolute top-2 right-2 px-2 py-1 text-xs text-white rounded-full ${categoryInfo.color}`}
           >
-            {post.category === 'promo' ? '도장' : '일반'}
+            {categoryInfo.label}
           </span>
         </div>
 

--- a/src/components/competition/CompetitionClient.tsx
+++ b/src/components/competition/CompetitionClient.tsx
@@ -1,0 +1,100 @@
+'use client';
+import { useState, useRef, useEffect } from 'react';
+import Pageheader from '@/components/layout/PageHeader';
+import CompetitionCard from '@/components/competition/CompetitionCard';
+import { useDebounce } from '@/hooks/useDebounce';
+import { useCompetiton } from '@/hooks/useCompetition';
+import { useAuth } from '@/hooks/useAuth';
+import LoadingSpinner from '@/components/common/LoadingSpinner';
+
+interface Competition {
+  id: string;
+  name: string;
+  location: string;
+  event_data: string;
+  category: string;
+  status: string;
+  description: string;
+  image_url: string;
+  participants: number;
+  apply_url: string;
+}
+
+interface CompetitionClientProps {
+  initialCompetitions: Competition[];
+}
+
+export default function CompetitionClient({
+  initialCompetitions,
+}: CompetitionClientProps) {
+  const [activeTab, setActiveTab] = useState('전체');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [headerHeight, setHeaderHeight] = useState(0);
+  const headerRef = useRef<HTMLDivElement>(null);
+  const debouncedSearch = useDebounce(searchQuery, 300);
+  const { data = initialCompetitions, isLoading } = useCompetiton();
+  const { user } = useAuth();
+  const isAdmin = user?.role === 'admin';
+  const isManager = user?.role === 'manager';
+
+  useEffect(() => {
+    if (headerRef.current) {
+      setHeaderHeight(headerRef.current.offsetHeight);
+    }
+  }, []);
+
+  const filteredCompetitions = data.filter((competition) => {
+    const matchTab = activeTab === '전체' || competition.status === activeTab;
+    const matchSearch = competition.name
+      .toLowerCase()
+      .includes(debouncedSearch.toLowerCase());
+    return matchTab && matchSearch;
+  });
+
+  return (
+    <div className="w-full min-h-screen">
+      <div
+        ref={headerRef}
+        className="fixed top-0 left-50 right-0 z-10 bg-white shadow-md flex justify-center"
+      >
+        <div className="w-full max-w-7xl px-6">
+          <Pageheader
+            title="대회일정"
+            description="전국 주짓수 대회 일정"
+            tabs={['전체', '모집중', '마감임박', '모집완료']}
+            activeTab={activeTab}
+            setActiveTab={setActiveTab}
+            searchQuery={searchQuery}
+            setSearchQuery={setSearchQuery}
+            writeLink={isManager || isAdmin ? '/competitions/write' : undefined}
+            writeLinkText="일정추가"
+          />
+        </div>
+      </div>
+
+      <div
+        style={{ paddingTop: `${headerHeight + 24}px` }}
+        className="pb-6 flex justify-center"
+      >
+        <div className="w-full max-w-7xl px-6">
+          <div className="grid grid-cols-2 gap-4">
+            {isLoading ? (
+              <LoadingSpinner />
+            ) : filteredCompetitions.length > 0 ? (
+              filteredCompetitions.map((competition) => (
+                <CompetitionCard
+                  key={competition.id}
+                  competition={competition}
+                />
+              ))
+            ) : (
+              <div className="col-span-2 flex flex-col items-center justify-center py-20 text-gray-400">
+                <p className="text-lg">대회 일정이 없습니다</p>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dojang/DojangClient.tsx
+++ b/src/components/dojang/DojangClient.tsx
@@ -1,0 +1,193 @@
+'use client';
+import { useState, useRef, useEffect } from 'react';
+import DojangCard from '@/components/dojang/DojangCard';
+import Pageheader from '@/components/layout/PageHeader';
+import { useDebounce } from '@/hooks/useDebounce';
+import Script from 'next/script';
+import { supabase } from '@/lib/supabase';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+declare global {
+  interface Window {
+    naver: any;
+  }
+}
+
+interface KakaoPlace {
+  id: string;
+  place_name: string;
+  address_name: string;
+  phone: string;
+  place_url: string;
+  category_name: string;
+  x: string;
+  y: string;
+}
+interface DojangClientProps {
+  initialVerifiedDojangs: string[];
+}
+
+export default function DojangClient({
+  initialVerifiedDojangs,
+}: DojangClientProps) {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [dojangs, setDojangs] = useState<KakaoPlace[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [mapLoaded, setMapLoaded] = useState(false);
+  const [headerHeight, setHeaderHeight] = useState(0);
+  const [verifiedDojangs, setVerifiedDojangs] = useState<string[]>([]);
+  const headerRef = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<HTMLDivElement>(null);
+  const mapInstance = useRef<any>(null);
+  const markersRef = useRef<any[]>([]);
+  const debouncedSearch = useDebounce(searchQuery, 500);
+
+  useEffect(() => {
+    if (headerRef.current) {
+      setHeaderHeight(headerRef.current.offsetHeight);
+    }
+  }, []);
+
+  useEffect(() => {
+    const fetchVerifiedDojangs = async () => {
+      const { data } = await supabase.from('dojang').select('name');
+      if (data) {
+        setVerifiedDojangs(data.map((d: { name: string }) => d.name));
+      }
+    };
+    fetchVerifiedDojangs();
+  }, []);
+
+  const initMap = () => {
+    if (mapRef.current && window.naver) {
+      mapInstance.current = new window.naver.maps.Map(mapRef.current, {
+        center: new window.naver.maps.LatLng(37.5665, 126.978),
+        zoom: 12,
+      });
+      setMapLoaded(true);
+    }
+  };
+
+  useEffect(() => {
+    if (window.naver && window.naver.maps) {
+      initMap();
+    }
+  }, []);
+
+  const clearMarkers = () => {
+    markersRef.current.forEach((marker) => marker.setMap(null));
+    markersRef.current = [];
+  };
+
+  useEffect(() => {
+    if (!debouncedSearch.trim()) return;
+
+    const fetchDojangs = async () => {
+      setIsLoading(true);
+      try {
+        const res = await fetch(
+          `https://dapi.kakao.com/v2/local/search/keyword.json?query=${debouncedSearch} 주짓수&size=15`,
+          {
+            headers: {
+              Authorization: `KakaoAK ${process.env.NEXT_PUBLIC_KAKAO_LOCAL_API_KEY}`,
+            },
+          },
+        );
+        const data = await res.json();
+        setDojangs(data.documents);
+        clearMarkers();
+
+        if (data.documents.length > 0 && mapInstance.current) {
+          const firstPlace = data.documents[0];
+          mapInstance.current.setCenter(
+            new window.naver.maps.LatLng(firstPlace.y, firstPlace.x),
+          );
+          mapInstance.current.setZoom(13);
+
+          data.documents.forEach((place: KakaoPlace) => {
+            const marker = new window.naver.maps.Marker({
+              position: new window.naver.maps.LatLng(place.y, place.x),
+              map: mapInstance.current,
+              title: place.place_name,
+            });
+            markersRef.current.push(marker);
+          });
+        }
+      } catch {
+        // 검색 실패 시 무시
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchDojangs();
+  }, [debouncedSearch]);
+
+  return (
+    <>
+      <Script
+        src={`https://openapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=${process.env.NEXT_PUBLIC_NAVER_MAP_CLIENT_ID}`}
+        onLoad={initMap}
+      />
+
+      <div className="w-full min-h-screen">
+        <div
+          ref={headerRef}
+          className="fixed top-0 left-50 right-0 z-10 bg-bg-white shadow-md flex justify-center"
+        >
+          <div className="w-full max-w-7xl px-6">
+            <Pageheader
+              title="도장찾기"
+              description="전국의 주짓수 도장"
+              searchQuery={searchQuery}
+              setSearchQuery={setSearchQuery}
+              searchPlaceholder="도장 이름이나 지역으로 검색..."
+            />
+          </div>
+        </div>
+
+        <div
+          style={{ paddingTop: `${headerHeight + 24}px` }}
+          className="pb-6 flex justify-center"
+        >
+          <div className="w-full max-w-7xl px-6 flex flex-col gap-4">
+            <div className="relative">
+              {!mapLoaded && (
+                <div className="absolute inset-0 bg-btn-basic rounded-lg flex items-center justify-center z-10">
+                  <div className="w-8 h-8 border-4 border-gray-200 border-t-btn-focus rounded-full animate-spin" />
+                </div>
+              )}
+              <div
+                ref={mapRef}
+                className="w-full h-100 rounded-lg overflow-hidden border border-gray-200"
+              />
+            </div>
+
+            {isLoading ? (
+              <div className="flex items-center justify-center py-20">
+                <div className="w-8 h-8 border-4 border-gray-200 border-t-btn-focus rounded-full animate-spin" />
+              </div>
+            ) : dojangs.length > 0 ? (
+              <div className="grid grid-cols-2 gap-4">
+                {dojangs.map((dojang) => (
+                  <DojangCard
+                    key={dojang.id}
+                    dojang={dojang}
+                    isVerified={verifiedDojangs.includes(dojang.place_name)}
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className="flex flex-col items-center justify-center py-20 text-text-secondary">
+                <p className="text-lg">검색어를 입력해주세요</p>
+                <p className="text-sm mt-2">
+                  지역명이나 도장 이름으로 검색해보세요
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -38,7 +38,6 @@ export default function Sidebar() {
 
   const handleLogout = async () => {
     await logout();
-    router.back();
   };
 
   return (

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -2,10 +2,12 @@
 import { useEffect, useState } from 'react';
 import { supabase } from '../lib/supabase';
 import { getCurrentUser, AuthUser } from '../lib/auth';
+import { useRouter } from 'next/navigation';
 
 export function useAuth() {
   const [user, setUser] = useState<AuthUser>(null);
   const [loading, setLoading] = useState(true);
+  const router = useRouter();
 
   useEffect(() => {
     getCurrentUser().then((u) => {
@@ -25,6 +27,7 @@ export function useAuth() {
   const logout = async () => {
     await supabase.auth.signOut();
     setUser(null);
+    router.push('/community');
   };
 
   return { user, loading, logout };

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -10,9 +10,16 @@ export function useAuth() {
   const router = useRouter();
 
   useEffect(() => {
-    getCurrentUser().then((u) => {
-      setUser(u);
-      setLoading(false);
+    // 로컬 세션 먼저 확인 (빠름)
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (session) {
+        getCurrentUser().then((u) => {
+          setUser(u);
+          setLoading(false);
+        });
+      } else {
+        setLoading(false);
+      }
     });
 
     const {

--- a/src/types/community.ts
+++ b/src/types/community.ts
@@ -1,4 +1,4 @@
-export type PostCategory = 'promo' | 'personal';
+export type PostCategory = 'personal' | 'promo' | 'notice';
 
 export interface Post {
   id: string;


### PR DESCRIPTION
## 📌 개요

- 커뮤니티, 대회일정, 도장찾기 구조 변경 (CSR -> SSR)
- 각각의 파일 안에 있는 내용을 커뮤니티, 대회일정, 도장찾기 클라이언트 파일을 만들어서 분리 후에 page.tsx에 임폴트
- 비회원일 경우 글쓰기 버튼 비활성화

## 💻 작업 사항

- 주요 변경 사항을 구체적으로 작성해주세요.
- 비회원일 경우 글쓰기 버튼 비활성화
- 공지 분류 탭 추가
<img width="1435" height="723" alt="스크린샷 2026-04-30 시간: 12 47 29" src="https://github.com/user-attachments/assets/95b7d2ab-1ba6-45bf-b75e-4ef320f8a8c0" />
<img width="1445" height="893" alt="스크린샷 2026-04-30 시간: 13 29 45" src="https://github.com/user-attachments/assets/98d79da2-e427-4127-957d-cc2451748a2a" />


## 💡 관련 Issue

Closes #41 

## ✅ 체크리스트
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
