### PR TITLE
[feat] 확인만 하는 팝업을 toast로 수정, toast는 공통 객체로 빼기(lib/toast.ts)

### DIFF
--- a/src/app/(main)/community/[id]/edit/page.tsx
+++ b/src/app/(main)/community/[id]/edit/page.tsx
@@ -11,6 +11,7 @@ import {
   updatePost,
   uploadPostImage,
 } from '@/services/communityService';
+import { showErrorToast } from '@/lib/toast';
 
 export default function EditPage({
   params,
@@ -53,7 +54,7 @@ export default function EditPage({
 
   const handleSubmit = async () => {
     if (!title.trim() || !content.trim()) {
-      alert('제목과 내용을 모두 입력해주세요.');
+      showErrorToast('제목과 내용을 모두 입력해주세요.');
       return;
     }
     setIsLoading(true);
@@ -64,9 +65,8 @@ export default function EditPage({
       }
       await updatePost(id, { title, content, image_url });
       router.push(`/community/${id}`);
-    } catch (e) {
-      console.error(e);
-      alert('게시글 수정에 실패했습니다.');
+    } catch {
+      showErrorToast('게시글 수정에 실패했습니다.');
     } finally {
       setIsLoading(false);
     }

--- a/src/app/(main)/community/[id]/page.tsx
+++ b/src/app/(main)/community/[id]/page.tsx
@@ -16,7 +16,7 @@ import Image from 'next/image';
 import LoadingSpinner from '@/components/common/LoadingSpinner';
 import { useAuth } from '@/hooks/useAuth';
 import { useLike } from '@/hooks/useLike';
-import toast from 'react-hot-toast';
+import { showErrorToast, showSuccessToast } from '@/lib/toast';
 
 function timeAgo(dateStr: string) {
   const diff = Date.now() - new Date(dateStr).getTime();
@@ -153,20 +153,9 @@ export default function PostDetailPage({
     } else {
       try {
         await navigator.clipboard.writeText(url);
-        toast.success('링크가 복사되었습니다!', {
-          duration: 2000,
-          position: 'bottom-center',
-          style: {
-            background: '#111',
-            color: '#fff',
-            fontWeight: '600',
-            borderRadius: '12px',
-            padding: '12px 20px',
-          },
-          icon: '🔗',
-        });
+        showSuccessToast('링크가 복사되었습니다!', '🔗');
       } catch {
-        toast.error('복사에 실패했습니다.');
+        showErrorToast('복사에 실패했습니다.');
       }
     }
   };

--- a/src/app/(main)/community/write/page.tsx
+++ b/src/app/(main)/community/write/page.tsx
@@ -8,6 +8,7 @@ import LoadingSpinner from '@/components/common/LoadingSpinner';
 import { supabase } from '@/lib/supabase';
 import { createPost, uploadPostImage } from '@/services/communityService';
 import { useAuth } from '@/hooks/useAuth';
+import { showErrorToast } from '@/lib/toast';
 
 export default function WritePage() {
   const router = useRouter();
@@ -37,7 +38,7 @@ export default function WritePage() {
 
   const handleSubmit = async () => {
     if (!title.trim() || !content.trim()) {
-      alert('제목과 내용을 모두 입력해주세요.');
+      showErrorToast('제목과 내용을 모두 입력해주세요.');
       return;
     }
     setIsLoading(true);
@@ -60,9 +61,8 @@ export default function WritePage() {
         user_id: user.id,
       });
       router.push('/community');
-    } catch (e) {
-      console.error(e);
-      alert('게시글 작성에 실패했습니다.');
+    } catch {
+      showErrorToast('게시글 작성에 실패했습니다.');
     } finally {
       setIsLoading(false);
     }

--- a/src/app/(main)/competitions/write/page.tsx
+++ b/src/app/(main)/competitions/write/page.tsx
@@ -9,6 +9,7 @@ import {
   createCompetition,
   uploadCompetitionImage,
 } from '@/services/competitionService';
+import { showErrorToast } from '@/lib/toast';
 
 export default function CompetitionWritePage() {
   const router = useRouter();
@@ -43,7 +44,7 @@ export default function CompetitionWritePage() {
 
   const handleSubmit = async () => {
     if (!name.trim() || !location.trim() || !eventDate || !applyDeadline) {
-      alert('필수 항목을 모두 입력해주세요.');
+      showErrorToast('필수 항목을 모두 입력해주세요.');
       return;
     }
     setIsLoading(true);
@@ -62,9 +63,8 @@ export default function CompetitionWritePage() {
         image_url,
       });
       router.push('/competitions');
-    } catch (e) {
-      console.error(e);
-      alert('대회 추가에 실패했습니다.');
+    } catch {
+      showErrorToast('대회 추가에 실패했습니다.');
     } finally {
       setIsLoading(false);
     }

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -1,0 +1,28 @@
+// lib/toast.ts
+import toast from 'react-hot-toast';
+
+export const showErrorToast = (message: string) => {
+  toast.error(message, {
+    position: 'bottom-center',
+    style: {
+      fontWeight: '600',
+      borderRadius: '12px',
+      boxShadow: '0 4px 16px rgba(0,0,0,0.12)',
+    },
+  });
+};
+
+export const showSuccessToast = (message: string, icon?: string) => {
+  toast.success(message, {
+    duration: 2000,
+    position: 'bottom-center',
+    style: {
+      background: '#111',
+      color: '#fff',
+      fontWeight: '600',
+      borderRadius: '12px',
+      padding: '12px 20px',
+    },
+    icon: icon ?? '✅',
+  });
+};


### PR DESCRIPTION
## 📌 개요

- 확인만 하는 팝업을 toast로 수정, toast는 공통 객체로 빼기(lib/toast.ts)

## 💻 작업 사항

- 게시글 작성, 수정 페이지에서 "제목과 내용을 모두 입력해주세요" 팝업을 toast로 수정
<img width="399" height="111" alt="image" src="https://github.com/user-attachments/assets/72beeed2-ada3-46dc-99c9-5e349dec9f1b" />


- 대회일정 추가페이지에서 "필수 항목을 모두 입력해주세요" 팝업을 toast로 수정
<img width="324" height="107" alt="image" src="https://github.com/user-attachments/assets/7985f7c4-8c5c-4072-a551-0b05e016b4c8" />

- 여러 페이지에 사용하는 코드임으로 lib/toast.ts 에 공통 객체로 분리

## 💡 관련 Issue

Closes #64 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #64 )
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.