### PR TITLE
[feat] 게시글 공유 기능 구현, 버튼에 툴팁 추가

### DIFF
--- a/src/app/(main)/community/[id]/page.tsx
+++ b/src/app/(main)/community/[id]/page.tsx
@@ -16,6 +16,7 @@ import Image from 'next/image';
 import LoadingSpinner from '@/components/common/LoadingSpinner';
 import { useAuth } from '@/hooks/useAuth';
 import { useLike } from '@/hooks/useLike';
+import toast from 'react-hot-toast';
 
 function timeAgo(dateStr: string) {
   const diff = Date.now() - new Date(dateStr).getTime();
@@ -139,6 +140,37 @@ export default function PostDetailPage({
 
   const isOwner = userId === post.user_id;
 
+  const handleShare = async () => {
+    const url = window.location.href;
+    const title = post?.title ?? '';
+
+    if (navigator.share && /Mobi|Android/i.test(navigator.userAgent)) {
+      try {
+        await navigator.share({ title, url });
+      } catch {
+        // 취소 무시
+      }
+    } else {
+      try {
+        await navigator.clipboard.writeText(url);
+        toast.success('링크가 복사되었습니다!', {
+          duration: 2000,
+          position: 'bottom-center',
+          style: {
+            background: '#111',
+            color: '#fff',
+            fontWeight: '600',
+            borderRadius: '12px',
+            padding: '12px 20px',
+          },
+          icon: '🔗',
+        });
+      } catch {
+        toast.error('복사에 실패했습니다.');
+      }
+    }
+  };
+
   return (
     <div className="max-w-2xl mx-auto p-4 space-y-4">
       {/* 뒤로가기 */}
@@ -221,6 +253,7 @@ export default function PostDetailPage({
             {isOwner ? (
               <>
                 <button
+                  title="수정하기"
                   onClick={() => router.push(`/community/${id}/edit`)}
                   aria-label={`${post.nickname}의 게시글 수정`}
                   className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-gray-100 transition-colors text-gray-500 cursor-pointer"
@@ -234,6 +267,7 @@ export default function PostDetailPage({
                   />
                 </button>
                 <button
+                  title="삭제하기"
                   onClick={handleDeletePost}
                   aria-label={`${post.nickname}의 게시글 삭제`}
                   className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-red-50 transition-colors text-red-400 cursor-pointer"
@@ -249,6 +283,7 @@ export default function PostDetailPage({
               </>
             ) : (
               <button
+                title="신고하기"
                 aria-label={`${post.nickname}의 게시글 신고`}
                 className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-gray-100 transition-colors text-gray-400 cursor-pointer"
               >
@@ -262,8 +297,10 @@ export default function PostDetailPage({
               </button>
             )}
             <button
+              title="공유하기"
+              onClick={handleShare}
               aria-label={`${post.nickname}의 게시글 공유`}
-              className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-gray-100 transition-colors text-gray-500 cursor-pointer"
+              className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-gray-100 transition-colors text-gray-500 cursor-pointer relative"
             >
               <Image
                 src="/postShare.svg"


### PR DESCRIPTION
## 📌 개요

- toast를 사용하여 게시글 공유 기능 구현, 버튼에 툴팁 추가

## 💻 작업 사항

- 게시글 상세 페이지에서 공유기능을 추가
- 데스트탑은 항상 클립보드 복사로 동작하기 때문에 버튼 클릭해서 toast 뜨는지 확인(navigator.clipboard 속성 사용)
<img width="686" height="818" alt="image" src="https://github.com/user-attachments/assets/e36782f2-f595-438b-a04e-870bb2c9b0c8" />

- 모바일은 navigator.share를 사용해서 공유
<img width="743" height="708" alt="image" src="https://github.com/user-attachments/assets/8ff0571a-f54a-42ac-84cd-35503f91711f" />

---

- 신고하기, 공유하기, 수정하기, 삭제하기 title 속성으로 툴팁 추가
<img width="124" height="73" alt="image" src="https://github.com/user-attachments/assets/8aaa9049-98a3-4aa9-8835-856d52c96d66" />
<img width="132" height="85" alt="image" src="https://github.com/user-attachments/assets/41b80b04-e535-41ae-8d8f-249a2665b1d9" />

## 💡 관련 Issue

Closes #55 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #55 )
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
