### PR TITLE
[feat] 대회일정추가에서 오늘 이전 날짜는 회색으로 비활성화 처리

### DIFF
--- a/src/app/(main)/competitions/write/page.tsx
+++ b/src/app/(main)/competitions/write/page.tsx
@@ -22,6 +22,7 @@ export default function CompetitionWritePage() {
   const [preview, setPreview] = useState<string | null>(null);
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const today = new Date().toISOString().split('T')[0];
 
   useEffect(() => {
     if (
@@ -131,6 +132,7 @@ export default function CompetitionWritePage() {
           <input
             type="date"
             value={eventDate}
+            min={today}
             onChange={(e) => setEventDate(e.target.value)}
             onClick={(e) => (e.target as HTMLInputElement).showPicker?.()}
             className="w-full bg-gray-50 rounded-lg pl-9 pr-3 py-2 text-sm outline-none text-gray-700 cursor-pointer"
@@ -148,6 +150,7 @@ export default function CompetitionWritePage() {
           <input
             type="date"
             value={applyDeadline}
+            min={today}
             onChange={(e) => setApplyDeadline(e.target.value)}
             onClick={(e) => (e.target as HTMLInputElement).showPicker?.()}
             className="w-full bg-gray-50 rounded-lg pl-9 pr-3 py-2 text-sm outline-none text-gray-700 cursor-pointer"


### PR DESCRIPTION
## 📌 개요

- 대회일정추가에서 과거의 날짜를 입력하여 대회일정이 모집완료로 넘어가지 않도록, 오늘 이전 날짜는 회색으로 비활성화 처리

## 💻 작업 사항

- 상태선언에서 오늘 날짜를 선언 
- min 속성으로 오늘 날짜 이후만 선택 가능(날짜 선택하는 input에 min 속성 추가)

---

- min 속성 추가전에는 이전 날짜로 이동 가능(위방향 화살표 활성화)
<img width="250" height="360" alt="image" src="https://github.com/user-attachments/assets/5b6d264c-f9f4-4e34-b011-52c3a21cad00" />

- min 속성 추가후에는 이전 날짜로 이동 불가능(위방향 화살표 비활성화)
<img width="245" height="345" alt="image" src="https://github.com/user-attachments/assets/65436279-efa6-4956-893c-1329af866da5" />

## 💡 관련 Issue

Closes #57 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #57 )
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
