### PR TITLE
[Feat]도장 디데이 및 상위 정렬 기능추가, 도장 찾기 검색 후 마커 클릭 시 하이라이트 기능 추가 + 사이드바 대회일정 관리 버튼 추가

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -98,7 +98,7 @@ export default function LoginPage() {
       </div>
 
       {/* 카드 */}
-      <div className="max-w-[600px] w-full bg-bg-white rounded-[32px] p-8 shadow-sm border-none">
+      <div className="max-w-150 w-full bg-bg-white rounded-[32px] p-8 shadow-sm border-none">
         <h2 className="text-2xl font-bold text-center text-text-primary mb-8">
           로그인
         </h2>

--- a/src/components/competition/CompetitionCard.tsx
+++ b/src/components/competition/CompetitionCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 import Image from 'next/image';
+import { getDday } from '@/utils/formatDate';
 
 interface CompetitionCardProps {
   competition: {
@@ -23,7 +24,13 @@ export default function CompetitionCard({ competition }: CompetitionCardProps) {
       마감임박: 'bg-orange-500',
       모집완료: 'bg-gray-400',
     }[competition.status] ?? 'bg-gray-400';
-
+  const dday = getDday(competition.event_data);
+  const ddayColor =
+    dday === 'D-DAY'
+      ? 'text-danger'
+      : dday.startsWith('D-')
+        ? 'text-blue-500'
+        : 'text-gray-400';
   return (
     <div className="rounded-lg overflow-hidden bg-bg-white border border-gray-200 flex flex-col min-h cursor-pointer hover:shadow-lg hover:-translate-y-1 transition-all duration-200">
       {/* 썸네일 + 배지 */}
@@ -76,6 +83,13 @@ export default function CompetitionCard({ competition }: CompetitionCardProps) {
           <div className="flex items-center gap-1">
             <Image src="/calendar.svg" alt="날짜" width={14} height={14} />
             <span>{competition.event_data}</span>
+            <div className="flex items-center gap-1">
+              <Image src="/calendar.svg" alt="날짜" width={14} height={14} />
+              <span>{competition.event_data}</span>
+              {competition.status !== '모집완료' && (
+                <span className={`ml-1 font-bold ${ddayColor}`}>{dday}</span>
+              )}
+            </div>
           </div>
           <div className="flex items-center gap-1">
             <Image src="/location.svg" alt="위치" width={14} height={14} />

--- a/src/components/competition/CompetitionCard.tsx
+++ b/src/components/competition/CompetitionCard.tsx
@@ -9,31 +9,48 @@ interface CompetitionCardProps {
     description: string;
     image_url: string;
     category: string;
-    status: string;
     event_data: string;
+    apply_deadline: string;
     location: string;
     participants: number;
     apply_url: string;
   };
 }
 
+function getStatus(applyDeadline: string): string {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const deadline = new Date(applyDeadline);
+  deadline.setHours(0, 0, 0, 0);
+  const diff = Math.ceil(
+    (deadline.getTime() - today.getTime()) / (1000 * 60 * 60 * 24),
+  );
+
+  if (diff < 0) return '모집완료';
+  if (diff <= 7) return '마감임박';
+  return '모집중';
+}
+
 export default function CompetitionCard({ competition }: CompetitionCardProps) {
+  const actualStatus = getStatus(competition.apply_deadline);
+
   const statusColor =
     {
       모집중: 'bg-green-500',
       마감임박: 'bg-orange-500',
       모집완료: 'bg-gray-400',
-    }[competition.status] ?? 'bg-gray-400';
-  const dday = getDday(competition.event_data);
+    }[actualStatus] ?? 'bg-gray-400';
+
+  const dday = getDday(competition.apply_deadline);
   const ddayColor =
     dday === 'D-DAY'
       ? 'text-danger'
       : dday.startsWith('D-')
         ? 'text-blue-500'
         : 'text-gray-400';
+
   return (
     <div className="rounded-lg overflow-hidden bg-bg-white border border-gray-200 flex flex-col min-h cursor-pointer hover:shadow-lg hover:-translate-y-1 transition-all duration-200">
-      {/* 썸네일 + 배지 */}
       <div className="relative shrink-0">
         {competition.image_url ? (
           <Image
@@ -49,47 +66,45 @@ export default function CompetitionCard({ competition }: CompetitionCardProps) {
           </div>
         )}
 
-        {/* 카테고리 배지 */}
         <span className="absolute bottom-10 left-2 px-2 py-1 text-xs text-white rounded-full bg-black/60">
           {competition.category}
         </span>
 
-        {/* 제목 오버레이 */}
         <div className="absolute bottom-0 left-0 right-0 bg-linear-to-t from-black/70 to-transparent p-3">
           <h2 className="font-bold text-white text-base line-clamp-1">
             {competition.name}
           </h2>
         </div>
 
-        {/* 상태 배지 */}
         <span
           className={`absolute top-2 right-2 px-2 py-1 text-xs text-white rounded-full ${statusColor}`}
         >
-          {competition.status}
+          {actualStatus}
         </span>
       </div>
 
-      {/* 카드 내용 */}
       <div className="p-4 flex flex-col gap-2 flex-1 overflow-hidden">
-        {/* 설명 */}
         <p className="text-sm text-gray-500 line-clamp-2">
           {competition.description}
         </p>
 
         <div className="flex-1" />
 
-        {/* 날짜 + 장소 + 참가자 */}
         <div className="flex flex-col gap-1 text-xs text-gray-400">
           <div className="flex items-center gap-1">
             <Image src="/calendar.svg" alt="날짜" width={14} height={14} />
-            <span>{competition.event_data}</span>
-            <div className="flex items-center gap-1">
-              <Image src="/calendar.svg" alt="날짜" width={14} height={14} />
-              <span>{competition.event_data}</span>
-              {competition.status !== '모집완료' && (
-                <span className={`ml-1 font-bold ${ddayColor}`}>{dday}</span>
-              )}
-            </div>
+            <span>대회 {competition.event_data}</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <Image src="/calendar.svg" alt="마감" width={14} height={14} />
+            <span>신청마감 {competition.apply_deadline}</span>
+            {actualStatus !== '모집완료' && (
+              <span className={`ml-1 font-bold ${ddayColor}`}>{dday}</span>
+            )}
+          </div>
+          <div className="flex items-center gap-1">
+            <Image src="/calendar.svg" alt="마감" width={14} height={14} />
+            <span>신청마감 {competition.apply_deadline}</span>
           </div>
           <div className="flex items-center gap-1">
             <Image src="/location.svg" alt="위치" width={14} height={14} />
@@ -101,10 +116,7 @@ export default function CompetitionCard({ competition }: CompetitionCardProps) {
           </div>
         </div>
 
-        {/* 구분선 */}
         <div className="border-t border-gray-100" />
-
-        {/* 신청하기 버튼 */}
 
         <a
           href={competition.apply_url}
@@ -112,15 +124,13 @@ export default function CompetitionCard({ competition }: CompetitionCardProps) {
           rel="noopener noreferrer"
           className={`w-full py-2 text-sm font-bold text-white text-center rounded-lg transition-all
             ${
-              competition.status === '모집완료'
+              actualStatus === '모집완료'
                 ? 'bg-gray-400 cursor-not-allowed'
                 : 'bg-[#2c2c2c] hover:bg-black'
             }`}
-          onClick={(e) =>
-            competition.status === '모집완료' && e.preventDefault()
-          }
+          onClick={(e) => actualStatus === '모집완료' && e.preventDefault()}
         >
-          {competition.status === '모집완료' ? '모집 완료' : '신청하기'}
+          {actualStatus === '모집완료' ? '모집 완료' : '신청하기'}
         </a>
       </div>
     </div>

--- a/src/components/competition/CompetitionClient.tsx
+++ b/src/components/competition/CompetitionClient.tsx
@@ -3,17 +3,18 @@ import { useState, useRef, useEffect } from 'react';
 import Pageheader from '@/components/layout/PageHeader';
 import CompetitionCard from '@/components/competition/CompetitionCard';
 import { useDebounce } from '@/hooks/useDebounce';
+import LoadingSpinner from '@/components/common/LoadingSpinner';
 import { useCompetiton } from '@/hooks/useCompetition';
 import { useAuth } from '@/hooks/useAuth';
-import LoadingSpinner from '@/components/common/LoadingSpinner';
+import { getStatus } from '@/utils/formatDate';
 
 interface Competition {
   id: string;
   name: string;
   location: string;
   event_data: string;
+  apply_deadline: string;
   category: string;
-  status: string;
   description: string;
   image_url: string;
   participants: number;
@@ -45,17 +46,22 @@ export default function CompetitionClient({
 
   const filteredCompetitions = data
     .filter((competition) => {
-      const matchTab = activeTab === '전체' || competition.status === activeTab;
+      const matchTab =
+        activeTab === '전체' ||
+        getStatus(competition.apply_deadline) === activeTab;
       const matchSearch = competition.name
         .toLowerCase()
         .includes(debouncedSearch.toLowerCase());
       return matchTab && matchSearch;
     })
     .sort((a, b) => {
-      const order = { 모집중: 1, 마감임박: 0, 모집완료: 2 };
+      const statusA = getStatus(a.apply_deadline);
+      const statusB = getStatus(b.apply_deadline);
+      if (statusA === '모집완료' && statusB !== '모집완료') return 1;
+      if (statusA !== '모집완료' && statusB === '모집완료') return -1;
       return (
-        (order[a.status as keyof typeof order] ?? 3) -
-        (order[b.status as keyof typeof order] ?? 3)
+        new Date(a.apply_deadline).getTime() -
+        new Date(b.apply_deadline).getTime()
       );
     });
 

--- a/src/components/competition/CompetitionClient.tsx
+++ b/src/components/competition/CompetitionClient.tsx
@@ -43,13 +43,21 @@ export default function CompetitionClient({
     }
   }, []);
 
-  const filteredCompetitions = data.filter((competition) => {
-    const matchTab = activeTab === '전체' || competition.status === activeTab;
-    const matchSearch = competition.name
-      .toLowerCase()
-      .includes(debouncedSearch.toLowerCase());
-    return matchTab && matchSearch;
-  });
+  const filteredCompetitions = data
+    .filter((competition) => {
+      const matchTab = activeTab === '전체' || competition.status === activeTab;
+      const matchSearch = competition.name
+        .toLowerCase()
+        .includes(debouncedSearch.toLowerCase());
+      return matchTab && matchSearch;
+    })
+    .sort((a, b) => {
+      const order = { 모집중: 1, 마감임박: 0, 모집완료: 2 };
+      return (
+        (order[a.status as keyof typeof order] ?? 3) -
+        (order[b.status as keyof typeof order] ?? 3)
+      );
+    });
 
   return (
     <div className="w-full min-h-screen">

--- a/src/components/dojang/DojangCard.tsx
+++ b/src/components/dojang/DojangCard.tsx
@@ -12,11 +12,19 @@ interface KakaoPlace {
 interface DojangCardProps {
   dojang: KakaoPlace;
   isVerified: boolean;
+  isSelected: boolean; // ✅ 추가
 }
 
-export default function DojangCard({ dojang, isVerified }: DojangCardProps) {
+export default function DojangCard({
+  dojang,
+  isVerified,
+  isSelected,
+}: DojangCardProps) {
   return (
-    <div className="p-4 border border-gray-200 rounded-lg bg-white hover:shadow-md transition-all cursor-pointer">
+    <div
+      className={`p-4 border rounded-lg bg-white hover:shadow-md transition-all cursor-pointer
+      ${isSelected ? 'border-btn-focus border-2 shadow-md' : 'border-gray-200'}`}
+    >
       {/* 도장 이름 + 인증 배지 */}
       <div className="flex items-center gap-2">
         <h3 className="font-bold text-base line-clamp-1">

--- a/src/components/dojang/DojangClient.tsx
+++ b/src/components/dojang/DojangClient.tsx
@@ -4,7 +4,6 @@ import DojangCard from '@/components/dojang/DojangCard';
 import Pageheader from '@/components/layout/PageHeader';
 import { useDebounce } from '@/hooks/useDebounce';
 import Script from 'next/script';
-import { supabase } from '@/lib/supabase';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 declare global {
@@ -23,6 +22,7 @@ interface KakaoPlace {
   x: string;
   y: string;
 }
+
 interface DojangClientProps {
   initialVerifiedDojangs: string[];
 }
@@ -35,27 +35,18 @@ export default function DojangClient({
   const [isLoading, setIsLoading] = useState(false);
   const [mapLoaded, setMapLoaded] = useState(false);
   const [headerHeight, setHeaderHeight] = useState(0);
-  const [verifiedDojangs, setVerifiedDojangs] = useState<string[]>([]);
+  const [selectedDojangId, setSelectedDojangId] = useState<string | null>(null);
   const headerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<HTMLDivElement>(null);
   const mapInstance = useRef<any>(null);
   const markersRef = useRef<any[]>([]);
+  const cardRefs = useRef<{ [key: string]: HTMLDivElement | null }>({});
   const debouncedSearch = useDebounce(searchQuery, 500);
 
   useEffect(() => {
     if (headerRef.current) {
       setHeaderHeight(headerRef.current.offsetHeight);
     }
-  }, []);
-
-  useEffect(() => {
-    const fetchVerifiedDojangs = async () => {
-      const { data } = await supabase.from('dojang').select('name');
-      if (data) {
-        setVerifiedDojangs(data.map((d: { name: string }) => d.name));
-      }
-    };
-    fetchVerifiedDojangs();
   }, []);
 
   const initMap = () => {
@@ -95,6 +86,7 @@ export default function DojangClient({
         );
         const data = await res.json();
         setDojangs(data.documents);
+        setSelectedDojangId(null);
         clearMarkers();
 
         if (data.documents.length > 0 && mapInstance.current) {
@@ -110,6 +102,18 @@ export default function DojangClient({
               map: mapInstance.current,
               title: place.place_name,
             });
+
+            window.naver.maps.Event.addListener(marker, 'click', () => {
+              setSelectedDojangId(place.id);
+              const card = cardRefs.current[place.id];
+              if (card) {
+                window.scrollTo({
+                  top: card.offsetTop - headerHeight - 24,
+                  behavior: 'smooth',
+                });
+              }
+            });
+
             markersRef.current.push(marker);
           });
         }
@@ -170,11 +174,20 @@ export default function DojangClient({
             ) : dojangs.length > 0 ? (
               <div className="grid grid-cols-2 gap-4">
                 {dojangs.map((dojang) => (
-                  <DojangCard
+                  <div
                     key={dojang.id}
-                    dojang={dojang}
-                    isVerified={verifiedDojangs.includes(dojang.place_name)}
-                  />
+                    ref={(el) => {
+                      cardRefs.current[dojang.id] = el;
+                    }}
+                  >
+                    <DojangCard
+                      dojang={dojang}
+                      isVerified={initialVerifiedDojangs.includes(
+                        dojang.place_name,
+                      )}
+                      isSelected={selectedDojangId === dojang.id}
+                    />
+                  </div>
                 ))}
               </div>
             ) : (

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -10,6 +10,7 @@ import {
   FileText,
   Users,
   HelpCircle,
+  Calendar,
 } from 'lucide-react';
 import { useAuth } from '../../hooks/useAuth';
 
@@ -28,6 +29,7 @@ const adminNavItems = [
   { label: '게시글 관리', href: '/admin/posts', icon: FileText },
   { label: '유저 관리', href: '/admin/users', icon: Users },
   { label: '고객 지원', href: '/admin/support', icon: HelpCircle },
+  { label: '대회일정 관리', href: '/admin/competitions', icon: Calendar },
 ];
 
 export default function Sidebar() {

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -17,3 +17,17 @@ export function formatDate(dateString: string): string {
   const day = String(date.getDate()).padStart(2, '0');
   return `${year}.${month}.${day}`;
 }
+
+export function getDday(eventDate: string): string {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const target = new Date(eventDate);
+  target.setHours(0, 0, 0, 0);
+  const diff = Math.ceil(
+    (target.getTime() - today.getTime()) / (1000 * 60 * 60 * 24),
+  );
+
+  if (diff === 0) return 'D-DAY';
+  if (diff > 0) return `D-${diff}`;
+  return `D+${Math.abs(diff)}`;
+}

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -31,3 +31,17 @@ export function getDday(eventDate: string): string {
   if (diff > 0) return `D-${diff}`;
   return `D+${Math.abs(diff)}`;
 }
+
+export function getStatus(applyDeadline: string): string {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const deadline = new Date(applyDeadline);
+  deadline.setHours(0, 0, 0, 0);
+  const diff = Math.ceil(
+    (deadline.getTime() - today.getTime()) / (1000 * 60 * 60 * 24),
+  );
+
+  if (diff < 0) return '모집완료';
+  if (diff <= 7) return '마감임박';
+  return '모집중';
+}


### PR DESCRIPTION
## 📌 개요

- 대회일정 디데이 추가 및 정렬 추가 (마감임박 -> 모집중 -> 마감완료 순으로 상위 배치)
- 도장찾기 마커 클릭 시 하이라이트 및 스크롤 이동

## 💻 작업 사항
- 대회일정 디데이 추가 및 정렬 추가 (마감임박 -> 모집중 -> 마감완료 순으로 상위 배치)
- 도장찾기 마커 클릭 시 하이라이트 및 스크롤 이동

<img width="1673" height="894" alt="스크린샷 2026-04-30 시간: 16 32 53" src="https://github.com/user-attachments/assets/89680248-9c15-4345-ab06-dae71067c07f" />
<img width="1686" height="895" alt="스크린샷 2026-04-30 시간: 16 44 50" src="https://github.com/user-attachments/assets/df13b6a3-67af-438b-bf42-7d5a91a71490" />

+ 대회일정 신청마감 날짜 추가 및 신청 마감 날짜 기준 정렬, 상태 설정 날짜에 맞춰 변경하도록 설정 
<img width="1636" height="878" alt="스크린샷 2026-04-30 시간: 17 30 12" src="https://github.com/user-attachments/assets/2153fc06-9930-4e8b-ab9d-6e0dafdf703e" />


+ 대회일정관리 버튼 추가 (관리자 전용 사이드바)
<img width="216" height="905" alt="스크린샷 2026-04-30 시간: 16 53 09" src="https://github.com/user-attachments/assets/f49a1a32-55b8-4dcf-af15-b90a89b0221f" />


## 💡 관련 Issue
Closes #46 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #46 )
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
