### PR TITLE
[Refactor] 사이드바 관리자 전용 버튼 위치 변경, 비회원이 좋아요 버튼 클릭 시 토스트 알림 기능 추가

### DIFF
--- a/src/components/community/Postcard.tsx
+++ b/src/components/community/Postcard.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useLike } from '@/hooks/useLike';
 import { formatDate } from '@/utils/formatDate';
 import { Heart, MessageCircle } from 'lucide-react';
+import { showErrorToast } from '@/lib/toast';
 
 interface PostCardProps {
   post: {
@@ -35,7 +36,10 @@ export default function PostCard({ post, userId }: PostCardProps) {
   const handleLike = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    if (!userId) return;
+    if (!userId) {
+      showErrorToast('로그인이 필요합니다');
+      return;
+    }
     toggle();
   };
 

--- a/src/components/community/Postcard.tsx
+++ b/src/components/community/Postcard.tsx
@@ -109,7 +109,7 @@ export default function PostCard({ post, userId }: PostCardProps) {
             <div className="w-12 flex items-center justify-end">
               <button
                 onClick={handleLike}
-                className="flex items-center gap-1 transition-all duration-200"
+                className="flex items-center gap-1 transition-all duration-200 cursor-pointer"
               >
                 <Heart
                   size={16}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -27,9 +27,9 @@ const navItems = [
 const adminNavItems = [
   { label: '대시 보드', href: '/admin', icon: LayoutDashboard },
   { label: '게시글 관리', href: '/admin/posts', icon: FileText },
+  { label: '대회일정 관리', href: '/admin/competitions', icon: Calendar },
   { label: '유저 관리', href: '/admin/users', icon: Users },
   { label: '고객 지원', href: '/admin/support', icon: HelpCircle },
-  { label: '대회일정 관리', href: '/admin/competitions', icon: Calendar },
 ];
 
 export default function Sidebar() {


### PR DESCRIPTION
## 📌 개요
- 토스트 알림 기능 추가
- 사이드바 관리자 전용 버튼 위치 변경

## 💻 작업 사항
- 토스트 알림 기능 추가
<img width="1036" height="754" alt="스크린샷 2026-05-06 시간: 13 52 46" src="https://github.com/user-attachments/assets/e10d9f0d-b248-4a76-b5a5-682b91b9cbac" />

- 사이드바 관리자 전용 버튼 위치 변경
<img width="220" height="440" alt="스크린샷 2026-05-06 시간: 13 57 23" src="https://github.com/user-attachments/assets/444b13a1-ad8e-43a2-9a9c-71c9e7a9c87e" />

## 💡 관련 Issue

Closes #85 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #85 )
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
