### PR TITLE
[Fix] 커뮤니티 페이지 하이드래이션 오류 및 스크롤 투 탑 이미지 오류 해결

### DIFF
--- a/src/components/common/ScrollToTop.tsx
+++ b/src/components/common/ScrollToTop.tsx
@@ -1,30 +1,49 @@
 'use client';
 import { useEffect, useState } from 'react';
-import Image from 'next/image';
+import { ArrowUp, ArrowDown } from 'lucide-react';
 
 export default function ScrollToTop() {
-  const [isVisible, setIsVisible] = useState(false);
-
+  const [scrollY, setScrollY] = useState(0);
+  const [isBottom, setIsBottom] = useState(false); // ✅ state로 변경
   useEffect(() => {
     const handleScroll = () => {
-      setIsVisible(window.scrollY > 300);
+      setScrollY(window.scrollY);
+      setIsBottom(
+        window.scrollY + window.innerHeight >= document.body.scrollHeight - 100,
+      );
     };
     window.addEventListener('scroll', handleScroll);
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
+  const isTop = scrollY <= 300;
+
   const scrollToTop = () => {
     window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
-  if (!isVisible) return null;
+  const scrollToBottom = () => {
+    window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' });
+  };
 
   return (
-    <button
-      onClick={scrollToTop}
-      className="fixed bottom-8 right-8 w-12 h-12 flex items-center justify-center z-100 cursor-pointer"
-    >
-      <Image src="/scrollTop.svg" alt="scroll to top" width={48} height={48} />
-    </button>
+    <div className="fixed bottom-8 right-8 flex flex-col gap-2 z-50">
+      {!isTop && (
+        <button
+          onClick={scrollToTop}
+          className="w-12 h-12 bg-btn-focus text-btn-focus-text rounded-full flex items-center justify-center cursor-pointer hover:opacity-80 transition-all"
+        >
+          <ArrowUp size={20} />
+        </button>
+      )}
+      {!isBottom && (
+        <button
+          onClick={scrollToBottom}
+          className="w-12 h-12 bg-btn-basic text-btn-text rounded-full flex items-center justify-center cursor-pointer hover:opacity-80 transition-all"
+        >
+          <ArrowDown size={20} />
+        </button>
+      )}
+    </div>
   );
 }

--- a/src/components/common/ScrollToTop.tsx
+++ b/src/components/common/ScrollToTop.tsx
@@ -4,7 +4,8 @@ import { ArrowUp, ArrowDown } from 'lucide-react';
 
 export default function ScrollToTop() {
   const [scrollY, setScrollY] = useState(0);
-  const [isBottom, setIsBottom] = useState(false); // ✅ state로 변경
+  const [isBottom, setIsBottom] = useState(false);
+
   useEffect(() => {
     const handleScroll = () => {
       setScrollY(window.scrollY);
@@ -31,7 +32,7 @@ export default function ScrollToTop() {
       {!isTop && (
         <button
           onClick={scrollToTop}
-          className="w-12 h-12 bg-btn-focus text-btn-focus-text rounded-full flex items-center justify-center cursor-pointer hover:opacity-80 transition-all"
+          className="w-12 h-12 bg-gray-300 text-gray-600 rounded-full flex items-center justify-center cursor-pointer hover:bg-btn-focus hover:text-btn-focus-text transition-all"
         >
           <ArrowUp size={20} />
         </button>
@@ -39,7 +40,7 @@ export default function ScrollToTop() {
       {!isBottom && (
         <button
           onClick={scrollToBottom}
-          className="w-12 h-12 bg-btn-basic text-btn-text rounded-full flex items-center justify-center cursor-pointer hover:opacity-80 transition-all"
+          className="w-12 h-12 bg-gray-300 text-gray-600 rounded-full flex items-center justify-center cursor-pointer hover:bg-btn-focus hover:text-btn-focus-text transition-all"
         >
           <ArrowDown size={20} />
         </button>

--- a/src/components/community/CommunityClient.tsx
+++ b/src/components/community/CommunityClient.tsx
@@ -21,13 +21,16 @@ export default function CommunityClient({
   // 1. 상태 선언 및 초기값 복원 (에러 해결 핵심: Lazy Initialization)
   const [activeTab, setActiveTab] = useState('전체');
   const [searchQuery, setSearchQuery] = useState('');
-  const [page, setPage] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const saved = sessionStorage.getItem('communityPage');
-      return saved ? parseInt(saved) : 1;
+  const [page, setPage] = useState(1);
+
+  useEffect(() => {
+    const saved = sessionStorage.getItem('communityPage');
+    if (saved) {
+      startTransition(() => {
+        setPage(parseInt(saved));
+      });
     }
-    return 1;
-  });
+  }, []);
 
   const [headerHeight, setHeaderHeight] = useState(160);
   const headerRef = useRef<HTMLDivElement>(null);

--- a/src/components/layout/PageHeader.tsx
+++ b/src/components/layout/PageHeader.tsx
@@ -73,7 +73,7 @@ export default function Pageheader({
         {writeLink && (
           <Link href={writeLink}>
             <Button
-              className="bg-btn-focus text-btn-focus-text shrink-0 w-31 h-12 flex items-center gap-2"
+              className="bg-btn-focus text-btn-focus-text shrink-0 w-31 h-12 flex items-center gap-2 cursor-pointer"
               onClick={handleWriteClick}
               aria-label="새 게시글 작성"
             >
@@ -91,7 +91,7 @@ export default function Pageheader({
             <Button
               key={tab}
               onClick={() => setActiveTab && setActiveTab(tab)}
-              className={`${
+              className={`cursor-pointer ${
                 activeTab === tab
                   ? 'bg-btn-focus text-btn-focus-text'
                   : 'bg-btn-basic text-btn-text hover:bg-gray-200'

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,7 +1,7 @@
 'use client';
 import Image from 'next/image';
 import Link from 'next/link';
-import { usePathname, useRouter } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 import { Button } from '../ui/button';
 import {
   LogOut,
@@ -34,7 +34,6 @@ const adminNavItems = [
 
 export default function Sidebar() {
   const pathname = usePathname();
-  const router = useRouter();
   const { user, loading, logout } = useAuth();
   const isAdmin = user?.role === 'admin';
 
@@ -49,7 +48,7 @@ export default function Sidebar() {
     >
       {/* 로고 */}
       <Link href="/">
-        <div className="flex items-center justify-center py-6">
+        <div className="flex items-center justify-center py-6 cursor-pointer">
           <Image src="/blackbelt.svg" alt="black-belt" width={95} height={37} />
         </div>
       </Link>
@@ -59,11 +58,11 @@ export default function Sidebar() {
       {/* 공통 네비게이션 */}
       <nav className="flex flex-col gap-1 px-3 py-3 flex-1">
         {navItems.map((item) => {
-          const isActive = pathname.startsWith(item.href);
+          const isActive = pathname === item.href;
           return (
-            <Link key={item.href} href={item.href}>
+            <Link key={item.href} href={item.href} className="cursor-pointer">
               <Button
-                className={`w-full h-12 justify-start gap-3 bg-bg-white text-btn-text hover:bg-btn-basic
+                className={`w-full h-12 justify-start gap-3 bg-bg-white text-btn-text hover:bg-btn-basic cursor-pointer
                   ${isActive ? 'bg-btn-focus text-btn-focus-text hover:bg-btn-focus' : ''}`}
               >
                 <Image
@@ -87,12 +86,16 @@ export default function Sidebar() {
         {isAdmin && (
           <div className="flex flex-col gap-1 mb-2">
             {adminNavItems.map((item) => {
-              const isActive = pathname.startsWith(item.href);
+              const isActive = pathname === item.href; // ✅ startsWith → === 변경
               const Icon = item.icon;
               return (
-                <Link key={item.href} href={item.href}>
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className="cursor-pointer"
+                >
                   <Button
-                    className={`w-full h-12 justify-start gap-3 bg-bg-white text-btn-text hover:bg-btn-basic
+                    className={`w-full h-12 justify-start gap-3 cursor-pointer bg-bg-white text-btn-text hover:bg-btn-basic
                       ${isActive ? 'bg-btn-focus text-btn-focus-text hover:bg-btn-focus' : ''}`}
                   >
                     <Icon size={18} />
@@ -109,7 +112,7 @@ export default function Sidebar() {
           <div className="h-12" />
         ) : user ? (
           <div className="flex flex-col gap-2">
-            <Link href="/mypage">
+            <Link href="/mypage" className="cursor-pointer">
               <div className="flex items-center gap-3 px-2 py-1 rounded-lg hover:bg-btn-basic transition-colors cursor-pointer">
                 <div className="w-9 h-9 rounded-full bg-btn-basic flex items-center justify-center overflow-hidden shrink-0">
                   {user.image ? (
@@ -137,7 +140,7 @@ export default function Sidebar() {
             </Link>
             <Button
               variant="ghost"
-              className="w-full h-10 gap-2 text-text-secondary hover:text-text-primary"
+              className="w-full h-10 gap-2 text-text-secondary hover:text-text-primary cursor-pointer"
               onClick={handleLogout}
             >
               <LogOut size={15} />
@@ -145,8 +148,8 @@ export default function Sidebar() {
             </Button>
           </div>
         ) : (
-          <Link href="/login">
-            <Button className="w-full h-12 gap-2 bg-btn-focus text-btn-focus-text">
+          <Link href="/login" className="cursor-pointer">
+            <Button className="w-full h-12 gap-2 bg-btn-focus text-btn-focus-text cursor-pointer">
               <LogIn size={16} />
               로그인
             </Button>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { Slot } from 'radix-ui';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none cursor-point focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## 📌 개요

- 커뮤니티 페이지 하이드래이션 오류 및 스크롤 투 탑 이미지 오류 해결

## 💻 작업 사항
- 커뮤니티 페이지 접속 시 하이드레이션 에러 발생
-> 세션 스토리지 접근을 유즈이펙트 내부로 이동하여 클라이언트 마운트 후에만 실행되도록 변경

- 스크롤 투 탑에 이미지 대신 루시드 이용
<img width="124" height="124" alt="스크린샷 2026-05-05 시간: 15 11 39" src="https://github.com/user-attachments/assets/ea3ead22-7571-47bf-8f81-1309a96755cb" />
<img width="176" height="154" alt="스크린샷 2026-05-05 시간: 15 11 42" src="https://github.com/user-attachments/assets/19548263-cd8b-4968-90a9-d5f7586b8d39" />
<img width="164" height="126" alt="스크린샷 2026-05-05 시간: 15 11 47" src="https://github.com/user-attachments/assets/68ec0205-4819-4bf2-a8ea-f6bd904d0c76" />

- 사이드바 및 헤더 버튼에 커서 포인터 적용

## 💡 관련 Issue

Closes #78 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #78 )
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
