### PR TITLE
[Feat] 대회일정추가 페이지 UI 구현, API 연동

### DIFF
--- a/src/app/(main)/competitions/write/page.tsx
+++ b/src/app/(main)/competitions/write/page.tsx
@@ -1,0 +1,203 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Image from 'next/image';
+import LoadingSpinner from '@/components/common/LoadingSpinner';
+import { useAuth } from '@/hooks/useAuth';
+
+export default function CompetitionWritePage() {
+  const router = useRouter();
+  const { user, loading } = useAuth();
+  const [name, setName] = useState('');
+  const [location, setLocation] = useState('');
+  const [eventDate, setEventDate] = useState('');
+  const [applyDeadline, setApplyDeadline] = useState('');
+  const [applyUrl, setApplyUrl] = useState('');
+  const [description, setDescription] = useState('');
+  const [preview, setPreview] = useState<string | null>(null);
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (
+      !loading &&
+      (!user || (user.role !== 'admin' && user.role !== 'manager'))
+    ) {
+      router.push('/competitions');
+    }
+  }, [user, loading, router]);
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      setImageFile(file);
+      setPreview(URL.createObjectURL(file));
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (!name.trim() || !location.trim() || !eventDate || !applyDeadline) {
+      alert('필수 항목을 모두 입력해주세요.');
+      return;
+    }
+    // TODO: API 연결
+    console.log({
+      name,
+      location,
+      eventDate,
+      applyDeadline,
+      applyUrl,
+      description,
+      imageFile,
+    });
+  };
+
+  if (loading || isLoading) return <LoadingSpinner />;
+
+  return (
+    <div className="max-w-2xl mx-auto p-6">
+      {/* 헤더 */}
+      <div className="relative w-full flex items-center justify-center mb-6">
+        <h1 className="text-lg font-semibold">대회 추가</h1>
+      </div>
+
+      {/* 대회 제목 */}
+      <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
+        <p className="text-sm text-gray-500 mb-2">대회 제목</p>
+        <input
+          type="text"
+          placeholder="예: 2026 서울 주짓수 챔피언십"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full bg-gray-50 rounded-lg px-3 py-2 text-sm outline-none"
+        />
+      </div>
+
+      {/* 대회 이미지 */}
+      <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
+        <p className="text-sm text-gray-500 mb-2">대회 이미지 (선택)</p>
+        <label className="block cursor-pointer">
+          {preview ? (
+            <div className="relative w-full h-48 rounded-lg overflow-hidden">
+              <Image
+                src={preview}
+                alt="preview"
+                fill
+                className="object-cover"
+              />
+            </div>
+          ) : (
+            <div className="flex flex-col items-center justify-center h-40 bg-gray-50 rounded-lg border-2 border-dashed border-gray-200">
+              <span className="text-3xl mb-2">↑</span>
+              <p className="text-sm text-gray-500">클릭하여 이미지 업로드</p>
+              <p className="text-xs text-gray-400 mt-1">
+                JPG, PNG, GIF (최대 10MB)
+              </p>
+            </div>
+          )}
+          <input
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={handleImageChange}
+          />
+        </label>
+      </div>
+
+      {/* 대회 날짜 */}
+      <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
+        <p className="text-sm text-gray-500 mb-2">대회 날짜</p>
+        <div className="relative">
+          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
+            📅
+          </span>
+          <input
+            type="date"
+            value={eventDate}
+            onChange={(e) => setEventDate(e.target.value)}
+            className="w-full bg-gray-50 rounded-lg pl-9 pr-3 py-2 text-sm outline-none text-gray-700"
+          />
+        </div>
+      </div>
+
+      {/* 신청 마감 날짜 */}
+      <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
+        <p className="text-sm text-gray-500 mb-2">신청 마감 날짜</p>
+        <div className="relative">
+          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
+            📅
+          </span>
+          <input
+            type="date"
+            value={applyDeadline}
+            onChange={(e) => setApplyDeadline(e.target.value)}
+            className="w-full bg-gray-50 rounded-lg pl-9 pr-3 py-2 text-sm outline-none text-gray-700"
+          />
+        </div>
+      </div>
+
+      {/* 대회 장소 */}
+      <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
+        <p className="text-sm text-gray-500 mb-2">대회 장소</p>
+        <div className="relative">
+          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
+            📍
+          </span>
+          <input
+            type="text"
+            placeholder="예: 잠실 체육관"
+            value={location}
+            onChange={(e) => setLocation(e.target.value)}
+            className="w-full bg-gray-50 rounded-lg pl-9 pr-3 py-2 text-sm outline-none"
+          />
+        </div>
+      </div>
+
+      {/* 참가 신청 링크 */}
+      <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
+        <p className="text-sm text-gray-500 mb-2">참가 신청 링크</p>
+        <div className="relative">
+          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
+            🔗
+          </span>
+          <input
+            type="url"
+            placeholder="https://example.com/register"
+            value={applyUrl}
+            onChange={(e) => setApplyUrl(e.target.value)}
+            className="w-full bg-gray-50 rounded-lg pl-9 pr-3 py-2 text-sm outline-none"
+          />
+        </div>
+      </div>
+
+      {/* 대회 설명 */}
+      <div className="bg-white rounded-xl p-4 mb-6 shadow-sm">
+        <p className="text-sm text-gray-500 mb-2">대회 설명</p>
+        <textarea
+          placeholder="대회에 대한 상세 설명을 입력하세요"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          rows={6}
+          className="w-full bg-gray-50 rounded-lg px-3 py-2 text-sm outline-none resize-none"
+        />
+      </div>
+
+      {/* 버튼 */}
+      <div className="flex gap-3">
+        <button
+          onClick={() => router.back()}
+          className="flex-1 py-3 rounded-xl bg-btn-basic border border-gray-300 text-black hover:bg-gray-200"
+        >
+          취소
+        </button>
+        <button
+          onClick={handleSubmit}
+          className="flex-3 py-3 rounded-xl bg-black text-white text-sm font-medium cursor-pointer"
+        >
+          추가하기
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/competitions/write/page.tsx
+++ b/src/app/(main)/competitions/write/page.tsx
@@ -5,6 +5,10 @@ import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import LoadingSpinner from '@/components/common/LoadingSpinner';
 import { useAuth } from '@/hooks/useAuth';
+import {
+  createCompetition,
+  uploadCompetitionImage,
+} from '@/services/competitionService';
 
 export default function CompetitionWritePage() {
   const router = useRouter();
@@ -41,16 +45,28 @@ export default function CompetitionWritePage() {
       alert('필수 항목을 모두 입력해주세요.');
       return;
     }
-    // TODO: API 연결
-    console.log({
-      name,
-      location,
-      eventDate,
-      applyDeadline,
-      applyUrl,
-      description,
-      imageFile,
-    });
+    setIsLoading(true);
+    try {
+      let image_url: string | undefined;
+      if (imageFile) {
+        image_url = await uploadCompetitionImage(imageFile);
+      }
+      await createCompetition({
+        name,
+        location,
+        event_data: eventDate,
+        apply_deadline: applyDeadline,
+        apply_url: applyUrl,
+        description,
+        image_url,
+      });
+      router.push('/competitions');
+    } catch (e) {
+      console.error(e);
+      alert('대회 추가에 실패했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   if (loading || isLoading) return <LoadingSpinner />;

--- a/src/app/(main)/competitions/write/page.tsx
+++ b/src/app/(main)/competitions/write/page.tsx
@@ -132,7 +132,8 @@ export default function CompetitionWritePage() {
             type="date"
             value={eventDate}
             onChange={(e) => setEventDate(e.target.value)}
-            className="w-full bg-gray-50 rounded-lg pl-9 pr-3 py-2 text-sm outline-none text-gray-700"
+            onClick={(e) => (e.target as HTMLInputElement).showPicker?.()}
+            className="w-full bg-gray-50 rounded-lg pl-9 pr-3 py-2 text-sm outline-none text-gray-700 cursor-pointer"
           />
         </div>
       </div>
@@ -148,7 +149,8 @@ export default function CompetitionWritePage() {
             type="date"
             value={applyDeadline}
             onChange={(e) => setApplyDeadline(e.target.value)}
-            className="w-full bg-gray-50 rounded-lg pl-9 pr-3 py-2 text-sm outline-none text-gray-700"
+            onClick={(e) => (e.target as HTMLInputElement).showPicker?.()}
+            className="w-full bg-gray-50 rounded-lg pl-9 pr-3 py-2 text-sm outline-none text-gray-700 cursor-pointer"
           />
         </div>
       </div>
@@ -203,7 +205,7 @@ export default function CompetitionWritePage() {
       <div className="flex gap-3">
         <button
           onClick={() => router.back()}
-          className="flex-1 py-3 rounded-xl bg-btn-basic border border-gray-300 text-black hover:bg-gray-200"
+          className="flex-1 py-3 rounded-xl bg-btn-basic border border-gray-300 text-black hover:bg-gray-200 cursor-pointer"
         >
           취소
         </button>

--- a/src/services/competitionService.ts
+++ b/src/services/competitionService.ts
@@ -1,0 +1,48 @@
+import { supabase } from '@/lib/supabase';
+
+export async function createCompetition({
+  name,
+  location,
+  event_data,
+  apply_deadline,
+  apply_url,
+  description,
+  image_url,
+}: {
+  name: string;
+  location: string;
+  event_data: string;
+  apply_deadline: string;
+  apply_url?: string;
+  description?: string;
+  image_url?: string;
+}) {
+  const { data, error } = await supabase
+    .from('competition')
+    .insert({
+      name,
+      location,
+      event_data,
+      apply_deadline,
+      apply_url,
+      description,
+      image_url,
+    })
+    .select()
+    .single();
+  if (error) throw error;
+  return data;
+}
+
+export async function uploadCompetitionImage(file: File): Promise<string> {
+  const ext = file.name.split('.').pop();
+  const fileName = `${Date.now()}.${ext}`;
+  const { error } = await supabase.storage
+    .from('competition-images')
+    .upload(fileName, file);
+  if (error) throw error;
+  const { data } = supabase.storage
+    .from('competition-images')
+    .getPublicUrl(fileName);
+  return data.publicUrl;
+}


### PR DESCRIPTION
## 📌 개요

- 도장(매니저), 관리자(admin)으로 로그인시 사용 가능한 대회일정 추가 페이지 UI 구현, API 연동

## 💻 작업 사항

- 대회일정 추가하는 페이지 UI 구현
<img width="518" height="876" alt="image" src="https://github.com/user-attachments/assets/391ffa00-01ee-423d-818c-65ad2cb5066a" />

- 마감날짜별로 모집중, 마감 임박, 모집 종료 확인
<img width="622" height="435" alt="image" src="https://github.com/user-attachments/assets/4d7c4949-7315-4939-9aed-0a4e32d59be9" />
<img width="629" height="446" alt="image" src="https://github.com/user-attachments/assets/130fd86d-1b86-4c28-b3c9-61429dd74895" />
<img width="636" height="439" alt="image" src="https://github.com/user-attachments/assets/8c3ef1a2-3c07-445a-b6d4-c193ade9eb07" />

- 관리자 아이디로도 작성됨을 확인
<img width="620" height="432" alt="image" src="https://github.com/user-attachments/assets/8469aa24-c5f0-4e87-8ca4-c8ad1e396671" />

- 참가하기 버튼 클릭하면 입력해놓은 링크도 연결이 잘 됨
- 멋사 홈페이지 URL 입력해놓음
<img width="667" height="113" alt="image" src="https://github.com/user-attachments/assets/e60faa8a-b384-4b89-8e39-8991dafa7b9a" />


## 💡 관련 Issue

Closes #44 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #44 )
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
