### PR TITLE
[fix] 게시글 수정 완료 이후 상세 페이지로 이동하는 과정에서 화면이 한 번 깜빡이는 현상 수정

### DIFF
--- a/src/app/(main)/community/[id]/edit/page.tsx
+++ b/src/app/(main)/community/[id]/edit/page.tsx
@@ -59,7 +59,6 @@ export default function EditPage({
       showErrorToast('제목과 내용을 모두 입력해주세요.');
       return;
     }
-    setIsLoading(true);
     try {
       let image_url: string | undefined;
       if (imageFile) {
@@ -71,8 +70,6 @@ export default function EditPage({
       router.push(`/community/${id}`);
     } catch {
       showErrorToast('게시글 수정에 실패했습니다.');
-    } finally {
-      setIsLoading(false);
     }
   };
 


### PR DESCRIPTION
## 📌 개요

-  게시글 수정 완료 이후 상세 페이지로 이동하는 과정에서 화면이 한 번 깜빡이는 현상 수정
- isLoading을 true로 설정되어 있고 LoadingSpinner가 렌더링되고, 그 후 router.push가 실행되면서 잠깐 수정 페이지가 다시 보이는 현상이 있었음
- 동일 로직을 사용한 게시글 작성과 대회일정 추가페이지에서는 추후 컴포넌트 분리 리팩토링때 같이 수정 예정

## 💻 작업 사항

- setIsLoading(true)를 제거하고 router.push 전에 toast만 띄우고 finally의 setIsLoading(false)도 같이 제거
<img width="1056" height="736" alt="20260504-0845-39 1332211" src="https://github.com/user-attachments/assets/5d5661ee-1e1a-4591-815a-de23db4dfc10" />


## 💡 관련 Issue

Closes #75 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #75 )
- [x] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
