### PR TITLE
[Feat] 게시글 관리 페이지네이션 구현

### DIFF
--- a/src/components/admin/AdminDataTable.tsx
+++ b/src/components/admin/AdminDataTable.tsx
@@ -1,10 +1,14 @@
-import { cn } from "@/lib/utils";
+'use client';
+
+import { useAdminTablePagination } from '@/hooks/useAdminTablePagination';
+import AdminTablePagination from '@/components/admin/AdminTablePagination';
+import { cn } from '@/lib/utils';
 
 export interface AdminTableColumn<T> {
   key: keyof T;
   header: string;
   width?: string;
-  align?: string;
+  align?: 'left' | 'center';
   // eslint-disable-next-line no-unused-vars
   render?: (_row: T) => React.ReactNode;
 }
@@ -12,6 +16,9 @@ export interface AdminTableColumn<T> {
 interface AdminDataTableProps<T> {
   columns: AdminTableColumn<T>[];
   data: T[];
+  emptyMessage?: string;
+  initialPageSize?: number;
+  pageSizeOptions?: readonly number[];
   // eslint-disable-next-line no-unused-vars
   getRowKey?: (_row: T, _index: number) => React.Key;
 }
@@ -19,10 +26,27 @@ interface AdminDataTableProps<T> {
 export default function AdminDataTable<T>({
   columns,
   data,
+  emptyMessage = '데이터가 없습니다.',
+  initialPageSize,
+  pageSizeOptions,
   getRowKey,
 }: AdminDataTableProps<T>) {
+  const {
+    pageSize,
+    currentPage,
+    totalPages,
+    paginatedData,
+    pageSizeOptions: normalizedPageSizeOptions,
+    handlePageChange,
+    handlePageSizeChange,
+  } = useAdminTablePagination({
+    data,
+    initialPageSize,
+    pageSizeOptions,
+  });
+
   return (
-    <section className="w-full max-w-7xl px-6 py-4 bg-white border rounded-md">
+    <section className="w-full max-w-7xl rounded-md border bg-white px-6 py-4 mb-8">
       <table className="w-full table-fixed border-collapse bg-white">
         <thead>
           <tr>
@@ -34,7 +58,7 @@ export default function AdminDataTable<T>({
                   column.align === 'center' && 'text-center',
                   column.align === 'left' && 'text-left',
                 )}
-                style={{width: column.width}}
+                style={{ width: column.width }}
               >
                 {column.header}
               </th>
@@ -49,34 +73,52 @@ export default function AdminDataTable<T>({
                 colSpan={columns.length}
                 className="px-4 py-10 text-center text-sm text-zinc-500"
               >
-                게시글이 없습니다.
+                {emptyMessage}
               </td>
             </tr>
           ) : (
-            data.map((row, rowIndex) => (
-              <tr
-                key={getRowKey ? getRowKey(row, rowIndex) : rowIndex}
-                className="group transition-colors duration-200 hover:bg-[var(--color-table-top)]"
-              >
-                {columns.map((column) => (
-                  <td
-                    key={String(column.key)}
-                    className={cn(
-                      'border-b px-4 py-3 text-sm text-zinc-700',
-                      column.align === 'center' && 'text-center',
-                      column.align === 'left' && 'text-left',
-                    )}  
-                  >
-                    <div className="truncate">
-                      {column.render ? column.render(row) : String(row[column.key])}
-                    </div>
-                  </td>
-                ))}
-              </tr>
-            ))
+            paginatedData.map((row, rowIndex) => {
+              const originalIndex = (currentPage - 1) * pageSize + rowIndex;
+
+              return (
+                <tr
+                  key={
+                    getRowKey ? getRowKey(row, originalIndex) : originalIndex
+                  }
+                  className="group transition-colors duration-200 hover:bg-[var(--color-table-top)]"
+                >
+                  {columns.map((column) => (
+                    <td
+                      key={String(column.key)}
+                      className={cn(
+                        'border-b px-4 py-3 text-sm text-zinc-700',
+                        column.align === 'center' && 'text-center',
+                        column.align === 'left' && 'text-left',
+                      )}
+                    >
+                      <div className="truncate">
+                        {column.render
+                          ? column.render(row)
+                          : String(row[column.key])}
+                      </div>
+                    </td>
+                  ))}
+                </tr>
+              );
+            })
           )}
         </tbody>
       </table>
+
+      <AdminTablePagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        totalItems={data.length}
+        pageSize={pageSize}
+        pageSizeOptions={normalizedPageSizeOptions}
+        onPageChange={handlePageChange}
+        onPageSizeChange={handlePageSizeChange}
+      />
     </section>
   );
 }

--- a/src/components/admin/AdminPostTableClient.tsx
+++ b/src/components/admin/AdminPostTableClient.tsx
@@ -50,9 +50,9 @@ const POST_COLUMNS: AdminTableColumn<AdminPostRow>[] = [
       return <AdminBadge label={label} variant={variant} />;
     },
   },
-  { key: 'view_count', header: '조회수', width: '10%', align: 'center'},
-  { key: 'report_count', header: '신고수', width: '8%', align: 'center'},
-  { key: 'created_at', header: '작성일', width: '10%', align: 'center'},
+  { key: 'view_count', header: '조회수', width: '10%', align: 'center' },
+  { key: 'report_count', header: '신고수', width: '8%', align: 'center' },
+  { key: 'created_at', header: '작성일', width: '10%', align: 'center' },
   {
     key: 'id',
     header: '관리',

--- a/src/components/admin/AdminTablePagination.tsx
+++ b/src/components/admin/AdminTablePagination.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { ChevronLeft, ChevronRight, MoreHorizontal } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+type PaginationItem = number | 'ellipsis-left' | 'ellipsis-right';
+
+interface AdminTablePaginationProps {
+  currentPage: number;
+  totalPages: number;
+  totalItems: number;
+  pageSize: number;
+  pageSizeOptions: readonly number[];
+  // eslint-disable-next-line no-unused-vars
+  onPageChange: (page: number) => void;
+  // eslint-disable-next-line no-unused-vars
+  onPageSizeChange: (pageSize: number) => void;
+}
+
+const navigationButtonClass =
+  'inline-flex h-9 min-w-9 items-center justify-center rounded-md border px-3 text-sm font-medium transition-colors duration-50 disabled:cursor-not-allowed disabled:opacity-40';
+
+function buildPaginationItems(
+  currentPage: number,
+  totalPages: number,
+): PaginationItem[] {
+  if (totalPages <= 5) {
+    return Array.from({ length: totalPages }, (_, index) => index + 1);
+  }
+
+  const items: PaginationItem[] = [1];
+  const middleStart = Math.max(2, currentPage - 1);
+  const middleEnd = Math.min(totalPages - 1, currentPage + 1);
+
+  if (middleStart > 2) {
+    items.push('ellipsis-left');
+  }
+
+  for (let page = middleStart; page <= middleEnd; page += 1) {
+    items.push(page);
+  }
+
+  if (middleEnd < totalPages - 1) {
+    items.push('ellipsis-right');
+  }
+
+  items.push(totalPages);
+
+  return items;
+}
+
+export default function AdminTablePagination({
+  currentPage,
+  totalPages,
+  totalItems,
+  pageSize,
+  pageSizeOptions,
+  onPageChange,
+  onPageSizeChange,
+}: AdminTablePaginationProps) {
+  if (totalItems === 0) {
+    return null;
+  }
+
+  const visibleItems = buildPaginationItems(currentPage, totalPages);
+  const startItem = (currentPage - 1) * pageSize + 1;
+  const endItem = Math.min(currentPage * pageSize, totalItems);
+
+  return (
+    <footer className="flex flex-col gap-4 border-t border-zinc-200 px-4 py-4 md:flex-row md:items-center md:justify-between">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+        <p className="text-sm text-text-secondary">
+          총 {totalItems}개 중 {startItem}-{endItem}개 표시
+        </p>
+
+        <label className="flex items-center gap-2 text-sm text-text-secondary">
+          페이지당
+          <select
+            className="h-9 cursor-pointer rounded-md border border-zinc-200 bg-bg-white px-3 text-sm text-text-primary outline-none transition-colors duration-200 focus:border-btn-focus"
+            value={pageSize}
+            onChange={(event) => onPageSizeChange(Number(event.target.value))}
+          >
+            {pageSizeOptions.map((option) => (
+              <option key={option} value={option}>
+                {option}개
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      {totalPages > 1 ? (
+        <nav
+          aria-label="테이블 페이지 이동"
+          className="flex items-center justify-between gap-2 sm:justify-end"
+        >
+          <button
+            type="button"
+            aria-label="이전 페이지"
+            className={cn(
+              navigationButtonClass,
+              'cursor-pointer border-zinc-200 bg-bg-white text-btn-text hover:bg-btn-basic',
+            )}
+            disabled={currentPage === 1}
+            onClick={() => onPageChange(currentPage - 1)}
+          >
+            <ChevronLeft className="size-4" />
+          </button>
+
+          <div className="flex items-center gap-2">
+            {visibleItems.map((item) => {
+              if (typeof item !== 'number') {
+                return (
+                  <span
+                    key={item}
+                    className="inline-flex h-9 min-w-9 items-center justify-center text-zinc-400"
+                  >
+                    <MoreHorizontal className="size-4" />
+                  </span>
+                );
+              }
+
+              const isActive = item === currentPage;
+
+              return (
+                <button
+                  key={item}
+                  type="button"
+                  aria-current={isActive ? 'page' : undefined}
+                  className={cn(
+                    navigationButtonClass,
+                    'cursor-pointer',
+                    isActive
+                      ? 'border-btn-focus bg-btn-focus text-btn-focus-text'
+                      : 'border-zinc-200 bg-bg-white text-btn-text hover:bg-btn-basic',
+                  )}
+                  onClick={() => onPageChange(item)}
+                >
+                  {item}
+                </button>
+              );
+            })}
+          </div>
+
+          <button
+            type="button"
+            aria-label="다음 페이지"
+            className={cn(
+              navigationButtonClass,
+              'cursor-pointer border-zinc-200 bg-bg-white text-btn-text hover:bg-btn-basic',
+            )}
+            disabled={currentPage === totalPages}
+            onClick={() => onPageChange(currentPage + 1)}
+          >
+            <ChevronRight className="size-4" />
+          </button>
+        </nav>
+      ) : null}
+    </footer>
+  );
+}

--- a/src/hooks/useAdminTablePagination.ts
+++ b/src/hooks/useAdminTablePagination.ts
@@ -1,0 +1,62 @@
+import { useMemo, useState } from 'react';
+
+interface UseTablePaginationParams<T> {
+  data: T[];
+  initialPageSize?: number;
+  pageSizeOptions?: readonly number[];
+}
+
+const DEFAULT_PAGE_SIZE = 10;
+const DEFAULT_PAGE_SIZE_OPTIONS = [10, 20, 50] as const;
+
+export function useAdminTablePagination<T>({
+  data,
+  initialPageSize = DEFAULT_PAGE_SIZE,
+  pageSizeOptions = DEFAULT_PAGE_SIZE_OPTIONS,
+}: UseTablePaginationParams<T>) {
+  const normalizedPageSizeOptions = useMemo(() => {
+    const mergedOptions = new Set<number>([
+      ...pageSizeOptions.filter((option) => option > 0),
+      initialPageSize > 0 ? initialPageSize : DEFAULT_PAGE_SIZE,
+    ]);
+
+    return Array.from(mergedOptions).sort((left, right) => left - right);
+  }, [initialPageSize, pageSizeOptions]);
+
+  const [pageSize, setPageSize] = useState(
+    initialPageSize > 0 ? initialPageSize : DEFAULT_PAGE_SIZE,
+  );
+
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const totalPages = Math.max(1, Math.ceil(data.length / pageSize));
+  const safeCurrentPage = Math.min(currentPage, totalPages);
+
+  const paginatedData = useMemo(() => {
+    const startIndex = (safeCurrentPage - 1) * pageSize;
+    const endIndex = startIndex + pageSize;
+
+    return data.slice(startIndex, endIndex);
+  }, [data, pageSize, safeCurrentPage]);
+
+  const handlePageChange = (page: number) => {
+    const clampedPage = Math.min(Math.max(page, 1), totalPages);
+
+    setCurrentPage(clampedPage);
+  };
+
+  const handlePageSizeChange = (nextPageSize: number) => {
+    setPageSize(nextPageSize);
+    setCurrentPage(1);
+  };
+
+  return {
+    pageSize,
+    currentPage: safeCurrentPage,
+    totalPages,
+    paginatedData,
+    pageSizeOptions: normalizedPageSizeOptions,
+    handlePageChange,
+    handlePageSizeChange,
+  };
+}


### PR DESCRIPTION
<!--
  PR 작성 가이드
  - 리뷰어를 존중하는 표현을 사용해주세요.
  - 변경 의도와 주요 내용을 명확하게 작성해주세요.
 -->

## 📌 개요

- 게시글 관리 / 페이지네이션 구현

## 💻 작업 사항
- 관리자 테이블에 페이지네이션 기능을 추가했습니다.
- 전체 데이터를 기준으로 현재 페이지에 해당하는 데이터만 slice하여 렌더링하도록 구현했습니다. (프론트엔드 페이지네이션)
- 페이지 번호 이동, 이전/다음 버튼, 페이지당 표시 개수 변경 기능을 구현했습니다.
- 페이지 수가 많을 경우 `...`(ellipsis)를 활용하여 페이지 버튼을 축약 표시하도록 처리했습니다. 
  - (현재 확인 불가 UI) 1 2 ... 4 **5** 6 ... 9 10  
- 데이터 개수에 따라 현재 페이지가 유효하지 않을 경우 자동으로 보정되도록 처리했습니다.
- 페이지당 개수 변경 시 1페이지로 초기화되도록 UX를 개선했습니다.
- 페이지네이션 로직을 `useTablePagination` 커스텀 훅으로 분리하여 재사용성과 가독성을 개선했습니다.

<img width="1335" height="927" alt="스크린샷 2026-05-04 오전 10 10 49" src="https://github.com/user-attachments/assets/e287125d-3f2b-4f52-85cf-f37a22468313" />


## 💡 관련 Issue

Closes #63

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #)
- [x] 불필요한 console.log를 제거했습니다.
- [x] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
