### PR TITLE
[Feat] 관리자 유저 관리 페이지 제작

### DIFF
--- a/src/app/(main)/admin/users/page.tsx
+++ b/src/app/(main)/admin/users/page.tsx
@@ -1,3 +1,84 @@
-export default function Page() {
-  return <main className="w-full min-h-screen space-y-2">users</main>;
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+
+import AdminHeader from '@/components/admin/AdminHeader';
+import AdminUsersClient from '@/components/admin/users/AdminUsersClient';
+import type {
+  DojangQueryRow,
+  ProfileQueryRow,
+} from '@/components/admin/users/types';
+import { mapProfilesToAdminUserRows } from '@/components/admin/users/utils';
+
+async function getAdminUsers() {
+  const cookieStore = await cookies();
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+      },
+    },
+  );
+
+  const [profilesResult, dojangsResult] = await Promise.all([
+    supabase
+      .from('profiles')
+      .select(
+        `
+        id,
+        nickname,
+        avatar_url,
+        bio,
+        belt_level,
+        created_at,
+        role,
+        email_value,
+        name,
+        account_status
+      `,
+      )
+      .order('created_at', { ascending: false }),
+    supabase.from('dojang').select(
+      `
+        id,
+        profile_id,
+        business_number,
+        representative,
+        phone_value,
+        address,
+        business_file_url,
+        dojang_status,
+        created_at,
+        updated_at
+      `,
+    ),
+  ]);
+
+  if (profilesResult.error) {
+    throw new Error(profilesResult.error.message);
+  }
+
+  if (dojangsResult.error) {
+    throw new Error(dojangsResult.error.message);
+  }
+
+  return mapProfilesToAdminUserRows(
+    (profilesResult.data ?? []) as ProfileQueryRow[],
+    (dojangsResult.data ?? []) as DojangQueryRow[],
+  );
+}
+
+export default async function AdminUsersPage() {
+  const data = await getAdminUsers();
+
+  return (
+    <main className="min-h-screen w-full pt-28 space-y-2">
+      <AdminHeader page="user" />
+      <AdminUsersClient data={data} />
+    </main>
+  );
 }

--- a/src/components/admin/AdminDataTable.tsx
+++ b/src/components/admin/AdminDataTable.tsx
@@ -9,6 +9,7 @@ export interface AdminTableColumn<T> {
   header: string;
   width?: string;
   align?: 'left' | 'center';
+  truncate?: boolean;
   // eslint-disable-next-line no-unused-vars
   render?: (_row: T) => React.ReactNode;
 }
@@ -96,7 +97,13 @@ export default function AdminDataTable<T>({
                         column.align === 'left' && 'text-left',
                       )}
                     >
-                      <div className="truncate">
+                      <div
+                        className={
+                          column.truncate === false
+                            ? 'whitespace-normal'
+                            : 'truncate'
+                        }
+                      >
                         {column.render
                           ? column.render(row)
                           : String(row[column.key])}

