### PR TITLE
[Feat] 게시글 작성 페이지에서 미리보기 기능 구현

### DIFF
--- a/src/app/(main)/community/[id]/page.tsx
+++ b/src/app/(main)/community/[id]/page.tsx
@@ -198,7 +198,7 @@ export default function PostDetailPage({
     <div className="max-w-2xl mx-auto p-4 space-y-4">
       {/* 뒤로가기 */}
       <button
-        onClick={() => router.back()}
+        onClick={() => router.push(`/community`)}
         className="flex items-center gap-2 px-2.5 py-2 border-2 border-white bg-white text-black text-sm font-medium rounded-xl hover:bg-(--color-btn-focus) hover:text-white transition-colors duration-200 cursor-pointer"
       >
         <svg

--- a/src/app/(main)/community/write/page.tsx
+++ b/src/app/(main)/community/write/page.tsx
@@ -8,11 +8,12 @@ import LoadingSpinner from '@/components/common/LoadingSpinner';
 import { supabase } from '@/lib/supabase';
 import { createPost, uploadPostImage } from '@/services/communityService';
 import { useAuth } from '@/hooks/useAuth';
-import { useQueryClient } from '@tanstack/react-query'; // 추가
+import { useQueryClient } from '@tanstack/react-query';
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
 
 export default function WritePage() {
   const router = useRouter();
+  const [tab, setTab] = useState<'write' | 'preview'>('write'); // ✅ 추가
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [preview, setPreview] = useState<string | null>(null);
@@ -20,7 +21,7 @@ export default function WritePage() {
   const [imageFile, setImageFile] = useState<File | null>(null);
   const { user, loading } = useAuth();
   const [category, setCategory] = useState<PostCategory>('personal');
-  const queryClient = useQueryClient(); // 추가
+  const queryClient = useQueryClient();
 
   useEffect(() => {
     if (!loading && !user) {
@@ -78,85 +79,206 @@ export default function WritePage() {
         <h1 className="text-lg font-semibold mx-auto">게시글 작성</h1>
       </div>
 
-      <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
-        <p className="text-sm text-gray-500 mb-2">게시글 유형</p>
-        {user?.role === 'manager' ? (
-          <div className="flex gap-2">
-            {(['personal', 'promo'] as PostCategory[]).map((type) => (
-              <button
-                key={type}
-                onClick={() => setCategory(type)}
-                className={`flex-1 py-2 rounded-lg text-sm font-medium cursor-pointer transition-colors ${
-                  category === type
-                    ? 'bg-black text-white'
-                    : 'bg-gray-100 text-gray-600'
-                }`}
-              >
-                {type === 'personal' ? '일반 게시글' : '도장 홍보'}
-              </button>
-            ))}
-          </div>
-        ) : (
-          <div className="py-2 px-3 rounded-lg text-sm font-medium bg-black text-white text-center">
-            {user?.role === 'admin' ? '공지' : '일반 게시글'}
-          </div>
-        )}
+      {/* ✅ 탭 버튼 추가 */}
+      <div className="flex bg-gray-100 rounded-xl p-1 mb-6">
+        <button
+          onClick={() => setTab('write')}
+          className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
+            tab === 'write' ? 'bg-white text-black shadow-sm' : 'text-gray-500'
+          }`}
+        >
+          작성
+        </button>
+        <button
+          onClick={() => setTab('preview')}
+          className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
+            tab === 'preview'
+              ? 'bg-white text-black shadow-sm'
+              : 'text-gray-500'
+          }`}
+        >
+          미리보기
+        </button>
       </div>
 
-      <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
-        <p className="text-sm text-gray-500 mb-2">제목</p>
-        <input
-          type="text"
-          placeholder="제목을 입력하세요"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          className="w-full bg-gray-50 rounded-lg px-3 py-2 text-sm outline-none"
-        />
-      </div>
+      {/* ✅ 작성 탭 */}
+      {tab === 'write' && (
+        <>
+          <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
+            <p className="text-sm text-gray-500 mb-2">게시글 유형</p>
+            {user?.role === 'manager' ? (
+              <div className="flex gap-2">
+                {(['personal', 'promo'] as PostCategory[]).map((type) => (
+                  <button
+                    key={type}
+                    onClick={() => setCategory(type)}
+                    className={`flex-1 py-2 rounded-lg text-sm font-medium cursor-pointer transition-colors ${
+                      category === type
+                        ? 'bg-black text-white'
+                        : 'bg-gray-100 text-gray-600'
+                    }`}
+                  >
+                    {type === 'personal' ? '일반 게시글' : '도장 홍보'}
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <div className="py-2 px-3 rounded-lg text-sm font-medium bg-black text-white text-center">
+                {user?.role === 'admin' ? '공지' : '일반 게시글'}
+              </div>
+            )}
+          </div>
 
-      <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
-        <p className="text-sm text-gray-500 mb-2">이미지 (선택)</p>
-        <label className="block cursor-pointer">
-          {preview ? (
-            <div className="relative w-full h-48 rounded-lg overflow-hidden">
-              <Image
-                src={preview}
-                alt="preview"
-                fill={true}
-                className="object-cover"
+          <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
+            <p className="text-sm text-gray-500 mb-2">제목</p>
+            <input
+              type="text"
+              placeholder="제목을 입력하세요"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="w-full bg-gray-50 rounded-lg px-3 py-2 text-sm outline-none"
+            />
+          </div>
+
+          <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
+            <p className="text-sm text-gray-500 mb-2">이미지 (선택)</p>
+            <label className="block cursor-pointer">
+              {preview ? (
+                <div className="relative w-full h-48 rounded-lg overflow-hidden">
+                  <Image
+                    src={preview}
+                    alt="preview"
+                    fill={true}
+                    className="object-cover"
+                  />
+                </div>
+              ) : (
+                <div className="flex flex-col items-center justify-center h-32 bg-gray-50 rounded-lg border-2 border-dashed border-gray-200">
+                  <span className="text-2xl mb-1">↑</span>
+                  <p className="text-sm text-gray-500">
+                    클릭하여 이미지 업로드
+                  </p>
+                  <p className="text-xs text-gray-400">
+                    JPG, PNG, GIF (최대 10MB)
+                  </p>
+                </div>
+              )}
+              <input
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={handleImageChange}
               />
+            </label>
+          </div>
+
+          <div className="bg-white rounded-xl p-4 mb-6 shadow-sm">
+            <p className="text-sm text-gray-500 mb-2">내용</p>
+            <textarea
+              placeholder="내용을 입력하세요"
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              rows={8}
+              className="w-full bg-gray-50 rounded-lg px-3 py-2 text-sm outline-none resize-none"
+            />
+          </div>
+        </>
+      )}
+
+      {/* ✅ 미리보기 탭 */}
+      {tab === 'preview' && (
+        <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden mb-6">
+          {!title && !content ? (
+            <div className="flex flex-col items-center justify-center py-16 text-gray-400">
+              <p className="text-sm">작성 탭에서 내용을 입력하면</p>
+              <p className="text-sm">여기서 미리볼 수 있어요.</p>
             </div>
           ) : (
-            <div className="flex flex-col items-center justify-center h-32 bg-gray-50 rounded-lg border-2 border-dashed border-gray-200">
-              <span className="text-2xl mb-1">↑</span>
-              <p className="text-sm text-gray-500">클릭하여 이미지 업로드</p>
-              <p className="text-xs text-gray-400">JPG, PNG, GIF (최대 10MB)</p>
-            </div>
+            <>
+              {/* 작성자 헤더 */}
+              <div className="flex items-center gap-3 px-5 pt-5 pb-4">
+                <div className="w-10 h-10 rounded-full bg-gray-200 overflow-hidden shrink-0">
+                  {user?.image && (
+                    <Image
+                      src={user.image}
+                      alt="프로필"
+                      width={40}
+                      height={40}
+                      className="w-full h-full object-cover"
+                    />
+                  )}
+                </div>
+                <div>
+                  {/* ✅ 닉네임 + role 뱃지 추가 */}
+                  <div className="flex items-center gap-1.5">
+                    <span className="text-sm font-semibold text-gray-900">
+                      {user?.name ?? '알 수 없음'}
+                    </span>
+                    {user?.role && (
+                      <span
+                        className={`text-xs px-2 py-0.5 rounded-full font-medium ${
+                          category === 'promo'
+                            ? 'bg-blue-50 text-blue-600'
+                            : user?.role === 'admin'
+                              ? 'bg-red-50 text-red-600'
+                              : 'bg-gray-100 text-gray-600'
+                        }`}
+                      >
+                        {category === 'promo'
+                          ? '도장'
+                          : user?.role === 'admin'
+                            ? '공지'
+                            : '일반'}
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-xs text-gray-400 mt-0.5">방금 전</p>
+                </div>
+              </div>
+
+              {/* 제목 */}
+              <div className="px-5 pb-3">
+                <h1 className="text-lg font-bold text-gray-900">{title}</h1>
+              </div>
+
+              {/* 이미지 */}
+              {preview && (
+                <div className="px-5 pb-4">
+                  <div className="rounded-xl overflow-hidden">
+                    <Image
+                      src={preview}
+                      alt="게시글 이미지"
+                      width={800}
+                      height={400}
+                      className="w-full object-cover max-h-72"
+                    />
+                  </div>
+                </div>
+              )}
+
+              {/* 본문 */}
+              <div className="px-5 pb-5">
+                <p className="text-sm text-gray-700 whitespace-pre-line leading-relaxed">
+                  {content}
+                </p>
+              </div>
+
+              {/* 하단 바 */}
+              <div className="px-5 py-3 border-t border-gray-100 flex items-center gap-4">
+                <span className="text-xs text-gray-400">좋아요 0</span>
+                <span className="text-xs text-gray-400">댓글 0</span>
+                <span className="text-xs text-gray-400">조회 0</span>
+              </div>
+            </>
           )}
-          <input
-            type="file"
-            accept="image/*"
-            className="hidden"
-            onChange={handleImageChange}
-          />
-        </label>
-      </div>
+        </div>
+      )}
 
-      <div className="bg-white rounded-xl p-4 mb-6 shadow-sm">
-        <p className="text-sm text-gray-500 mb-2">내용</p>
-        <textarea
-          placeholder="내용을 입력하세요"
-          value={content}
-          onChange={(e) => setContent(e.target.value)}
-          rows={8}
-          className="w-full bg-gray-50 rounded-lg px-3 py-2 text-sm outline-none resize-none"
-        />
-      </div>
-
+      {/* 기존 하단 버튼 (그대로 유지) */}
       <div className="flex gap-3">
         <button
           onClick={() => router.back()}
-          className="flex-1 py-3 rounded-xl bg-btn-basic border border-gray-300 text-black hover:bg-gray-200"
+          className="flex-1 py-3 rounded-xl bg-btn-basic border border-gray-300 text-black hover:bg-gray-200 cursor-pointer"
         >
           취소
         </button>


### PR DESCRIPTION
## 📌 개요

- 게시글 상세 페이지에서 "목록으로" 버튼 클릭시 커뮤니티 페이지로 연결했습니다.
- 게시글 작성 페이지(`WritePage`)에 미리보기 기능을 추가했습니다.
- 작성 중인 내용을 실제 게시글 상세 페이지와 동일한 UI로 확인할 수 있습니다.

## 💻 작업 사항

**목록으로 버튼 수정**
- onClick={() => router.back()} 을 ->router.push(`/community`)로 수정했습니다.

**미리보기 탭 추가**
- 상단에 `작성 / 미리보기` 탭 버튼 UI를 추가했습니다.
- `tab` 상태(`'write' | 'preview'`)를 추가하여 탭 전환을 관리합니다.
- 기존 폼 영역을 `{tab === 'write' && ...}`로 감싸 탭에 따라 표시 여부를 제어합니다.

**미리보기 UI 구현**
- 미리보기 탭에서는 제목, 내용, 이미지, 작성자 정보(닉네임, role 뱃지, 프로필 이미지)를 실제 상세 페이지와 동일한 레이아웃으로 렌더링합니다.
- role 뱃지는 category 상태와 user.role을 기준으로 표시합니다.
  - `promo` → 도장 홍보 (파란색)
  - `admin` → 공지 (빨간색)
  - 그 외 → 일반 게시글 (회색)
- 제목과 내용이 모두 비어 있을 경우 안내 문구를 표시합니다.

<img width="1310" height="864" alt="20260506-0233-53 4781596" src="https://github.com/user-attachments/assets/2c455cb0-acdd-46b1-a7f4-5818e8a34a44" />
<img width="954" height="426" alt="image" src="https://github.com/user-attachments/assets/185ea92f-d405-445e-a3b5-5d2ab8675701" />


**기타**
- 탭 버튼 및 하단 취소 버튼에 `cursor-pointer` 추가

## 💡 관련 Issue

Closes #83 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #83 )
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
