### PR TITLE
[Feat](auth)/layout.tsx에 로고 추가 및 홈 링크 연결

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,10 +1,26 @@
+import Link from 'next/link';
+import Image from 'next/image';
+
 export default function AuthLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-bg-page px-10 py-6">
+    <div className="relative min-h-screen flex flex-col items-center justify-center bg-bg-page px-10 py-6">
+      {/* 로고 — 클릭 시 홈으로 이동 */}
+      <Link href="/" className="flex flex-col items-center mb-6">
+        <div className="relative w-40 h-20 mb-3">
+          <Image
+            src="/blackbelt.svg"
+            alt="Black Belt Logo"
+            fill
+            className="object-contain"
+            priority
+          />
+        </div>
+      </Link>
+
       {children}
     </div>
   );

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -9,7 +9,7 @@ export default function AuthLayout({
   return (
     <div className="relative min-h-screen flex flex-col items-center justify-center bg-bg-page px-10 py-6">
       {/* 로고 — 클릭 시 홈으로 이동 */}
-      <Link href="/" className="flex flex-col items-center mb-6">
+      <Link href="/" className="flex flex-col items-center mb-2">
         <div className="relative w-40 h-20 mb-3">
           <Image
             src="/blackbelt.svg"

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -81,21 +81,9 @@ export default function LoginPage() {
   };
   return (
     <>
-      {/* 로고 */}
-      <div className="flex flex-col items-center mb-6">
-        <div className="relative w-40 h-20 mb-3">
-          <Image
-            src="/blackbelt.svg"
-            alt="Black Belt Logo"
-            fill
-            className="object-contain"
-            priority
-          />
-        </div>
-        <p className="text-text-secondary text-sm font-medium text-center">
-          주짓수 커뮤니티에 오신 것을 환영합니다
-        </p>
-      </div>
+      <p className="text-text-secondary text-sm font-medium text-center mb-6">
+        주짓수 커뮤니티에 오신 것을 환영합니다
+      </p>
 
       {/* 카드 */}
       <div className="max-w-150 w-full bg-bg-white rounded-[32px] p-8 shadow-sm border-none">

--- a/src/app/(auth)/register/layout.tsx
+++ b/src/app/(auth)/register/layout.tsx
@@ -7,21 +7,9 @@ export default function RegisterLayout({
 }) {
   return (
     <>
-      {/* 로고 — 로그인이랑 완전 동일 */}
-      <div className="flex flex-col items-center mb-6">
-        <div className="relative w-40 h-20 mb-3">
-          <Image
-            src="/blackbelt.svg"
-            alt="Black Belt Logo"
-            fill
-            className="object-contain"
-            priority
-          />
-        </div>
-        <p className="text-text-secondary text-sm font-medium text-center">
-          새로운 계정을 만들어보세요
-        </p>
-      </div>
+      <p className="text-text-secondary text-sm font-medium text-center mb-6">
+        새로운 계정을 만들어보세요
+      </p>
 
       {/* 카드 — 로그인이랑 완전 동일 */}
       <div className="max-w-150 w-full bg-bg-white rounded-3xl p-8 shadow-sm border-none">


### PR DESCRIPTION
## 📌 개요

로그인, 회원가입, 비밀번호 찾기 페이지에서
로고 클릭 시 홈으로 이동할 수 있도록 구현했습니다.

## 💻 작업 사항

- (auth)/layout.tsx에 로고 추가 및 홈 링크 연결
- login/page.tsx 로고 제거 (auth layout으로 통합)
- register/layout.tsx 로고 제거 (auth layout으로 통합)
- find-password/page.tsx 로고 제거 (auth layout으로 통합)
- 로그인 페이지 서브타이틀 하단 여백 추가
- (auth)/layout.tsx에 통합해서 한 곳만 수정하면 모든 auth 페이지에 적용됨
<br>

https://github.com/user-attachments/assets/8dd9a238-16a1-41b9-94c3-52c8de6b680a

## 💡 관련 Issue

Closes #52

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #52)
- [x] 불필요한 console.log를 제거했습니다.
- [x] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
