### PR TITLE
[Feat] 게시글 상세 페이지에서 신고 기능 구현

### DIFF
--- a/src/app/(main)/community/[id]/page.tsx
+++ b/src/app/(main)/community/[id]/page.tsx
@@ -10,11 +10,7 @@ import {
   deleteComment,
   incrementViewCount,
 } from '@/services/communityService';
-import {
-  reportPost,
-  reportComment,
-  ReportReason,
-} from '@/services/reportService';
+import { reportPost } from '@/services/reportService';
 import { supabase } from '@/lib/supabase';
 import type { Post, Comment } from '@/types/community';
 import Image from 'next/image';
@@ -50,12 +46,7 @@ export default function PostDetailPage({
   const { user } = useAuth();
   const { likeCount, isLiked, toggle } = useLike(id, user?.id ?? '');
 
-  // ── 신고 모달 상태 ──
-  const [reportModal, setReportModal] = useState<{
-    open: boolean;
-    target: '게시글' | '댓글';
-    commentId?: string;
-  }>({ open: false, target: '게시글' });
+  const [reportModalOpen, setReportModalOpen] = useState(false);
 
   useEffect(() => {
     const load = async () => {
@@ -139,23 +130,19 @@ export default function PostDetailPage({
   };
 
   // ── 신고 제출 핸들러 ──
-  const handleReportSubmit = async (reason: ReportReason) => {
+  const handleReportSubmit = async (reason: string) => {
     if (!userId) {
       showErrorToast('로그인이 필요합니다.');
       return;
     }
     try {
-      if (reportModal.target === '게시글') {
-        await reportPost(userId, id, reason);
-      } else if (reportModal.commentId) {
-        await reportComment(userId, reportModal.commentId, id, reason);
-      }
+      await reportPost(userId, id, reason);
       showSuccessToast('신고가 접수되었습니다.', '🚨');
-      setReportModal({ open: false, target: '게시글' });
+      setReportModalOpen(false);
     } catch (e: unknown) {
       if (e instanceof Error && e.message === 'ALREADY_REPORTED') {
         showErrorToast('이미 신고한 게시물입니다.');
-        setReportModal({ open: false, target: '게시글' });
+        setReportModalOpen(false);
       } else {
         showErrorToast('신고 처리 중 오류가 발생했습니다.');
       }
@@ -311,7 +298,7 @@ export default function PostDetailPage({
               // ── 신고 버튼 (게시글) ──
               <button
                 title="신고하기"
-                onClick={() => setReportModal({ open: true, target: '게시글' })}
+                onClick={() => setReportModalOpen(true)}
                 aria-label={`${post.nickname}의 게시글 신고`}
                 className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-gray-100 transition-colors text-gray-400 cursor-pointer"
               >
@@ -514,7 +501,7 @@ export default function PostDetailPage({
                       />
                       {timeAgo(c.created_at)}
                     </span>
-                    {userId === c.user_id ? (
+                    {userId === c.user_id && (
                       <>
                         <button
                           onClick={() => {
@@ -534,22 +521,7 @@ export default function PostDetailPage({
                           삭제
                         </button>
                       </>
-                    ) : userId ? (
-                      // ── 신고 버튼 (댓글) ──
-                      <button
-                        onClick={() =>
-                          setReportModal({
-                            open: true,
-                            target: '댓글',
-                            commentId: c.id,
-                          })
-                        }
-                        aria-label={`${c.nickname}의 댓글 신고`}
-                        className="text-xs text-gray-400 hover:text-red-400 transition-colors"
-                      >
-                        신고
-                      </button>
-                    ) : null}
+                    )}
                   </div>
                 </div>
               </div>
@@ -565,10 +537,9 @@ export default function PostDetailPage({
 
       {/* ── 신고 모달 ── */}
       <ReportModal
-        isOpen={reportModal.open}
-        onClose={() => setReportModal({ open: false, target: '게시글' })}
+        isOpen={reportModalOpen}
+        onClose={() => setReportModalOpen(false)}
         onSubmit={handleReportSubmit}
-        target={reportModal.target}
       />
     </div>
   );

--- a/src/app/(main)/community/[id]/page.tsx
+++ b/src/app/(main)/community/[id]/page.tsx
@@ -10,6 +10,11 @@ import {
   deleteComment,
   incrementViewCount,
 } from '@/services/communityService';
+import {
+  reportPost,
+  reportComment,
+  ReportReason,
+} from '@/services/reportService';
 import { supabase } from '@/lib/supabase';
 import type { Post, Comment } from '@/types/community';
 import Image from 'next/image';
@@ -17,6 +22,7 @@ import LoadingSpinner from '@/components/common/LoadingSpinner';
 import { useAuth } from '@/hooks/useAuth';
 import { useLike } from '@/hooks/useLike';
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
+import ReportModal from '@/components/community/ReportModal';
 
 function timeAgo(dateStr: string) {
   const diff = Date.now() - new Date(dateStr).getTime();
@@ -43,6 +49,13 @@ export default function PostDetailPage({
   const [editingContent, setEditingContent] = useState('');
   const { user } = useAuth();
   const { likeCount, isLiked, toggle } = useLike(id, user?.id ?? '');
+
+  // ── 신고 모달 상태 ──
+  const [reportModal, setReportModal] = useState<{
+    open: boolean;
+    target: '게시글' | '댓글';
+    commentId?: string;
+  }>({ open: false, target: '게시글' });
 
   useEffect(() => {
     const load = async () => {
@@ -122,6 +135,30 @@ export default function PostDetailPage({
       setComments((prev) => prev.filter((c) => c.id !== commentId));
     } catch (e) {
       console.error(e);
+    }
+  };
+
+  // ── 신고 제출 핸들러 ──
+  const handleReportSubmit = async (reason: ReportReason) => {
+    if (!userId) {
+      showErrorToast('로그인이 필요합니다.');
+      return;
+    }
+    try {
+      if (reportModal.target === '게시글') {
+        await reportPost(userId, id, reason);
+      } else if (reportModal.commentId) {
+        await reportComment(userId, reportModal.commentId, id, reason);
+      }
+      showSuccessToast('신고가 접수되었습니다.', '🚨');
+      setReportModal({ open: false, target: '게시글' });
+    } catch (e: unknown) {
+      if (e instanceof Error && e.message === 'ALREADY_REPORTED') {
+        showErrorToast('이미 신고한 게시물입니다.');
+        setReportModal({ open: false, target: '게시글' });
+      } else {
+        showErrorToast('신고 처리 중 오류가 발생했습니다.');
+      }
     }
   };
 
@@ -271,8 +308,10 @@ export default function PostDetailPage({
                 </button>
               </>
             ) : (
+              // ── 신고 버튼 (게시글) ──
               <button
                 title="신고하기"
+                onClick={() => setReportModal({ open: true, target: '게시글' })}
                 aria-label={`${post.nickname}의 게시글 신고`}
                 className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-gray-100 transition-colors text-gray-400 cursor-pointer"
               >
@@ -475,7 +514,7 @@ export default function PostDetailPage({
                       />
                       {timeAgo(c.created_at)}
                     </span>
-                    {userId === c.user_id && (
+                    {userId === c.user_id ? (
                       <>
                         <button
                           onClick={() => {
@@ -495,7 +534,22 @@ export default function PostDetailPage({
                           삭제
                         </button>
                       </>
-                    )}
+                    ) : userId ? (
+                      // ── 신고 버튼 (댓글) ──
+                      <button
+                        onClick={() =>
+                          setReportModal({
+                            open: true,
+                            target: '댓글',
+                            commentId: c.id,
+                          })
+                        }
+                        aria-label={`${c.nickname}의 댓글 신고`}
+                        className="text-xs text-gray-400 hover:text-red-400 transition-colors"
+                      >
+                        신고
+                      </button>
+                    ) : null}
                   </div>
                 </div>
               </div>
@@ -508,6 +562,14 @@ export default function PostDetailPage({
           )}
         </div>
       </div>
+
+      {/* ── 신고 모달 ── */}
+      <ReportModal
+        isOpen={reportModal.open}
+        onClose={() => setReportModal({ open: false, target: '게시글' })}
+        onSubmit={handleReportSubmit}
+        target={reportModal.target}
+      />
     </div>
   );
 }

--- a/src/app/(main)/community/[id]/page.tsx
+++ b/src/app/(main)/community/[id]/page.tsx
@@ -10,7 +10,7 @@ import {
   deleteComment,
   incrementViewCount,
 } from '@/services/communityService';
-import { reportPost } from '@/services/reportService';
+import { reportPost, ReportReason } from '@/services/reportService';
 import { supabase } from '@/lib/supabase';
 import type { Post, Comment } from '@/types/community';
 import Image from 'next/image';
@@ -130,7 +130,7 @@ export default function PostDetailPage({
   };
 
   // ── 신고 제출 핸들러 ──
-  const handleReportSubmit = async (reason: string) => {
+  const handleReportSubmit = async (reason: ReportReason) => {
     if (!userId) {
       showErrorToast('로그인이 필요합니다.');
       return;

--- a/src/components/community/ReportModal.tsx
+++ b/src/components/community/ReportModal.tsx
@@ -4,18 +4,23 @@ import { useState } from 'react';
 import { REPORT_REASONS } from '@/services/reportService';
 import type { ReportReason } from '@/services/reportService';
 
+const slideUpStyle = `
+  @keyframes slide-up {
+    from { transform: translateY(20px); opacity: 0; }
+    to { transform: translateY(0); opacity: 1; }
+  }
+`;
+
 interface ReportModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSubmit: (reason: string) => Promise<void>;
-  target: '게시글' | '댓글';
+  onSubmit: (reason: ReportReason) => Promise<void>;
 }
 
 export default function ReportModal({
   isOpen,
   onClose,
   onSubmit,
-  target,
 }: ReportModalProps) {
   const [selected, setSelected] = useState<ReportReason | null>(null);
   const [loading, setLoading] = useState(false);
@@ -38,98 +43,87 @@ export default function ReportModal({
   };
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 backdrop-blur-sm"
-      onClick={handleBackdropClick}
-    >
-      <div className="w-full sm:max-w-sm bg-white rounded-t-3xl sm:rounded-2xl shadow-xl overflow-hidden animate-slide-up">
-        {/* 헤더 */}
-        <div className="flex items-center justify-between px-5 pt-5 pb-4 border-b border-gray-100">
-          <div>
-            <h2 className="text-base font-bold text-gray-900">
-              {target} 신고하기
-            </h2>
-            <p className="text-xs text-gray-400 mt-0.5">
-              신고 사유를 선택해주세요
-            </p>
-          </div>
-          <button
-            onClick={onClose}
-            className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-gray-100 transition-colors text-gray-400"
-            aria-label="닫기"
-          >
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-              <path
-                d="M12 4L4 12M4 4L12 12"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-              />
-            </svg>
-          </button>
-        </div>
-
-        {/* 사유 목록 */}
-        <div className="px-5 py-3 space-y-1.5">
-          {REPORT_REASONS.map((reason) => (
+    <>
+      <style>{slideUpStyle}</style>
+      <div
+        className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 backdrop-blur-sm"
+        onClick={handleBackdropClick}
+      >
+        <div
+          className="w-full sm:max-w-sm bg-white rounded-t-3xl sm:rounded-2xl shadow-xl overflow-hidden"
+          style={{ animation: 'slide-up 0.2s ease-out' }}
+        >
+          {/* 헤더 */}
+          <div className="flex items-center justify-between px-5 pt-5 pb-4 border-b border-gray-100">
+            <div>
+              <h2 className="text-base font-bold text-gray-900">
+                게시글 신고하기
+              </h2>
+              <p className="text-xs text-gray-400 mt-0.5">
+                신고 사유를 선택해주세요
+              </p>
+            </div>
             <button
-              key={reason}
-              onClick={() => setSelected(reason)}
-              className={`w-full flex items-center gap-3 px-4 py-3 rounded-xl text-sm text-left transition-all duration-150 cursor-pointer ${
-                selected === reason
-                  ? 'bg-red-50 text-red-600 font-medium'
-                  : 'text-gray-700 hover:bg-gray-50'
-              }`}
+              onClick={onClose}
+              className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-gray-100 transition-colors text-gray-400"
+              aria-label="닫기"
             >
-              {/* 라디오 */}
-              <span
-                className={`w-4 h-4 rounded-full border-2 flex items-center justify-center shrink-0 transition-colors ${
-                  selected === reason ? 'border-red-500' : 'border-gray-300'
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                <path
+                  d="M12 4L4 12M4 4L12 12"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                />
+              </svg>
+            </button>
+          </div>
+
+          {/* 사유 목록 */}
+          <div className="px-5 py-3 space-y-1.5">
+            {REPORT_REASONS.map((reason) => (
+              <button
+                key={reason}
+                onClick={() => setSelected(reason)}
+                className={`w-full flex items-center gap-3 px-4 py-3 rounded-xl text-sm text-left transition-all duration-150 cursor-pointer ${
+                  selected === reason
+                    ? 'bg-red-50 text-red-600 font-medium'
+                    : 'text-gray-700 hover:bg-gray-50'
                 }`}
               >
-                {selected === reason && (
-                  <span className="w-2 h-2 rounded-full bg-red-500" />
-                )}
-              </span>
-              {reason}
-            </button>
-          ))}
-        </div>
+                <span
+                  className={`w-4 h-4 rounded-full border-2 flex items-center justify-center shrink-0 transition-colors ${
+                    selected === reason ? 'border-red-500' : 'border-gray-300'
+                  }`}
+                >
+                  {selected === reason && (
+                    <span className="w-2 h-2 rounded-full bg-red-500" />
+                  )}
+                </span>
+                {reason}
+              </button>
+            ))}
+          </div>
 
-        {/* 하단 버튼 */}
-        <div className="px-5 pt-2 pb-6 flex gap-2">
-          <button
-            onClick={onClose}
-            className="flex-1 py-3 rounded-xl border border-gray-200 text-sm font-medium text-gray-600 hover:bg-gray-50 transition-colors cursor-pointer"
-          >
-            취소
-          </button>
-          <button
-            onClick={handleSubmit}
-            disabled={!selected || loading}
-            className="flex-1 py-3 rounded-xl text-sm font-semibold text-white transition-all cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
-            style={{ backgroundColor: selected ? '#ef4444' : '#d1d5db' }}
-          >
-            {loading ? '신고 중...' : '신고하기'}
-          </button>
+          {/* 하단 버튼 */}
+          <div className="px-5 pt-2 pb-6 flex gap-2">
+            <button
+              onClick={onClose}
+              className="flex-1 py-3 rounded-xl border border-gray-200 text-sm font-medium text-gray-600 hover:bg-gray-50 transition-colors cursor-pointer"
+            >
+              취소
+            </button>
+            <button
+              onClick={handleSubmit}
+              disabled={!selected || loading}
+              className="flex-1 py-3 rounded-xl text-sm font-semibold text-white transition-all cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+              style={{ backgroundColor: selected ? '#ef4444' : '#d1d5db' }}
+            >
+              {loading ? '신고 중...' : '신고하기'}
+            </button>
+          </div>
         </div>
       </div>
-
-      <style jsx>{`
-        @keyframes slide-up {
-          from {
-            transform: translateY(20px);
-            opacity: 0;
-          }
-          to {
-            transform: translateY(0);
-            opacity: 1;
-          }
-        }
-        .animate-slide-up {
-          animation: slide-up 0.2s ease-out;
-        }
-      `}</style>
-    </div>
+    </>
   );
 }

--- a/src/components/community/ReportModal.tsx
+++ b/src/components/community/ReportModal.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useState } from 'react';
+import { REPORT_REASONS } from '@/services/reportService';
+import type { ReportReason } from '@/services/reportService';
+
+interface ReportModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (reason: string) => Promise<void>;
+  target: '게시글' | '댓글';
+}
+
+export default function ReportModal({
+  isOpen,
+  onClose,
+  onSubmit,
+  target,
+}: ReportModalProps) {
+  const [selected, setSelected] = useState<ReportReason | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = async () => {
+    if (!selected) return;
+    setLoading(true);
+    try {
+      await onSubmit(selected);
+    } finally {
+      setLoading(false);
+      setSelected(null);
+    }
+  };
+
+  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 backdrop-blur-sm"
+      onClick={handleBackdropClick}
+    >
+      <div className="w-full sm:max-w-sm bg-white rounded-t-3xl sm:rounded-2xl shadow-xl overflow-hidden animate-slide-up">
+        {/* 헤더 */}
+        <div className="flex items-center justify-between px-5 pt-5 pb-4 border-b border-gray-100">
+          <div>
+            <h2 className="text-base font-bold text-gray-900">
+              {target} 신고하기
+            </h2>
+            <p className="text-xs text-gray-400 mt-0.5">
+              신고 사유를 선택해주세요
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-gray-100 transition-colors text-gray-400"
+            aria-label="닫기"
+          >
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+              <path
+                d="M12 4L4 12M4 4L12 12"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* 사유 목록 */}
+        <div className="px-5 py-3 space-y-1.5">
+          {REPORT_REASONS.map((reason) => (
+            <button
+              key={reason}
+              onClick={() => setSelected(reason)}
+              className={`w-full flex items-center gap-3 px-4 py-3 rounded-xl text-sm text-left transition-all duration-150 cursor-pointer ${
+                selected === reason
+                  ? 'bg-red-50 text-red-600 font-medium'
+                  : 'text-gray-700 hover:bg-gray-50'
+              }`}
+            >
+              {/* 라디오 */}
+              <span
+                className={`w-4 h-4 rounded-full border-2 flex items-center justify-center shrink-0 transition-colors ${
+                  selected === reason ? 'border-red-500' : 'border-gray-300'
+                }`}
+              >
+                {selected === reason && (
+                  <span className="w-2 h-2 rounded-full bg-red-500" />
+                )}
+              </span>
+              {reason}
+            </button>
+          ))}
+        </div>
+
+        {/* 하단 버튼 */}
+        <div className="px-5 pt-2 pb-6 flex gap-2">
+          <button
+            onClick={onClose}
+            className="flex-1 py-3 rounded-xl border border-gray-200 text-sm font-medium text-gray-600 hover:bg-gray-50 transition-colors cursor-pointer"
+          >
+            취소
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={!selected || loading}
+            className="flex-1 py-3 rounded-xl text-sm font-semibold text-white transition-all cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
+            style={{ backgroundColor: selected ? '#ef4444' : '#d1d5db' }}
+          >
+            {loading ? '신고 중...' : '신고하기'}
+          </button>
+        </div>
+      </div>
+
+      <style jsx>{`
+        @keyframes slide-up {
+          from {
+            transform: translateY(20px);
+            opacity: 0;
+          }
+          to {
+            transform: translateY(0);
+            opacity: 1;
+          }
+        }
+        .animate-slide-up {
+          animation: slide-up 0.2s ease-out;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/services/reportService.ts
+++ b/src/services/reportService.ts
@@ -1,0 +1,85 @@
+// services/reportService.ts
+import { supabase } from '@/lib/supabase';
+
+export type ReportReason =
+  | '스팸 또는 광고'
+  | '욕설 및 혐오 발언'
+  | '음란물 또는 불건전한 내용'
+  | '개인정보 침해'
+  | '허위 정보'
+  | '기타';
+
+export const REPORT_REASONS: ReportReason[] = [
+  '스팸 또는 광고',
+  '욕설 및 혐오 발언',
+  '음란물 또는 불건전한 내용',
+  '개인정보 침해',
+  '허위 정보',
+  '기타',
+];
+
+interface ReportPayload {
+  reporter_id: string;
+  reason: ReportReason;
+  post_id?: string;
+  comment_id?: string;
+}
+
+export async function reportPost(
+  reporterId: string,
+  postId: string,
+  reason: ReportReason,
+) {
+  // 중복 신고 확인
+  const { data: existing } = await supabase
+    .from('reports')
+    .select('id')
+    .eq('reporter_id', reporterId)
+    .eq('post_id', postId)
+    .maybeSingle();
+
+  if (existing) {
+    throw new Error('ALREADY_REPORTED');
+  }
+
+  const payload: ReportPayload = {
+    reporter_id: reporterId,
+    post_id: postId,
+    reason,
+  };
+
+  const { error } = await supabase.from('reports').insert(payload);
+  if (error) throw error;
+
+  // posts 테이블 report_count 증가
+  await supabase.rpc('increment_report_count', { post_id: postId });
+}
+
+export async function reportComment(
+  reporterId: string,
+  commentId: string,
+  postId: string,
+  reason: ReportReason,
+) {
+  // 중복 신고 확인
+  const { data: existing } = await supabase
+    .from('reports')
+    .select('id')
+    .eq('reporter_id', reporterId)
+    .eq('comment_id', commentId)
+    .maybeSingle();
+
+  if (existing) {
+    throw new Error('ALREADY_REPORTED');
+  }
+
+  const payload: ReportPayload = {
+    reporter_id: reporterId,
+    comment_id: commentId,
+    post_id: postId,
+    reason,
+  };
+
+  const { error } = await supabase.from('reports').insert(payload);
+  if (error) throw error;
+}


### PR DESCRIPTION
## 📌 개요

-게시글 상세 페이지에서 신고 기능 구현

## 💻 작업 사항

게시글 신고 기능 구현
신규 파일
- services/reportService.ts — 신고 관련 Supabase 로직 (중복 신고 방지 포함)
- components/community/ReportModal.tsx — 신고 사유 선택 모달

변경 파일
- app/(main)/community/[id]/page.tsx — 게시글 신고 버튼에 기능 연결

동작 방식
- 본인 게시글이 아닐 때 신고 버튼 노출
- 신고 버튼 클릭 시 사유 선택 모달 표시 (스팸, 욕설, 음란물, 개인정보 침해, 허위 정보, 기타)
<img width="436" height="543" alt="image" src="https://github.com/user-attachments/assets/dff439fd-c5ac-47e2-8975-02107d2e3b42" />

- 신고 완료 시 성공 토스트, 중복 신고 시 "이미 신고한 게시물입니다" 토스트 표시
<img width="266" height="86" alt="image" src="https://github.com/user-attachments/assets/3d45fbe2-b629-43e1-b208-de448cdb15f9" />
<img width="267" height="73" alt="image" src="https://github.com/user-attachments/assets/5a3c5312-c362-4df6-8374-7b0215f7d3ec" />

- 모바일: 바텀시트, 데스크탑: 센터 모달로 동작
<img width="463" height="806" alt="image" src="https://github.com/user-attachments/assets/b6558bca-2aa6-4144-93c8-889f6125c61e" />

DB
- reports 테이블에 신고 데이터 저장
<img width="1196" height="263" alt="image" src="https://github.com/user-attachments/assets/875457d9-4b35-4f16-8646-8aa94ce0dde6" />

- 중복 신고 방지: 동일 유저가 같은 게시글 재신고 불가
- posts.report_count 증가를 위한 RPC 함수 필요

```
create or replace function increment_report_count(post_id uuid)
returns void as $$
  update posts set report_count = report_count + 1 where id = post_id;
$$ language sql;
```

## 💡 관련 Issue

Closes #56 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #56 )
- [x] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