--- a/src/components/admin/AdminHeader.tsx
+++ b/src/components/admin/AdminHeader.tsx
@@ -7,12 +7,12 @@ interface AdminHeaderProps {
 export default function AdminHeader({ page }: AdminHeaderProps) {
   const { title, description } = ADMIN_META[page];
 
-    return (
-      <header className="fixed top-0 left-50 right-0 z-10 bg-white shadow-md flex justify-center">
-        <div className="w-full max-w-7xl px-6 py-6 space-y-2">
-          <h1 className="text-2xl font-bold text-zinc-950">{title}</h1>
-          <p className="text-sm text-zinc-500">{description}</p>
-        </div>
-      </header>
-    );
+  return (
+    <header className="fixed top-0 left-50 right-0 z-50 bg-white shadow-md flex justify-center">
+      <div className="w-full max-w-7xl px-6 py-6 space-y-2">
+        <h1 className="text-2xl font-bold text-zinc-950">{title}</h1>
+        <p className="text-sm text-zinc-500">{description}</p>
+      </div>
+    </header>
+  );
 }

--- a/src/components/admin/AdminTableToolbar.tsx
+++ b/src/components/admin/AdminTableToolbar.tsx
@@ -28,7 +28,7 @@ export default function AdminTableToolbar<TFilter extends string>({
   return (
     <section
       className="w-full max-w-7xl px-6 py-4"
-      aria-label="게시글 검색 및 필터"
+      aria-label="데이터 검색 및 필터"
     >
       <div className="flex items-center justify-between gap-4">
         <div className="flex gap-2">

--- a/src/components/admin/users/AdminUserActions.tsx
+++ b/src/components/admin/users/AdminUserActions.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+import { ExternalLink, Power, PowerOff } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+
+import AdminBadge from '@/components/admin/AdminBadge';
+import {
+  ACCOUNT_STATUS_BADGE_VARIANT_MAP,
+  DOJANG_APPROVAL_BADGE_VARIANT_MAP,
+  USER_TYPE_BADGE_VARIANT_MAP,
+} from '@/components/admin/users/constants';
+import type { AdminUserRow } from '@/components/admin/users/types';
+import {
+  formatOptionalText,
+  getNextAccountStatus,
+} from '@/components/admin/users/utils';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { supabase } from '@/lib/supabase';
+
+interface AdminUserActionsProps {
+  user: AdminUserRow;
+}
+
+interface DetailItemProps {
+  label: string;
+  value: React.ReactNode;
+}
+
+const actionButtonClass =
+  'inline-flex h-9 items-center justify-center gap-1 rounded-md border px-3 text-xs font-medium transition-colors duration-200 cursor-pointer';
+
+function DetailItem({ label, value }: DetailItemProps) {
+  return (
+    <div className="grid grid-cols-[104px_minmax(0,1fr)] items-start gap-3 rounded-lg bg-zinc-50 px-4 py-3">
+      <dt className="text-sm font-medium text-zinc-500">{label}</dt>
+      <dd className="min-w-0 text-sm text-zinc-800 break-words">{value}</dd>
+    </div>
+  );
+}
+
+function UserAvatar({
+  avatarUrl,
+  nickname,
+  sizeClassName,
+}: {
+  avatarUrl: string | null;
+  nickname: string;
+  sizeClassName: string;
+}) {
+  if (avatarUrl) {
+    return (
+      <div
+        role="img"
+        aria-label={`${nickname} 프로필 이미지`}
+        className={`${sizeClassName} shrink-0 rounded-full bg-cover bg-center`}
+        style={{ backgroundImage: `url(${avatarUrl})` }}
+      />
+    );
+  }
+
+  return (
+    <div
+      className={`${sizeClassName} flex shrink-0 items-center justify-center rounded-full bg-zinc-100 text-sm font-semibold text-zinc-500`}
+      aria-hidden="true"
+    >
+      {nickname.slice(0, 1)}
+    </div>
+  );
+}
+
+export default function AdminUserActions({ user }: AdminUserActionsProps) {
+  const router = useRouter();
+
+  const isActive = user.account_status === '활성';
+  const nextAccountLabel = isActive ? '비활성' : '활성';
+
+  const handleToggleAccountStatus = async () => {
+    const confirmed = window.confirm(
+      `${user.nickname} 계정을 ${nextAccountLabel} 상태로 변경하시겠습니까?`,
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    const { error } = await supabase
+      .from('profiles')
+      .update({ account_status: getNextAccountStatus(user.raw_account_status) })
+      .eq('id', user.id);
+
+    if (error) {
+      alert('계정 상태 변경에 실패했습니다.');
+      return;
+    }
+
+    router.refresh();
+  };
+
+  return (
+    <div className="flex items-center justify-center gap-2">
+      <Dialog>
+        <DialogTrigger asChild>
+          <button
+            type="button"
+            aria-label={`${user.nickname} 상세 정보 보기`}
+            className={`${actionButtonClass} border-zinc-200 bg-white text-zinc-700 hover:bg-zinc-100`}
+          >
+            상세보기
+          </button>
+        </DialogTrigger>
+
+        <DialogContent className="sm:max-w-2xl">
+          <DialogHeader className="gap-4">
+            <div className="flex items-center gap-4">
+              <UserAvatar
+                avatarUrl={user.avatar_url}
+                nickname={user.nickname}
+                sizeClassName="aspect-square w-[clamp(3.25rem,6vw,4rem)]"
+              />
+
+              <div className="space-y-2">
+                <div className="flex flex-wrap items-center gap-2">
+                  <DialogTitle className="text-xl font-semibold text-zinc-900">
+                    {user.nickname}
+                  </DialogTitle>
+
+                  <AdminBadge
+                    label={user.user_type}
+                    variant={USER_TYPE_BADGE_VARIANT_MAP[user.user_type]}
+                  />
+
+                  <AdminBadge
+                    label={user.account_status}
+                    variant={
+                      ACCOUNT_STATUS_BADGE_VARIANT_MAP[user.account_status]
+                    }
+                  />
+                </div>
+
+                <DialogDescription className="text-sm text-zinc-500">
+                  {user.email}
+                </DialogDescription>
+              </div>
+            </div>
+          </DialogHeader>
+
+          <div className="space-y-5">
+            <section className="space-y-3">
+              <h3 className="text-sm font-semibold text-zinc-900">기본 정보</h3>
+
+              <dl className="space-y-2">
+                <DetailItem label="이름" value={user.name} />
+                <DetailItem label="이메일" value={user.email} />
+                <DetailItem label="유형" value={user.user_type} />
+                <DetailItem label="계정 상태" value={user.account_status} />
+                <DetailItem label="가입일" value={user.joined_at} />
+                <DetailItem
+                  label="벨트"
+                  value={formatOptionalText(user.belt_level)}
+                />
+                <DetailItem
+                  label="소개"
+                  value={formatOptionalText(user.bio)}
+                />
+              </dl>
+            </section>
+
+            {user.user_type === '도장' ? (
+              <section className="space-y-3">
+                <h3 className="text-sm font-semibold text-zinc-900">
+                  도장 정보
+                </h3>
+
+                <dl className="space-y-2">
+                  <DetailItem
+                    label="도장 승인"
+                    value={
+                      user.dojang_approval_status ? (
+                        <AdminBadge
+                          label={user.dojang_approval_status}
+                          variant={
+                            DOJANG_APPROVAL_BADGE_VARIANT_MAP[
+                              user.dojang_approval_status
+                            ]
+                          }
+                        />
+                      ) : (
+                        '-'
+                      )
+                    }
+                  />
+                  <DetailItem
+                    label="사업자등록번호"
+                    value={formatOptionalText(user.business_number)}
+                  />
+                  <DetailItem
+                    label="대표자명"
+                    value={formatOptionalText(user.representative)}
+                  />
+                  <DetailItem
+                    label="연락처"
+                    value={formatOptionalText(user.phone_value)}
+                  />
+                  <DetailItem
+                    label="주소"
+                    value={formatOptionalText(user.address)}
+                  />
+                  <DetailItem
+                    label="첨부 파일"
+                    value={
+                      user.business_file_url ? (
+                        <a
+                          href={user.business_file_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 text-sm font-medium text-blue-600 hover:underline"
+                        >
+                          파일 보기
+                          <ExternalLink className="size-4" />
+                        </a>
+                      ) : (
+                        '-'
+                      )
+                    }
+                  />
+                </dl>
+              </section>
+            ) : null}
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <button
+        type="button"
+        onClick={handleToggleAccountStatus}
+        aria-label={`${user.nickname} 계정 ${isActive ? '비활성화' : '활성화'}`}
+        className={`${actionButtonClass} ${
+          isActive
+            ? 'border-red-200 bg-red-50 text-red-600 hover:bg-red-100'
+            : 'border-green-200 bg-green-50 text-green-700 hover:bg-green-100'
+        }`}
+      >
+        {isActive ? <PowerOff className="size-4" /> : <Power className="size-4" />}
+        {isActive ? '비활성화' : '활성화'}
+      </button>
+    </div>
+  );
+}

--- a/src/components/admin/users/AdminUsersClient.tsx
+++ b/src/components/admin/users/AdminUsersClient.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import AdminBadge from '@/components/admin/AdminBadge';
+import AdminDataTable, {
+  type AdminTableColumn,
+} from '@/components/admin/AdminDataTable';
+import AdminTableToolbar from '@/components/admin/AdminTableToolbar';
+import AdminUserActions from '@/components/admin/users/AdminUserActions';
+import {
+  ACCOUNT_STATUS_BADGE_VARIANT_MAP,
+  ADMIN_USER_FILTERS,
+  DOJANG_APPROVAL_BADGE_VARIANT_MAP,
+  USER_TYPE_BADGE_VARIANT_MAP,
+} from '@/components/admin/users/constants';
+import type {
+  AdminUserFilterValue,
+  AdminUserRow,
+} from '@/components/admin/users/types';
+import { filterAdminUsers } from '@/components/admin/users/utils';
+
+interface AdminUsersClientProps {
+  data: AdminUserRow[];
+}
+
+function UserAvatarCell({
+  avatarUrl,
+  nickname,
+}: {
+  avatarUrl: string | null;
+  nickname: string;
+}) {
+  if (avatarUrl) {
+    return (
+      <div
+        role="img"
+        aria-label={`${nickname} 프로필 이미지`}
+        className="mx-auto aspect-square w-[clamp(2.25rem,3vw,2.75rem)] rounded-full bg-cover bg-center"
+        style={{ backgroundImage: `url(${avatarUrl})` }}
+      />
+    );
+  }
+
+  return (
+    <div
+      className="mx-auto flex aspect-square w-[clamp(2.25rem,3vw,2.75rem)] items-center justify-center rounded-full bg-zinc-100 text-sm font-semibold text-zinc-500"
+      aria-hidden="true"
+    >
+      {nickname.slice(0, 1)}
+    </div>
+  );
+}
+
+const USER_COLUMNS: AdminTableColumn<AdminUserRow>[] = [
+  {
+    key: 'avatar_url',
+    header: '이미지',
+    width: '9%',
+    align: 'center',
+    truncate: false,
+    render: (row) => (
+      <UserAvatarCell avatarUrl={row.avatar_url} nickname={row.nickname} />
+    ),
+  },
+  {
+    key: 'nickname',
+    header: '닉네임 / 이름',
+    width: '18%',
+    align: 'left',
+    truncate: false,
+    render: (row) => (
+      <div className="flex min-w-0 flex-col gap-1">
+        <span
+          className="block truncate text-[15px] font-semibold text-zinc-950"
+          title={row.nickname}
+        >
+          {row.nickname}
+        </span>
+        <span className="block truncate text-sm text-zinc-500" title={row.name}>
+          {row.name}
+        </span>
+      </div>
+    ),
+  },
+  {
+    key: 'email',
+    header: '이메일',
+    width: '18%',
+    align: 'left',
+    render: (row) => (
+      <span className="block truncate" title={row.email}>
+        {row.email}
+      </span>
+    ),
+  },
+  {
+    key: 'user_type',
+    header: '유형',
+    width: '8%',
+    align: 'center',
+    truncate: false,
+    render: (row) => (
+      <AdminBadge
+        label={row.user_type}
+        variant={USER_TYPE_BADGE_VARIANT_MAP[row.user_type]}
+      />
+    ),
+  },
+  {
+    key: 'account_status',
+    header: '계정',
+    width: '8%',
+    align: 'center',
+    truncate: false,
+    render: (row) => (
+      <AdminBadge
+        label={row.account_status}
+        variant={ACCOUNT_STATUS_BADGE_VARIANT_MAP[row.account_status]}
+      />
+    ),
+  },
+  {
+    key: 'dojang_approval_status',
+    header: '도장 승인',
+    width: '10%',
+    align: 'center',
+    truncate: false,
+    render: (row) =>
+      row.dojang_approval_status ? (
+        <AdminBadge
+          label={row.dojang_approval_status}
+          variant={
+            DOJANG_APPROVAL_BADGE_VARIANT_MAP[row.dojang_approval_status]
+          }
+        />
+      ) : (
+        <span className="text-zinc-400">-</span>
+      ),
+  },
+  { key: 'joined_at', header: '가입일', width: '10%', align: 'center' },
+  {
+    key: 'id',
+    header: '관리',
+    width: '17%',
+    align: 'center',
+    truncate: false,
+    render: (row) => <AdminUserActions user={row} />,
+  },
+];
+
+export default function AdminUsersClient({ data }: AdminUsersClientProps) {
+  const [activeFilter, setActiveFilter] = useState<AdminUserFilterValue>('all');
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const filteredData = useMemo(() => {
+    return filterAdminUsers(data, activeFilter, searchQuery);
+  }, [activeFilter, data, searchQuery]);
+
+  return (
+    <>
+      <AdminTableToolbar
+        filters={ADMIN_USER_FILTERS}
+        activeFilter={activeFilter}
+        onFilterChange={setActiveFilter}
+        searchQuery={searchQuery}
+        onSearchQueryChange={setSearchQuery}
+        searchPlaceholder="닉네임, 이름, 이메일 검색..."
+      />
+
+      <AdminDataTable
+        columns={USER_COLUMNS}
+        data={filteredData}
+        emptyMessage="등록된 사용자가 없습니다."
+        getRowKey={(row) => row.id}
+      />
+    </>
+  );
+}

--- a/src/components/admin/users/constants.ts
+++ b/src/components/admin/users/constants.ts
@@ -1,0 +1,45 @@
+import type { AdminBadgeVariant } from '@/components/admin/AdminBadge';
+
+import type {
+  AdminAccountStatus,
+  AdminDojangApprovalStatus,
+  AdminUserFilterOption,
+  AdminUserType,
+} from './types';
+
+export const UNKNOWN_USER_NICKNAME = '알 수 없음';
+export const UNKNOWN_USER_NAME = '-';
+export const UNKNOWN_USER_EMAIL = '-';
+
+export const ADMIN_USER_FILTERS = [
+  { label: '전체', value: 'all' },
+  { label: '일반', value: '일반' },
+  { label: '도장', value: '도장' },
+  { label: '관리자', value: '관리자' },
+] as const satisfies readonly AdminUserFilterOption[];
+
+export const USER_TYPE_BADGE_VARIANT_MAP: Record<
+  AdminUserType,
+  AdminBadgeVariant
+> = {
+  일반: 'gray',
+  도장: 'blue',
+  관리자: 'red',
+};
+
+export const ACCOUNT_STATUS_BADGE_VARIANT_MAP: Record<
+  AdminAccountStatus,
+  AdminBadgeVariant
+> = {
+  활성: 'green',
+  비활성: 'red',
+};
+
+export const DOJANG_APPROVAL_BADGE_VARIANT_MAP: Record<
+  AdminDojangApprovalStatus,
+  AdminBadgeVariant
+> = {
+  승인대기: 'yellow',
+  승인완료: 'green',
+  승인거부: 'red',
+};

--- a/src/components/admin/users/types.ts
+++ b/src/components/admin/users/types.ts
@@ -1,0 +1,86 @@
+export type RawUserRole =
+  | 'user'
+  | 'manager'
+  | 'dojang'
+  | 'pending'
+  | 'admin'
+  | string
+  | null;
+
+export type RawAccountStatus =
+  | 'active'
+  | 'inactive'
+  | 'suspended'
+  | string
+  | null;
+
+export type RawDojangStatus =
+  | 'pending'
+  | 'approved'
+  | 'rejected'
+  | string
+  | null;
+
+export type AdminUserType = '일반' | '도장' | '관리자';
+
+export type AdminAccountStatus = '활성' | '비활성';
+
+export type AdminDojangApprovalStatus =
+  | '승인대기'
+  | '승인완료'
+  | '승인거부';
+
+export type AdminUserFilterValue = 'all' | AdminUserType;
+
+export interface AdminUserFilterOption {
+  label: string;
+  value: AdminUserFilterValue;
+}
+
+export interface ProfileQueryRow {
+  id: string;
+  nickname: string | null;
+  avatar_url: string | null;
+  bio: string | null;
+  belt_level: string | null;
+  created_at: string;
+  role: RawUserRole;
+  email_value: string | null;
+  name: string | null;
+  account_status: RawAccountStatus;
+}
+
+export interface DojangQueryRow {
+  id: string;
+  profile_id: string;
+  business_number: string | null;
+  representative: string | null;
+  phone_value: string | null;
+  address: string | null;
+  business_file_url: string | null;
+  dojang_status: RawDojangStatus;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AdminUserRow {
+  id: string;
+  avatar_url: string | null;
+  nickname: string;
+  name: string;
+  email: string;
+  user_type: AdminUserType;
+  account_status: AdminAccountStatus;
+  dojang_approval_status: AdminDojangApprovalStatus | null;
+  joined_at: string;
+  raw_role: RawUserRole;
+  raw_account_status: RawAccountStatus;
+  raw_dojang_status: RawDojangStatus;
+  bio: string | null;
+  belt_level: string | null;
+  business_number: string | null;
+  representative: string | null;
+  phone_value: string | null;
+  address: string | null;
+  business_file_url: string | null;
+}

--- a/src/components/admin/users/utils.ts
+++ b/src/components/admin/users/utils.ts
@@ -1,0 +1,188 @@
+import {
+  UNKNOWN_USER_EMAIL,
+  UNKNOWN_USER_NAME,
+  UNKNOWN_USER_NICKNAME,
+} from './constants';
+import type {
+  AdminAccountStatus,
+  AdminDojangApprovalStatus,
+  AdminUserFilterValue,
+  AdminUserRow,
+  AdminUserType,
+  DojangQueryRow,
+  ProfileQueryRow,
+  RawAccountStatus,
+  RawDojangStatus,
+  RawUserRole,
+} from './types';
+
+const DOJANG_ROLE_SET = new Set(['manager', 'dojang', 'pending']);
+
+export function formatUserDate(dateText: string) {
+  return dateText.slice(0, 10);
+}
+
+export function formatOptionalText(value: string | null | undefined) {
+  const normalizedValue = value?.trim();
+
+  return normalizedValue && normalizedValue.length > 0
+    ? normalizedValue
+    : UNKNOWN_USER_NAME;
+}
+
+export function formatNickname(value: string | null | undefined) {
+  const normalizedValue = value?.trim();
+
+  return normalizedValue && normalizedValue.length > 0
+    ? normalizedValue
+    : UNKNOWN_USER_NICKNAME;
+}
+
+export function formatEmail(value: string | null | undefined) {
+  const normalizedValue = value?.trim();
+
+  return normalizedValue && normalizedValue.length > 0
+    ? normalizedValue
+    : UNKNOWN_USER_EMAIL;
+}
+
+export function getUserType(role: RawUserRole): AdminUserType {
+  if (role === 'admin') {
+    return '관리자';
+  }
+
+  if (typeof role === 'string' && DOJANG_ROLE_SET.has(role)) {
+    return '도장';
+  }
+
+  return '일반';
+}
+
+export function isUserActive(accountStatus: RawAccountStatus) {
+  return accountStatus !== 'inactive' && accountStatus !== 'suspended';
+}
+
+export function getAccountStatusLabel(
+  accountStatus: RawAccountStatus,
+): AdminAccountStatus {
+  return isUserActive(accountStatus) ? '활성' : '비활성';
+}
+
+export function getNextAccountStatus(accountStatus: RawAccountStatus) {
+  return isUserActive(accountStatus) ? 'suspended' : 'active';
+}
+
+export function getDojangApprovalStatus(
+  role: RawUserRole,
+  dojangStatus: RawDojangStatus,
+): AdminDojangApprovalStatus | null {
+  if (getUserType(role) !== '도장') {
+    return null;
+  }
+
+  if (dojangStatus === 'approved') {
+    return '승인완료';
+  }
+
+  if (dojangStatus === 'rejected') {
+    return '승인거부';
+  }
+
+  if (dojangStatus === 'pending') {
+    return '승인대기';
+  }
+
+  if (role === 'manager' || role === 'dojang') {
+    return '승인완료';
+  }
+
+  return '승인대기';
+}
+
+function buildDojangByProfileIdMap(dojangs: DojangQueryRow[]) {
+  const dojangByProfileId = new Map<string, DojangQueryRow>();
+
+  for (const dojang of dojangs) {
+    if (!dojang.profile_id || dojangByProfileId.has(dojang.profile_id)) {
+      continue;
+    }
+
+    dojangByProfileId.set(dojang.profile_id, dojang);
+  }
+
+  return dojangByProfileId;
+}
+
+export function mapProfileQueryRowToAdminUserRow(
+  profile: ProfileQueryRow,
+  dojangByProfileId: Map<string, DojangQueryRow>,
+): AdminUserRow {
+  const dojang = dojangByProfileId.get(profile.id) ?? null;
+
+  return {
+    id: profile.id,
+    avatar_url: profile.avatar_url,
+    nickname: formatNickname(profile.nickname),
+    name: formatOptionalText(profile.name),
+    email: formatEmail(profile.email_value),
+    user_type: getUserType(profile.role),
+    account_status: getAccountStatusLabel(profile.account_status),
+    dojang_approval_status: getDojangApprovalStatus(
+      profile.role,
+      dojang?.dojang_status ?? null,
+    ),
+    joined_at: formatUserDate(profile.created_at),
+    raw_role: profile.role,
+    raw_account_status: profile.account_status,
+    raw_dojang_status: dojang?.dojang_status ?? null,
+    bio: profile.bio,
+    belt_level: profile.belt_level,
+    business_number: dojang?.business_number ?? null,
+    representative: dojang?.representative ?? null,
+    phone_value: dojang?.phone_value ?? null,
+    address: dojang?.address ?? null,
+    business_file_url: dojang?.business_file_url ?? null,
+  };
+}
+
+export function mapProfilesToAdminUserRows(
+  profiles: ProfileQueryRow[],
+  dojangs: DojangQueryRow[],
+) {
+  const dojangByProfileId = buildDojangByProfileIdMap(dojangs);
+
+  return profiles.map((profile) =>
+    mapProfileQueryRowToAdminUserRow(profile, dojangByProfileId),
+  );
+}
+
+export function matchesUserFilter(
+  user: AdminUserRow,
+  activeFilter: AdminUserFilterValue,
+) {
+  if (activeFilter === 'all') {
+    return true;
+  }
+
+  return user.user_type === activeFilter;
+}
+
+export function filterAdminUsers(
+  users: AdminUserRow[],
+  activeFilter: AdminUserFilterValue,
+  searchQuery: string,
+) {
+  const normalizedSearchQuery = searchQuery.trim().toLowerCase();
+
+  return users.filter((user) => {
+    const isFilterMatched = matchesUserFilter(user, activeFilter);
+
+    const isSearchMatched =
+      normalizedSearchQuery.length === 0 ||
+      user.nickname.toLowerCase().includes(normalizedSearchQuery) ||
+      user.name.toLowerCase().includes(normalizedSearchQuery) ||
+      user.email.toLowerCase().includes(normalizedSearchQuery);
+
+    return isFilterMatched && isSearchMatched;
+  });
+}


### PR DESCRIPTION
<!--
  PR 작성 가이드
  - 리뷰어를 존중하는 표현을 사용해주세요.
  - 변경 의도와 주요 내용을 명확하게 작성해주세요.
 -->

## 📌 개요

- 관리자 유저 관리 페이지 제작

## 💻 작업 사항
- 관리자 유저 관리 페이지 UI를 구현했습니다.
- `AdminHeader`, `AdminTableToolbar`, `AdminDataTable` 구조를 재사용해 기존 관리자 페이지와 일관성을 맞췄습니다.
- 유저 관리 전용 `types`, `constants`, `utils` 파일을 분리해 역할을 정리했습니다.
- 서버 컴포넌트에서 `profiles`, `dojang` 데이터를 조회하고 관리자 테이블용 데이터로 가공했습니다.
- 클라이언트 컴포넌트에서 역할별 필터(`전체 / 일반 / 도장 / 관리자`)와 검색 기능을 구현했습니다.
- 검색은 `nickname`, `name`, `email` 기준으로 동작하도록 연결했습니다.
- 테이블 컬럼에 프로필 이미지, 닉네임/이름, 이메일, 유형, 계정 상태, 도장 승인 상태, 가입일, 관리 액션을 구성했습니다.
- `AdminBadge`를 재사용해 유형/계정/도장 승인 상태를 뱃지 형태로 표시했습니다.
- 관리 컬럼에 유저 상세보기 모달과 활성/비활성 토글 버튼을 추가했습니다.
- 기존 관리자 공통 테이블에 멀티라인 셀 대응을 보완해 유저 관리 페이지 UI를 안정적으로 표시하도록 개선했습니다.

<img width="1911" height="930" alt="스크린샷 2026-05-06 오후 4 12 35" src="https://github.com/user-attachments/assets/cf16497e-50eb-4e23-9ede-6017d06b876a" />


## 💡 관련 Issue

Closes #71

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #)
- [x] 불필요한 console.log를 제거했습니다.
- [x] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
