### PR TITLE
[feat] 도장로그인시 게시글 작성 유형 일반, 도장 선택 가능

### DIFF
--- a/src/app/(main)/community/write/page.tsx
+++ b/src/app/(main)/community/write/page.tsx
@@ -17,12 +17,7 @@ export default function WritePage() {
   const [isLoading, setIsLoading] = useState(false);
   const [imageFile, setImageFile] = useState<File | null>(null);
   const { user, loading } = useAuth();
-  const category: PostCategory =
-    user?.role === 'manager'
-      ? 'promo'
-      : user?.role === 'admin'
-        ? 'notice'
-        : 'personal';
+  const [category, setCategory] = useState<PostCategory>('personal');
 
   useEffect(() => {
     if (!loading && !user) {
@@ -81,13 +76,27 @@ export default function WritePage() {
 
       <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
         <p className="text-sm text-gray-500 mb-2">게시글 유형</p>
-        <div className="py-2 px-3 rounded-lg text-sm font-medium bg-black text-white text-center">
-          {user?.role === 'manager'
-            ? '도장 홍보'
-            : user?.role === 'admin'
-              ? '공지'
-              : '일반 게시글'}
-        </div>
+        {user?.role === 'manager' ? (
+          <div className="flex gap-2">
+            {(['personal', 'promo'] as PostCategory[]).map((type) => (
+              <button
+                key={type}
+                onClick={() => setCategory(type)}
+                className={`flex-1 py-2 rounded-lg text-sm font-medium cursor-pointer transition-colors ${
+                  category === type
+                    ? 'bg-black text-white'
+                    : 'bg-gray-100 text-gray-600'
+                }`}
+              >
+                {type === 'personal' ? '일반 게시글' : '도장 홍보'}
+              </button>
+            ))}
+          </div>
+        ) : (
+          <div className="py-2 px-3 rounded-lg text-sm font-medium bg-black text-white text-center">
+            {user?.role === 'admin' ? '공지' : '일반 게시글'}
+          </div>
+        )}
       </div>
 
       <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">


### PR DESCRIPTION
## 📌 개요

- 도장 로그인시 게시글 작성 유형 일반, 도장 선택 가능

## 💻 작업 사항

- 도장으로 로그인하여 게시글을 작성할 때, 게시글 유형을 일반, 도장홍보 중 하나를 선택
<img width="1456" height="870" alt="image" src="https://github.com/user-attachments/assets/d95d63e2-209e-4862-8c48-f612204751ff" />

- 유형선택별로 아이콘 다르게 표시되는 것을 확인
<img width="1303" height="428" alt="image" src="https://github.com/user-attachments/assets/a98e57b5-7bd9-4652-9c13-b19abac05214" />

---
- 게시글 수정에서는 게시글 생성시 선택한 유형으로 읽기전용으로 표시만 하기
<img width="1029" height="355" alt="image" src="https://github.com/user-attachments/assets/b52855f4-8422-4b78-a895-d3d42e89a439" />
<img width="1038" height="365" alt="image" src="https://github.com/user-attachments/assets/e4561606-7759-4a43-b9f6-2371126eadb2" />


## 💡 관련 Issue

Closes #48 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #48 )
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
