### PR TITLE
[Refactor] 커뮤니티 및 대회 페이지의 반복되는 UI를 공통 컴포넌트로 분리

### DIFF
--- a/src/app/(main)/community/[id]/edit/page.tsx
+++ b/src/app/(main)/community/[id]/edit/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useQueryClient } from '@tanstack/react-query'; // 추가
+import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import type { PostCategory } from '@/types/community';
@@ -28,7 +28,7 @@ export default function EditPage({
   const [preview, setPreview] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [imageFile, setImageFile] = useState<File | null>(null);
-  const queryClient = useQueryClient(); // 추가
+  const queryClient = useQueryClient();
 
   useEffect(() => {
     const load = async () => {

--- a/src/app/(main)/community/[id]/edit/page.tsx
+++ b/src/app/(main)/community/[id]/edit/page.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/services/communityService';
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
 import ImageUpload from '@/components/community/ImageUpload';
+import PostFormActions from '@/components/community/PostFormActions';
 
 export default function EditPage({
   params,
@@ -114,20 +115,11 @@ export default function EditPage({
         />
       </div>
 
-      <div className="flex gap-3">
-        <button
-          onClick={() => router.back()}
-          className="flex-1 py-3 rounded-xl bg-btn-basic border border-gray-300 text-black hover:bg-gray-200"
-        >
-          취소
-        </button>
-        <button
-          onClick={handleSubmit}
-          className="flex-3 py-3 rounded-xl bg-black text-white text-sm font-medium cursor-pointer"
-        >
-          수정하기
-        </button>
-      </div>
+      <PostFormActions
+        onCancel={() => router.back()}
+        onSubmit={handleSubmit}
+        submitLabel="수정하기"
+      />
     </div>
   );
 }

--- a/src/app/(main)/community/[id]/edit/page.tsx
+++ b/src/app/(main)/community/[id]/edit/page.tsx
@@ -4,7 +4,6 @@ import { useQueryClient } from '@tanstack/react-query'; // 추가
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import type { PostCategory } from '@/types/community';
-import Image from 'next/image';
 import LoadingSpinner from '@/components/common/LoadingSpinner';
 import { use } from 'react';
 import {
@@ -13,6 +12,7 @@ import {
   uploadPostImage,
 } from '@/services/communityService';
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
+import ImageUpload from '@/components/community/ImageUpload';
 
 export default function EditPage({
   params,
@@ -45,14 +45,6 @@ export default function EditPage({
     };
     load();
   }, [id]);
-
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      setImageFile(file);
-      setPreview(URL.createObjectURL(file));
-    }
-  };
 
   const handleSubmit = async () => {
     if (!title.trim() || !content.trim()) {
@@ -103,33 +95,13 @@ export default function EditPage({
         />
       </div>
 
-      <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
-        <p className="text-sm text-gray-500 mb-2">이미지 (선택)</p>
-        <label className="block cursor-pointer">
-          {preview ? (
-            <div className="relative w-full h-48 rounded-lg overflow-hidden">
-              <Image
-                src={preview}
-                alt="preview"
-                fill={true}
-                className="object-cover"
-              />
-            </div>
-          ) : (
-            <div className="flex flex-col items-center justify-center h-32 bg-gray-50 rounded-lg border-2 border-dashed border-gray-200">
-              <span className="text-2xl mb-1">↑</span>
-              <p className="text-sm text-gray-500">클릭하여 이미지 업로드</p>
-              <p className="text-xs text-gray-400">JPG, PNG, GIF (최대 10MB)</p>
-            </div>
-          )}
-          <input
-            type="file"
-            accept="image/*"
-            className="hidden"
-            onChange={handleImageChange}
-          />
-        </label>
-      </div>
+      <ImageUpload
+        preview={preview}
+        onChange={(file, previewUrl) => {
+          setImageFile(file);
+          setPreview(previewUrl);
+        }}
+      />
 
       <div className="bg-white rounded-xl p-4 mb-6 shadow-sm">
         <p className="text-sm text-gray-500 mb-2">내용</p>

--- a/src/app/(main)/community/[id]/page.tsx
+++ b/src/app/(main)/community/[id]/page.tsx
@@ -77,7 +77,10 @@ export default function PostDetailPage({
       showErrorToast('로그인이 필요합니다.');
       return;
     }
-    if (!comment.trim() || !userId) return;
+    if (!comment.trim()) {
+      showErrorToast('댓글을 입력해주세요.');
+      return;
+    }
     try {
       const newComment = await createComment({
         post_id: id,
@@ -253,11 +256,19 @@ export default function PostDetailPage({
                 </button>
               </>
             ) : (
-              <button title="신고하기" onClick={() => setReportModalOpen(true)}>
+              <button
+                title="신고하기"
+                onClick={() => setReportModalOpen(true)}
+                className="w-8 h-8 flex items-center justify-center"
+              >
                 <Image src="/postReport.svg" alt="" width={27} height={27} />
               </button>
             )}
-            <button title="공유하기" onClick={handleShare}>
+            <button
+              title="공유하기"
+              onClick={handleShare}
+              className="w-8 h-8 flex items-center justify-center"
+            >
               <Image src="/postShare.svg" alt="" width={18} height={18} />
             </button>
           </>

--- a/src/app/(main)/community/[id]/page.tsx
+++ b/src/app/(main)/community/[id]/page.tsx
@@ -20,15 +20,8 @@ import { useAuth } from '@/hooks/useAuth';
 import { useLike } from '@/hooks/useLike';
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
 import ReportModal from '@/components/community/ReportModal';
-
-function timeAgo(dateStr: string) {
-  const diff = Date.now() - new Date(dateStr).getTime();
-  const min = Math.floor(diff / 60000);
-  if (min < 60) return `${min}분 전`;
-  const hr = Math.floor(min / 60);
-  if (hr < 24) return `${hr}시간 전`;
-  return `${Math.floor(hr / 24)}일 전`;
-}
+import PostCard, { PostCardData } from '@/components/community/Postcard';
+import { timeAgo } from '@/utils/timeAgo';
 
 export default function PostDetailPage({
   params,
@@ -194,6 +187,19 @@ export default function PostDetailPage({
     }
   };
 
+  const postCardData: PostCardData = {
+    nickname: post.nickname ?? '알 수 없음',
+    avatar_url: post.avatar_url,
+    role: post.role,
+    created_at: post.created_at,
+    title: post.title,
+    image_url: post.image_url,
+    content: post.content,
+    likeCount: likeCount ?? 0,
+    commentCount: comments.length,
+    view_count: post.view_count,
+  };
+
   return (
     <div className="max-w-2xl mx-auto p-4 space-y-4">
       {/* 뒤로가기 */}
@@ -220,183 +226,41 @@ export default function PostDetailPage({
       </button>
 
       {/* ── 게시글 카드 ── */}
-      <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden">
-        {/* 작성자 헤더 */}
-        <div className="flex items-center justify-between px-5 pt-5 pb-4">
-          <div className="flex items-center gap-3">
-            <div className="w-10 h-10 rounded-full bg-gray-200 overflow-hidden shrink-0">
-              {post.avatar_url && (
-                <Image
-                  src={post.avatar_url}
-                  alt={`${post.nickname} 프로필 이미지`}
-                  width={40}
-                  height={40}
-                  className="w-full h-full object-cover"
-                />
-              )}
-            </div>
-            <div>
-              <div className="flex items-center gap-1.5">
-                <span className="text-sm font-semibold text-gray-900">
-                  {post.nickname ?? '알 수 없음'}
-                </span>
-                {post.role && (
-                  <span
-                    className={`text-xs px-2 py-0.5 rounded-full font-medium ${
-                      post.role === 'manager'
-                        ? 'bg-blue-50 text-blue-600'
-                        : post.role === 'admin'
-                          ? 'bg-red-50 text-red-600'
-                          : 'bg-gray-100 text-gray-600'
-                    }`}
-                  >
-                    {post.role === 'manager'
-                      ? '도장'
-                      : post.role === 'admin'
-                        ? '관리자'
-                        : '일반'}
-                  </span>
-                )}
-              </div>
-              <p className="text-xs text-gray-400 mt-0.5 flex items-center gap-1">
-                <Image
-                  src="/postTime.svg"
-                  alt="시간"
-                  width={11}
-                  height={11}
-                  className="opacity-50"
-                />
-                {timeAgo(post.created_at)}
-              </p>
-            </div>
-          </div>
-
-          {/* 오너 액션 버튼 */}
-          <div className="flex items-center gap-1">
+      <PostCard
+        post={postCardData}
+        isLiked={isLiked}
+        onLike={() => {
+          if (!userId) {
+            showErrorToast('로그인이 필요합니다.');
+            return;
+          }
+          toggle();
+        }}
+        headerActions={
+          <>
             {isOwner ? (
               <>
                 <button
                   title="수정하기"
                   onClick={() => router.push(`/community/${id}/edit`)}
-                  aria-label={`${post.nickname}의 게시글 수정`}
-                  className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-gray-100 transition-colors text-gray-500 cursor-pointer"
                 >
-                  <Image
-                    src="/postEdit.svg"
-                    alt=""
-                    width={30}
-                    height={30}
-                    aria-hidden="true"
-                  />
+                  <Image src="/postEdit.svg" alt="" width={30} height={30} />
                 </button>
-                <button
-                  title="삭제하기"
-                  onClick={handleDeletePost}
-                  aria-label={`${post.nickname}의 게시글 삭제`}
-                  className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-red-50 transition-colors text-red-400 cursor-pointer"
-                >
-                  <Image
-                    src="/postDelete.svg"
-                    alt=""
-                    width={32}
-                    height={32}
-                    aria-hidden="true"
-                  />
+                <button title="삭제하기" onClick={handleDeletePost}>
+                  <Image src="/postDelete.svg" alt="" width={32} height={32} />
                 </button>
               </>
             ) : (
-              // ── 신고 버튼 (게시글) ──
-              <button
-                title="신고하기"
-                onClick={() => setReportModalOpen(true)}
-                aria-label={`${post.nickname}의 게시글 신고`}
-                className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-gray-100 transition-colors text-gray-400 cursor-pointer"
-              >
-                <Image
-                  src="/postReport.svg"
-                  alt=""
-                  width={27}
-                  height={27}
-                  aria-hidden="true"
-                />
+              <button title="신고하기" onClick={() => setReportModalOpen(true)}>
+                <Image src="/postReport.svg" alt="" width={27} height={27} />
               </button>
             )}
-            <button
-              title="공유하기"
-              onClick={handleShare}
-              aria-label={`${post.nickname}의 게시글 공유`}
-              className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-gray-100 transition-colors text-gray-500 cursor-pointer relative"
-            >
-              <Image
-                src="/postShare.svg"
-                alt=""
-                width={18}
-                height={18}
-                aria-hidden="true"
-              />
+            <button title="공유하기" onClick={handleShare}>
+              <Image src="/postShare.svg" alt="" width={18} height={18} />
             </button>
-          </div>
-        </div>
-
-        {/* 제목 */}
-        <div className="px-5 pb-3">
-          <h1 className="text-lg font-bold text-gray-900">{post.title}</h1>
-        </div>
-
-        {/* 이미지 */}
-        {post.image_url && (
-          <div className="px-5 pb-4">
-            <div className="rounded-xl overflow-hidden">
-              <Image
-                src={post.image_url}
-                alt={`${post.title} 게시글 이미지`}
-                width={800}
-                height={400}
-                className="w-full object-cover max-h-72"
-              />
-            </div>
-          </div>
-        )}
-
-        {/* 본문 */}
-        <div className="px-5 pb-5">
-          <p className="text-sm text-gray-700 whitespace-pre-line leading-relaxed">
-            {post.content}
-          </p>
-        </div>
-
-        {/* 하단 액션 바 */}
-        <div className="px-5 py-3 border-t border-gray-100 flex items-center gap-4">
-          <button
-            onClick={() => {
-              if (!userId) {
-                showErrorToast('로그인이 필요합니다.');
-                return;
-              }
-              toggle();
-            }}
-            aria-pressed={isLiked}
-            aria-label={`좋아요 ${likeCount}개, ${isLiked ? '좋아요 취소' : '좋아요'}`}
-            className={`flex items-center gap-1.5 text-xs transition-colors cursor-pointer text-gray-500 hover:text-red-500`}
-          >
-            <Image
-              src="/like.svg"
-              alt=""
-              width={16}
-              height={16}
-              aria-hidden="true"
-            />
-            <span>좋아요 {likeCount}</span>
-          </button>
-          <div className="flex items-center gap-1.5 text-xs text-gray-500">
-            <Image src="/postComment.svg" alt="댓글" width={16} height={16} />
-            <span>댓글 {comments.length}</span>
-          </div>
-          <span className="flex items-center gap-1.5 text-xs text-gray-500">
-            조회 {post.view_count}
-          </span>
-        </div>
-      </div>
+          </>
+        }
+      />
 
       {/* ── 댓글 카드 ── */}
       <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden">

--- a/src/app/(main)/community/[id]/page.tsx
+++ b/src/app/(main)/community/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useQueryClient } from '@tanstack/react-query'; // 추가
+import { useQueryClient } from '@tanstack/react-query';
 import { use, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import {
@@ -20,7 +20,9 @@ import { useAuth } from '@/hooks/useAuth';
 import { useLike } from '@/hooks/useLike';
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
 import ReportModal from '@/components/community/ReportModal';
-import PostCard, { PostCardData } from '@/components/community/Postcard';
+import PostDetailCard, {
+  PostDetailCardData,
+} from '@/components/community/PostDetailCard';
 import { timeAgo } from '@/utils/timeAgo';
 
 export default function PostDetailPage({
@@ -39,7 +41,7 @@ export default function PostDetailPage({
   const [editingContent, setEditingContent] = useState('');
   const { user } = useAuth();
   const { likeCount, isLiked, toggle } = useLike(id, user?.id ?? '');
-  const queryClient = useQueryClient(); // 추가
+  const queryClient = useQueryClient();
 
   const [reportModalOpen, setReportModalOpen] = useState(false);
 
@@ -187,7 +189,7 @@ export default function PostDetailPage({
     }
   };
 
-  const postCardData: PostCardData = {
+  const postDetailCardData: PostDetailCardData = {
     nickname: post.nickname ?? '알 수 없음',
     avatar_url: post.avatar_url,
     role: post.role,
@@ -226,8 +228,8 @@ export default function PostDetailPage({
       </button>
 
       {/* ── 게시글 카드 ── */}
-      <PostCard
-        post={postCardData}
+      <PostDetailCard
+        post={postDetailCardData}
         isLiked={isLiked}
         onLike={() => {
           if (!userId) {

--- a/src/app/(main)/community/write/page.tsx
+++ b/src/app/(main)/community/write/page.tsx
@@ -11,11 +11,11 @@ import { useQueryClient } from '@tanstack/react-query';
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
 import ImageUpload from '@/components/community/ImageUpload';
 import PostFormActions from '@/components/community/PostFormActions';
-import PostCard from '@/components/community/Postcard';
+import PostDetailCard from '@/components/community/PostDetailCard';
 
 export default function WritePage() {
   const router = useRouter();
-  const [tab, setTab] = useState<'write' | 'preview'>('write'); // ✅ 추가
+  const [tab, setTab] = useState<'write' | 'preview'>('write');
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [preview, setPreview] = useState<string | null>(null);
@@ -158,25 +158,27 @@ export default function WritePage() {
       {/* ✅ 미리보기 탭 */}
       {tab === 'preview' &&
         (!title && !content ? (
-          <div className="flex flex-col items-center justify-center py-16 text-gray-400">
+          <div className="flex flex-col items-center justify-center py-16 text-gray-400 mb-6">
             <p className="text-sm">작성 탭에서 내용을 입력하면</p>
             <p className="text-sm">여기서 미리볼 수 있어요.</p>
           </div>
         ) : (
-          <PostCard
-            post={{
-              nickname: user?.name ?? '알 수 없음',
-              avatar_url: user?.image ?? null,
-              role: category === 'promo' ? 'manager' : (user?.role ?? null),
-              created_at: new Date().toISOString(),
-              title,
-              image_url: preview,
-              content,
-              likeCount: 0,
-              commentCount: 0,
-              view_count: 0,
-            }}
-          />
+          <div className="mb-6">
+            <PostDetailCard
+              post={{
+                nickname: user?.name ?? '알 수 없음',
+                avatar_url: user?.image ?? null,
+                role: category === 'promo' ? 'manager' : (user?.role ?? null),
+                created_at: new Date().toISOString(),
+                title,
+                image_url: preview,
+                content,
+                likeCount: 0,
+                commentCount: 0,
+                view_count: 0,
+              }}
+            />
+          </div>
         ))}
 
       {/* 하단 버튼 */}

--- a/src/app/(main)/community/write/page.tsx
+++ b/src/app/(main)/community/write/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import type { PostCategory } from '@/types/community';
-import Image from 'next/image';
 import LoadingSpinner from '@/components/common/LoadingSpinner';
 import { supabase } from '@/lib/supabase';
 import { createPost, uploadPostImage } from '@/services/communityService';
@@ -12,6 +11,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
 import ImageUpload from '@/components/community/ImageUpload';
 import PostFormActions from '@/components/community/PostFormActions';
+import PostCard from '@/components/community/Postcard';
 
 export default function WritePage() {
   const router = useRouter();
@@ -156,93 +156,28 @@ export default function WritePage() {
       )}
 
       {/* ✅ 미리보기 탭 */}
-      {tab === 'preview' && (
-        <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden mb-6">
-          {!title && !content ? (
-            <div className="flex flex-col items-center justify-center py-16 text-gray-400">
-              <p className="text-sm">작성 탭에서 내용을 입력하면</p>
-              <p className="text-sm">여기서 미리볼 수 있어요.</p>
-            </div>
-          ) : (
-            <>
-              {/* 작성자 헤더 */}
-              <div className="flex items-center gap-3 px-5 pt-5 pb-4">
-                <div className="w-10 h-10 rounded-full bg-gray-200 overflow-hidden shrink-0">
-                  {user?.image && (
-                    <Image
-                      src={user.image}
-                      alt="프로필"
-                      width={40}
-                      height={40}
-                      className="w-full h-full object-cover"
-                    />
-                  )}
-                </div>
-                <div>
-                  {/* ✅ 닉네임 + role 뱃지 추가 */}
-                  <div className="flex items-center gap-1.5">
-                    <span className="text-sm font-semibold text-gray-900">
-                      {user?.name ?? '알 수 없음'}
-                    </span>
-                    {user?.role && (
-                      <span
-                        className={`text-xs px-2 py-0.5 rounded-full font-medium ${
-                          category === 'promo'
-                            ? 'bg-blue-50 text-blue-600'
-                            : user?.role === 'admin'
-                              ? 'bg-red-50 text-red-600'
-                              : 'bg-gray-100 text-gray-600'
-                        }`}
-                      >
-                        {category === 'promo'
-                          ? '도장'
-                          : user?.role === 'admin'
-                            ? '공지'
-                            : '일반'}
-                      </span>
-                    )}
-                  </div>
-                  <p className="text-xs text-gray-400 mt-0.5">방금 전</p>
-                </div>
-              </div>
-
-              {/* 제목 */}
-              <div className="px-5 pb-3">
-                <h1 className="text-lg font-bold text-gray-900">{title}</h1>
-              </div>
-
-              {/* 이미지 */}
-              {preview && (
-                <div className="px-5 pb-4">
-                  <div className="rounded-xl overflow-hidden">
-                    <Image
-                      src={preview}
-                      alt="게시글 이미지"
-                      width={800}
-                      height={400}
-                      className="w-full object-cover max-h-72"
-                    />
-                  </div>
-                </div>
-              )}
-
-              {/* 본문 */}
-              <div className="px-5 pb-5">
-                <p className="text-sm text-gray-700 whitespace-pre-line leading-relaxed">
-                  {content}
-                </p>
-              </div>
-
-              {/* 하단 바 */}
-              <div className="px-5 py-3 border-t border-gray-100 flex items-center gap-4">
-                <span className="text-xs text-gray-400">좋아요 0</span>
-                <span className="text-xs text-gray-400">댓글 0</span>
-                <span className="text-xs text-gray-400">조회 0</span>
-              </div>
-            </>
-          )}
-        </div>
-      )}
+      {tab === 'preview' &&
+        (!title && !content ? (
+          <div className="flex flex-col items-center justify-center py-16 text-gray-400">
+            <p className="text-sm">작성 탭에서 내용을 입력하면</p>
+            <p className="text-sm">여기서 미리볼 수 있어요.</p>
+          </div>
+        ) : (
+          <PostCard
+            post={{
+              nickname: user?.name ?? '알 수 없음',
+              avatar_url: user?.image ?? null,
+              role: category === 'promo' ? 'manager' : (user?.role ?? null),
+              created_at: new Date().toISOString(),
+              title,
+              image_url: preview,
+              content,
+              likeCount: 0,
+              commentCount: 0,
+              view_count: 0,
+            }}
+          />
+        ))}
 
       {/* 하단 버튼 */}
       <PostFormActions

--- a/src/app/(main)/community/write/page.tsx
+++ b/src/app/(main)/community/write/page.tsx
@@ -11,6 +11,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { useQueryClient } from '@tanstack/react-query';
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
 import ImageUpload from '@/components/community/ImageUpload';
+import PostFormActions from '@/components/community/PostFormActions';
 
 export default function WritePage() {
   const router = useRouter();
@@ -243,21 +244,12 @@ export default function WritePage() {
         </div>
       )}
 
-      {/* 기존 하단 버튼 (그대로 유지) */}
-      <div className="flex gap-3">
-        <button
-          onClick={() => router.back()}
-          className="flex-1 py-3 rounded-xl bg-btn-basic border border-gray-300 text-black hover:bg-gray-200 cursor-pointer"
-        >
-          취소
-        </button>
-        <button
-          onClick={handleSubmit}
-          className="flex-3 py-3 rounded-xl bg-black text-white text-sm font-medium cursor-pointer"
-        >
-          작성하기
-        </button>
-      </div>
+      {/* 하단 버튼 */}
+      <PostFormActions
+        onCancel={() => router.back()}
+        onSubmit={handleSubmit}
+        submitLabel="작성하기"
+      />
     </div>
   );
 }

--- a/src/app/(main)/community/write/page.tsx
+++ b/src/app/(main)/community/write/page.tsx
@@ -10,6 +10,7 @@ import { createPost, uploadPostImage } from '@/services/communityService';
 import { useAuth } from '@/hooks/useAuth';
 import { useQueryClient } from '@tanstack/react-query';
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
+import ImageUpload from '@/components/community/ImageUpload';
 
 export default function WritePage() {
   const router = useRouter();
@@ -30,14 +31,6 @@ export default function WritePage() {
   }, [user, loading, router]);
 
   if (loading || isLoading) return <LoadingSpinner />;
-
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      setImageFile(file);
-      setPreview(URL.createObjectURL(file));
-    }
-  };
 
   const handleSubmit = async () => {
     if (!title.trim() || !content.trim()) {
@@ -140,37 +133,13 @@ export default function WritePage() {
             />
           </div>
 
-          <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
-            <p className="text-sm text-gray-500 mb-2">이미지 (선택)</p>
-            <label className="block cursor-pointer">
-              {preview ? (
-                <div className="relative w-full h-48 rounded-lg overflow-hidden">
-                  <Image
-                    src={preview}
-                    alt="preview"
-                    fill={true}
-                    className="object-cover"
-                  />
-                </div>
-              ) : (
-                <div className="flex flex-col items-center justify-center h-32 bg-gray-50 rounded-lg border-2 border-dashed border-gray-200">
-                  <span className="text-2xl mb-1">↑</span>
-                  <p className="text-sm text-gray-500">
-                    클릭하여 이미지 업로드
-                  </p>
-                  <p className="text-xs text-gray-400">
-                    JPG, PNG, GIF (최대 10MB)
-                  </p>
-                </div>
-              )}
-              <input
-                type="file"
-                accept="image/*"
-                className="hidden"
-                onChange={handleImageChange}
-              />
-            </label>
-          </div>
+          <ImageUpload
+            preview={preview}
+            onChange={(file, previewUrl) => {
+              setImageFile(file);
+              setPreview(previewUrl);
+            }}
+          />
 
           <div className="bg-white rounded-xl p-4 mb-6 shadow-sm">
             <p className="text-sm text-gray-500 mb-2">내용</p>

--- a/src/app/(main)/competitions/write/page.tsx
+++ b/src/app/(main)/competitions/write/page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import Image from 'next/image';
 import LoadingSpinner from '@/components/common/LoadingSpinner';
 import { useAuth } from '@/hooks/useAuth';
 import {
@@ -10,6 +9,8 @@ import {
   uploadCompetitionImage,
 } from '@/services/competitionService';
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
+import ImageUpload from '@/components/community/ImageUpload';
+import PostFormActions from '@/components/community/PostFormActions';
 
 export default function CompetitionWritePage() {
   const router = useRouter();
@@ -33,14 +34,6 @@ export default function CompetitionWritePage() {
       router.push('/competitions');
     }
   }, [user, loading, router]);
-
-  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      setImageFile(file);
-      setPreview(URL.createObjectURL(file));
-    }
-  };
 
   const handleSubmit = async () => {
     if (!name.trim() || !location.trim() || !eventDate || !applyDeadline) {
@@ -93,35 +86,14 @@ export default function CompetitionWritePage() {
       </div>
 
       {/* 대회 이미지 */}
-      <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
-        <p className="text-sm text-gray-500 mb-2">대회 이미지 (선택)</p>
-        <label className="block cursor-pointer">
-          {preview ? (
-            <div className="relative w-full h-48 rounded-lg overflow-hidden">
-              <Image
-                src={preview}
-                alt="preview"
-                fill
-                className="object-cover"
-              />
-            </div>
-          ) : (
-            <div className="flex flex-col items-center justify-center h-40 bg-gray-50 rounded-lg border-2 border-dashed border-gray-200">
-              <span className="text-3xl mb-2">↑</span>
-              <p className="text-sm text-gray-500">클릭하여 이미지 업로드</p>
-              <p className="text-xs text-gray-400 mt-1">
-                JPG, PNG, GIF (최대 10MB)
-              </p>
-            </div>
-          )}
-          <input
-            type="file"
-            accept="image/*"
-            className="hidden"
-            onChange={handleImageChange}
-          />
-        </label>
-      </div>
+      <ImageUpload
+        preview={preview}
+        label="대회 이미지 (선택)"
+        onChange={(file, previewUrl) => {
+          setImageFile(file);
+          setPreview(previewUrl);
+        }}
+      />
 
       {/* 대회 날짜 */}
       <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
@@ -206,20 +178,11 @@ export default function CompetitionWritePage() {
       </div>
 
       {/* 버튼 */}
-      <div className="flex gap-3">
-        <button
-          onClick={() => router.back()}
-          className="flex-1 py-3 rounded-xl bg-btn-basic border border-gray-300 text-black hover:bg-gray-200 cursor-pointer"
-        >
-          취소
-        </button>
-        <button
-          onClick={handleSubmit}
-          className="flex-3 py-3 rounded-xl bg-black text-white text-sm font-medium cursor-pointer"
-        >
-          추가하기
-        </button>
-      </div>
+      <PostFormActions
+        onCancel={() => router.back()}
+        onSubmit={handleSubmit}
+        submitLabel="추가하기"
+      />
     </div>
   );
 }

--- a/src/components/community/ImageUpload.tsx
+++ b/src/components/community/ImageUpload.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import Image from 'next/image';
+
+interface ImageUploadProps {
+  preview: string | null;
+  onChange: (file: File, previewUrl: string) => void;
+}
+
+export default function ImageUpload({ preview, onChange }: ImageUploadProps) {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      onChange(file, URL.createObjectURL(file));
+    }
+  };
+
+  return (
+    <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
+      <p className="text-sm text-gray-500 mb-2">이미지 (선택)</p>
+      <label className="block cursor-pointer">
+        {preview ? (
+          <div className="relative w-full h-48 rounded-lg overflow-hidden">
+            <Image
+              src={preview}
+              alt="preview"
+              fill={true}
+              className="object-cover"
+            />
+          </div>
+        ) : (
+          <div className="flex flex-col items-center justify-center h-32 bg-gray-50 rounded-lg border-2 border-dashed border-gray-200">
+            <span className="text-2xl mb-1">↑</span>
+            <p className="text-sm text-gray-500">클릭하여 이미지 업로드</p>
+            <p className="text-xs text-gray-400">JPG, PNG, GIF (최대 10MB)</p>
+          </div>
+        )}
+        <input
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={handleChange}
+        />
+      </label>
+    </div>
+  );
+}

--- a/src/components/community/ImageUpload.tsx
+++ b/src/components/community/ImageUpload.tsx
@@ -5,9 +5,14 @@ import Image from 'next/image';
 interface ImageUploadProps {
   preview: string | null;
   onChange: (file: File, previewUrl: string) => void;
+  label?: string;
 }
 
-export default function ImageUpload({ preview, onChange }: ImageUploadProps) {
+export default function ImageUpload({
+  preview,
+  onChange,
+  label = '이미지 (선택)',
+}: ImageUploadProps) {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
@@ -17,7 +22,7 @@ export default function ImageUpload({ preview, onChange }: ImageUploadProps) {
 
   return (
     <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
-      <p className="text-sm text-gray-500 mb-2">이미지 (선택)</p>
+      <p className="text-sm text-gray-500 mb-2">{label}</p>
       <label className="block cursor-pointer">
         {preview ? (
           <div className="relative w-full h-48 rounded-lg overflow-hidden">

--- a/src/components/community/PostDetailCard.tsx
+++ b/src/components/community/PostDetailCard.tsx
@@ -1,0 +1,147 @@
+import { timeAgo } from '@/utils/timeAgo';
+import Image from 'next/image';
+import Link from 'next/link';
+
+export interface PostDetailCardData {
+  nickname: string;
+  avatar_url?: string | null;
+  role?: string | null;
+  created_at: string;
+  title: string;
+  image_url?: string | null;
+  content: string;
+  likeCount: number;
+  commentCount: number;
+  view_count: number;
+}
+
+interface PostDetailCardProps {
+  post: PostDetailCardData;
+  href?: string;
+  headerActions?: React.ReactNode;
+  onLike?: () => void;
+  isLiked?: boolean;
+}
+
+export default function PostDetailCard({
+  post,
+  href,
+  headerActions,
+  onLike,
+  isLiked,
+}: PostDetailCardProps) {
+  const roleBadge =
+    post.role === 'manager'
+      ? { label: '도장', className: 'bg-blue-50 text-blue-600' }
+      : post.role === 'admin'
+        ? { label: '관리자', className: 'bg-red-50 text-red-600' }
+        : { label: '일반', className: 'bg-gray-100 text-gray-600' };
+
+  const card = (
+    <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden">
+      <div className="flex items-center justify-between px-5 pt-5 pb-4">
+        <div className="flex items-center gap-3">
+          <div className="w-10 h-10 rounded-full bg-gray-200 overflow-hidden shrink-0">
+            {post.avatar_url && (
+              <Image
+                src={post.avatar_url}
+                alt={`${post.nickname} 프로필 이미지`}
+                width={40}
+                height={40}
+                className="w-full h-full object-cover"
+              />
+            )}
+          </div>
+          <div>
+            <div className="flex items-center gap-1.5">
+              <span className="text-sm font-semibold text-gray-900">
+                {post.nickname}
+              </span>
+              {post.role && (
+                <span
+                  className={`text-xs px-2 py-0.5 rounded-full font-medium ${roleBadge.className}`}
+                >
+                  {roleBadge.label}
+                </span>
+              )}
+            </div>
+            <p className="text-xs text-gray-400 mt-0.5 flex items-center gap-1">
+              <Image
+                src="/postTime.svg"
+                alt="시간"
+                width={11}
+                height={11}
+                className="opacity-50"
+              />
+              {timeAgo(post.created_at)}
+            </p>
+          </div>
+        </div>
+        {headerActions && (
+          <div className="flex items-center gap-1 [&_button]:cursor-pointer">
+            {headerActions}
+          </div>
+        )}
+      </div>
+
+      <div className="px-5 pb-3">
+        <h1 className="text-lg font-bold text-gray-900">{post.title}</h1>
+      </div>
+
+      {post.image_url && (
+        <div className="px-5 pb-4">
+          <div className="rounded-xl overflow-hidden">
+            <Image
+              src={post.image_url}
+              alt={`${post.title} 게시글 이미지`}
+              width={800}
+              height={400}
+              className="w-full object-cover max-h-72"
+            />
+          </div>
+        </div>
+      )}
+
+      <div className="px-5 pb-5">
+        <p className="text-sm text-gray-700 whitespace-pre-line leading-relaxed">
+          {post.content}
+        </p>
+      </div>
+
+      <div className="px-5 py-3 border-t border-gray-100 flex items-center gap-4">
+        {onLike ? (
+          <button
+            onClick={onLike}
+            aria-pressed={isLiked}
+            aria-label={`좋아요 ${post.likeCount}개`}
+            className="flex items-center gap-1.5 text-xs transition-colors cursor-pointer text-gray-500 hover:text-red-500"
+          >
+            <Image
+              src="/like.svg"
+              alt=""
+              width={16}
+              height={16}
+              aria-hidden="true"
+            />
+            <span>좋아요 {post.likeCount}</span>
+          </button>
+        ) : (
+          <span className="text-xs text-gray-400">좋아요 {post.likeCount}</span>
+        )}
+        <div className="flex items-center gap-1.5 text-xs text-gray-500">
+          <Image src="/postComment.svg" alt="댓글" width={16} height={16} />
+          <span>댓글 {post.commentCount}</span>
+        </div>
+        <span className="text-xs text-gray-500">조회 {post.view_count}</span>
+      </div>
+    </div>
+  );
+
+  return href ? (
+    <Link href={href} className="block">
+      {card}
+    </Link>
+  ) : (
+    card
+  );
+}

--- a/src/components/community/PostDetailCard.tsx
+++ b/src/components/community/PostDetailCard.tsx
@@ -1,4 +1,5 @@
 import { timeAgo } from '@/utils/timeAgo';
+import { Heart } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 
@@ -114,16 +115,15 @@ export default function PostDetailCard({
             onClick={onLike}
             aria-pressed={isLiked}
             aria-label={`좋아요 ${post.likeCount}개`}
-            className="flex items-center gap-1.5 text-xs transition-colors cursor-pointer text-gray-500 hover:text-red-500"
+            className="flex items-center gap-1.5 text-xs transition-colors cursor-pointer"
           >
-            <Image
-              src="/like.svg"
-              alt=""
-              width={16}
-              height={16}
-              aria-hidden="true"
+            <Heart
+              size={16}
+              className={isLiked ? 'fill-danger text-danger' : 'text-gray-500'}
             />
-            <span>좋아요 {post.likeCount}</span>
+            <span className={isLiked ? 'text-danger' : 'text-gray-500'}>
+              좋아요 {post.likeCount}
+            </span>
           </button>
         ) : (
           <span className="text-xs text-gray-400">좋아요 {post.likeCount}</span>

--- a/src/components/community/PostDetailCard.tsx
+++ b/src/components/community/PostDetailCard.tsx
@@ -110,24 +110,22 @@ export default function PostDetailCard({
       </div>
 
       <div className="px-5 py-3 border-t border-gray-100 flex items-center gap-4">
-        {onLike ? (
-          <button
-            onClick={onLike}
-            aria-pressed={isLiked}
-            aria-label={`좋아요 ${post.likeCount}개`}
-            className="flex items-center gap-1.5 text-xs transition-colors cursor-pointer"
-          >
-            <Heart
-              size={16}
-              className={isLiked ? 'fill-danger text-danger' : 'text-gray-500'}
-            />
-            <span className={isLiked ? 'text-danger' : 'text-gray-500'}>
-              좋아요 {post.likeCount}
-            </span>
-          </button>
-        ) : (
-          <span className="text-xs text-gray-400">좋아요 {post.likeCount}</span>
-        )}
+        <button
+          onClick={onLike}
+          disabled={!onLike}
+          aria-pressed={isLiked}
+          aria-label={`좋아요 ${post.likeCount}개`}
+          className="flex items-center gap-1.5 text-xs transition-colors cursor-pointer"
+        >
+          <Heart
+            size={16}
+            className={isLiked ? 'fill-danger text-danger' : 'text-gray-500'}
+          />
+          <span className={isLiked ? 'text-danger' : 'text-gray-500'}>
+            좋아요 {post.likeCount}
+          </span>
+        </button>
+
         <div className="flex items-center gap-1.5 text-xs text-gray-500">
           <Image src="/postComment.svg" alt="댓글" width={16} height={16} />
           <span>댓글 {post.commentCount}</span>

--- a/src/components/community/PostFormActions.tsx
+++ b/src/components/community/PostFormActions.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+interface PostFormActionsProps {
+  onCancel: () => void;
+  onSubmit: () => void;
+  submitLabel: string;
+}
+
+export default function PostFormActions({
+  onCancel,
+  onSubmit,
+  submitLabel,
+}: PostFormActionsProps) {
+  return (
+    <div className="flex gap-3">
+      <button
+        onClick={onCancel}
+        className="flex-1 py-3 rounded-xl bg-btn-basic border border-gray-300 text-black hover:bg-gray-200 cursor-pointer"
+      >
+        취소
+      </button>
+      <button
+        onClick={onSubmit}
+        className="flex-3 py-3 rounded-xl bg-black text-white text-sm font-medium cursor-pointer"
+      >
+        {submitLabel}
+      </button>
+    </div>
+  );
+}

--- a/src/components/community/Postcard.tsx
+++ b/src/components/community/Postcard.tsx
@@ -1,128 +1,166 @@
 'use client';
 
-import Image from 'next/image';
-import Link from 'next/link';
-import { useLike } from '@/hooks/useLike';
-import { formatDate } from '@/utils/formatDate';
-import { Heart, MessageCircle } from 'lucide-react';
+import { useState, useRef, useEffect, startTransition, useMemo } from 'react';
+import Pageheader from '@/components/layout/PageHeader';
+import Postcard from '@/components/community/Postcard';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+import { useDebounce } from '@/hooks/useDebounce';
+import { usePosts } from '@/hooks/useCommunity';
+import { useAuth } from '@/hooks/useAuth';
+import type { Post } from '@/types/community';
 
-interface PostCardProps {
-  post: {
-    id: string;
-    title: string;
-    content: string;
-    category: string;
-    nickname: string;
-    avatar_url: string;
-    image_url: string;
-    view_count: number;
-    created_at: string;
-    comment_count: number;
-  };
-  userId: string;
+const PAGE_SIZE = 10;
+
+interface CommunityClientProps {
+  initialPosts: Post[];
 }
 
-const categoryMap: Record<string, { label: string; color: string }> = {
-  promo: { label: '도장', color: 'bg-[#155DFC]' },
-  notice: { label: '공지', color: 'bg-[#e7000b]' },
-  personal: { label: '일반', color: 'bg-[#364153]' },
-};
+export default function CommunityClient({
+  initialPosts,
+}: CommunityClientProps) {
+  const [activeTab, setActiveTab] = useState('전체');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [page, setPage] = useState(1);
 
-export default function PostCard({ post, userId }: PostCardProps) {
-  const { likeCount, isLiked, toggle } = useLike(post.id, userId);
-  const categoryInfo = categoryMap[post.category] ?? categoryMap.personal;
+  useEffect(() => {
+    const saved = sessionStorage.getItem('communityPage');
+    if (saved) {
+      startTransition(() => {
+        setPage(parseInt(saved));
+      });
+    }
+  }, []);
 
-  const handleLike = (e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    if (!userId) return;
-    toggle();
-  };
+  const [headerHeight, setHeaderHeight] = useState(160);
+  const headerRef = useRef<HTMLDivElement>(null);
+  const isScrollRestoredRef = useRef(false);
+
+  const debouncedSearch = useDebounce(searchQuery, 300);
+  const { user, loading } = useAuth();
+  const { data: posts = initialPosts } = usePosts();
+
+  useEffect(() => {
+    if (headerRef.current) {
+      setHeaderHeight(headerRef.current.offsetHeight);
+    }
+  }, []);
+
+  useEffect(() => {
+    sessionStorage.setItem('communityPage', page.toString());
+  }, [page]);
+
+  const filteredPosts = useMemo(() => {
+    return posts.filter((post) => {
+      const matchTab =
+        activeTab === '전체' ||
+        (activeTab === '공지' && post.category === 'notice') ||
+        (activeTab === '도장 홍보' && post.category === 'promo') ||
+        (activeTab === '일반 게시글' && post.category === 'personal');
+      const matchSearch = post.title
+        .toLowerCase()
+        .includes(debouncedSearch.toLowerCase());
+      return matchTab && matchSearch;
+    });
+  }, [posts, activeTab, debouncedSearch]);
+
+  const visiblePosts = filteredPosts.slice(0, page * PAGE_SIZE);
+  const hasMore = visiblePosts.length < filteredPosts.length;
+
+  useEffect(() => {
+    const lastPostId = sessionStorage.getItem('lastPostId');
+    if (isScrollRestoredRef.current || !lastPostId) return;
+    if (visiblePosts.length > 0) {
+      const timer = setTimeout(() => {
+        const el = document.getElementById(lastPostId);
+        if (el) {
+          el.scrollIntoView({ block: 'center', behavior: 'instant' });
+          sessionStorage.removeItem('lastPostId');
+          isScrollRestoredRef.current = true;
+        }
+      }, 100);
+      return () => clearTimeout(timer);
+    }
+  }, [visiblePosts]);
+
+  const observerRef = useInfiniteScroll(() => {
+    if (hasMore) {
+      startTransition(() => {
+        setPage((prev) => prev + 1);
+      });
+    }
+  });
 
   return (
-    <Link href={`/community/${post.id}`} className="block w-full">
-      <div className="rounded-lg overflow-hidden border bg-bg-white border-gray-200 flex flex-col h-97.5 cursor-pointer hover:shadow-lg hover:-translate-y-1 transition-all duration-200">
-        {/* 이미지 영역 */}
-        <div className="relative w-full h-50 bg-btn-basic shrink-0">
-          {post.image_url ? (
-            <Image
-              src={post.image_url}
-              alt={post.title}
-              fill
-              sizes="(max-width: 768px) 100vw, 50vw"
-              loading="eager"
-              className="object-cover"
-            />
-          ) : (
-            <div className="w-full h-full flex items-center justify-center">
-              <span className="text-text-secondary text-sm">이미지 없음</span>
-            </div>
-          )}
-          <span
-            className={`absolute top-2 right-2 px-2 py-1 text-xs text-white rounded-full ${categoryInfo.color}`}
-          >
-            {categoryInfo.label}
-          </span>
-        </div>
-
-        {/* 카드 내용 */}
-        <div className="p-4 flex flex-col gap-2 flex-1 overflow-hidden">
-          <h2 className="font-bold text-base line-clamp-1">{post.title}</h2>
-          <p className="text-sm text-text-secondary line-clamp-2">
-            {post.content}
-          </p>
-
-          <div className="flex-1" />
-
-          {/* 날짜 + 조회수 + 댓글수 */}
-          <div className="flex gap-3 text-xs text-text-secondary items-center">
-            <span>{formatDate(post.created_at)}</span>
-            <span>조회 {post.view_count}</span>
-            <span className="flex items-center gap-1">
-              <MessageCircle size={12} />
-              <span className="translate-y-px">{post.comment_count ?? 0}</span>
-            </span>
-          </div>
-
-          <div className="border-t border-gray-200" />
-
-          {/* 프로필 + 좋아요 */}
-          <div className="flex items-center justify-between pt-2">
-            <div className="flex items-center gap-2">
-              <div className="relative w-6 h-6 shrink-0">
-                <Image
-                  src={post.avatar_url || '/basic.svg'}
-                  alt={post.nickname}
-                  fill
-                  sizes="24px"
-                  className="rounded-full object-cover"
-                />
-              </div>
-              <span className="text-sm">{post.nickname}</span>
-            </div>
-
-            {/* 좋아요 버튼 */}
-            <div className="w-12 flex items-center justify-end">
-              <button
-                onClick={handleLike}
-                className="flex items-center gap-1 transition-all duration-200"
-              >
-                <Heart
-                  size={16}
-                  className={
-                    isLiked ? 'fill-danger text-danger' : 'text-text-secondary'
-                  }
-                />
-                <span
-                  className={`text-sm w-2 text-right ${isLiked ? 'text-danger' : 'text-text-secondary'}`}
-                >
-                  {likeCount}
-                </span>
-              </button>
-            </div>
-          </div>
+    <main className="w-full min-h-screen">
+      <div
+        ref={headerRef}
+        className="fixed top-0 left-50 right-0 z-10 bg-white shadow-sm flex justify-center"
+      >
+        <div className="w-full max-w-7xl px-6">
+          <Pageheader
+            title="커뮤니티"
+            description="주짓수에 대한 모든 이야기"
+            tabs={['전체', '공지', '도장 홍보', '일반 게시글']}
+            activeTab={activeTab}
+            setActiveTab={(tab) => {
+              setActiveTab(tab);
+              setPage(1);
+              window.scrollTo(0, 0);
+            }}
+            searchQuery={searchQuery}
+            setSearchQuery={(query) => {
+              setSearchQuery(query);
+              setPage(1);
+            }}
+            writeLink={
+              loading ? undefined : user ? '/community/write' : undefined
+            }
+          />
         </div>
       </div>
-    </Link>
+
+      <div
+        style={{ paddingTop: `${headerHeight + 24}px` }}
+        className="pb-20 flex justify-center"
+      >
+        <div className="w-full max-w-7xl px-6">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {visiblePosts.length > 0 ? (
+              visiblePosts.map((post) => (
+                <div
+                  key={post.id}
+                  id={post.id}
+                  onClick={() => sessionStorage.setItem('lastPostId', post.id)}
+                >
+                  <Postcard
+                    post={{
+                      ...post,
+                      nickname: post.nickname ?? '알 수 없음',
+                      avatar_url: post.avatar_url ?? '',
+                      image_url: post.image_url ?? '',
+                    }}
+                    userId={user?.id ?? ''}
+                  />
+                </div>
+              ))
+            ) : (
+              <div className="col-span-full flex flex-col items-center justify-center py-40 text-gray-400 font-light">
+                <p className="text-lg">조건에 맞는 게시글이 없습니다</p>
+                <p className="text-sm mt-2">새로운 소식을 들려주세요!</p>
+              </div>
+            )}
+          </div>
+
+          {hasMore && (
+            <div
+              ref={observerRef}
+              className="h-20 flex items-center justify-center"
+            >
+              <div className="w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+            </div>
+          )}
+        </div>
+      </div>
+    </main>
   );
 }

--- a/src/components/community/Postcard.tsx
+++ b/src/components/community/Postcard.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useLike } from '@/hooks/useLike';
 import { formatDate } from '@/utils/formatDate';
 import { Heart, MessageCircle } from 'lucide-react';
+import { showErrorToast } from '@/lib/toast';
 
 interface PostCardProps {
   post: {
@@ -35,7 +36,10 @@ export default function PostCard({ post, userId }: PostCardProps) {
   const handleLike = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    if (!userId) return;
+    if (!userId) {
+      showErrorToast('로그인이 필요합니다');
+      return;
+    }
     toggle();
   };
 
@@ -105,7 +109,7 @@ export default function PostCard({ post, userId }: PostCardProps) {
             <div className="w-12 flex items-center justify-end">
               <button
                 onClick={handleLike}
-                className="flex items-center gap-1 transition-all duration-200"
+                className="flex items-center gap-1 transition-all duration-200 cursor-pointer"
               >
                 <Heart
                   size={16}

--- a/src/components/community/Postcard.tsx
+++ b/src/components/community/Postcard.tsx
@@ -1,155 +1,105 @@
 'use client';
 
-import { useState, useRef, useEffect, startTransition, useMemo } from 'react';
-import Pageheader from '@/components/layout/PageHeader';
-import Postcard from '@/components/community/Postcard';
-import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
-import { useDebounce } from '@/hooks/useDebounce';
-import { usePosts } from '@/hooks/useCommunity';
-import { useAuth } from '@/hooks/useAuth';
-import type { Post } from '@/types/community';
+import Image from 'next/image';
+import Link from 'next/link';
+import { useLike } from '@/hooks/useLike';
+import { formatDate } from '@/utils/formatDate';
+import { Heart, MessageCircle } from 'lucide-react';
 
-const PAGE_SIZE = 10;
-
-interface CommunityClientProps {
-  initialPosts: Post[];
+interface PostCardProps {
+  post: {
+    id: string;
+    title: string;
+    content: string;
+    category: string;
+    nickname: string;
+    avatar_url: string;
+    image_url: string;
+    view_count: number;
+    created_at: string;
+    comment_count: number;
+  };
+  userId: string;
 }
 
-export default function CommunityClient({
-  initialPosts,
-}: CommunityClientProps) {
-  const [activeTab, setActiveTab] = useState('전체');
-  const [searchQuery, setSearchQuery] = useState('');
-  const [page, setPage] = useState(1);
+const categoryMap: Record<string, { label: string; color: string }> = {
+  promo: { label: '도장', color: 'bg-[#155DFC]' },
+  notice: { label: '공지', color: 'bg-[#e7000b]' },
+  personal: { label: '일반', color: 'bg-[#364153]' },
+};
 
-  useEffect(() => {
-    const saved = sessionStorage.getItem('communityPage');
-    if (saved) {
-      startTransition(() => {
-        setPage(parseInt(saved));
-      });
-    }
-  }, []);
+export default function PostCard({ post, userId }: PostCardProps) {
+  const { likeCount, isLiked, toggle } = useLike(post.id, userId);
+  const categoryInfo = categoryMap[post.category] ?? categoryMap.personal;
 
-  const [headerHeight, setHeaderHeight] = useState(160);
-  const headerRef = useRef<HTMLDivElement>(null);
-  const isScrollRestoredRef = useRef(false);
-
-  const debouncedSearch = useDebounce(searchQuery, 300);
-  const { user, loading } = useAuth();
-  const { data: posts = initialPosts } = usePosts();
-
-  useEffect(() => {
-    if (headerRef.current) {
-      setHeaderHeight(headerRef.current.offsetHeight);
-    }
-  }, []);
-
-  useEffect(() => {
-    sessionStorage.setItem('communityPage', page.toString());
-  }, [page]);
-
-  const filteredPosts = useMemo(() => {
-    return posts.filter((post) => {
-      const matchTab =
-        activeTab === '전체' ||
-        (activeTab === '공지' && post.category === 'notice') ||
-        (activeTab === '도장 홍보' && post.category === 'promo') ||
-        (activeTab === '일반 게시글' && post.category === 'personal');
-      const matchSearch = post.title
-        .toLowerCase()
-        .includes(debouncedSearch.toLowerCase());
-      return matchTab && matchSearch;
-    });
-  }, [posts, activeTab, debouncedSearch]);
-
-  const visiblePosts = filteredPosts.slice(0, page * PAGE_SIZE);
-  const hasMore = visiblePosts.length < filteredPosts.length;
-
-  useEffect(() => {
-    const lastPostId = sessionStorage.getItem('lastPostId');
-    if (isScrollRestoredRef.current || !lastPostId) return;
-    if (visiblePosts.length > 0) {
-      const timer = setTimeout(() => {
-        const el = document.getElementById(lastPostId);
-        if (el) {
-          el.scrollIntoView({ block: 'center', behavior: 'instant' });
-          sessionStorage.removeItem('lastPostId');
-          isScrollRestoredRef.current = true;
-        }
-      }, 100);
-      return () => clearTimeout(timer);
-    }
-  }, [visiblePosts]);
-
-  const observerRef = useInfiniteScroll(() => {
-    if (hasMore) {
-      startTransition(() => {
-        setPage((prev) => prev + 1);
-      });
-    }
-  });
+  const handleLike = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!userId) return;
+    toggle();
+  };
 
   return (
-    <main className="w-full min-h-screen">
-      <div
-        ref={headerRef}
-        className="fixed top-0 left-50 right-0 z-10 bg-white shadow-sm flex justify-center"
-      >
-        <div className="w-full max-w-7xl px-6">
-          <Pageheader
-            title="커뮤니티"
-            description="주짓수에 대한 모든 이야기"
-            tabs={['전체', '공지', '도장 홍보', '일반 게시글']}
-            activeTab={activeTab}
-            setActiveTab={(tab) => {
-              setActiveTab(tab);
-              setPage(1);
-              window.scrollTo(0, 0);
-            }}
-            searchQuery={searchQuery}
-            setSearchQuery={(query) => {
-              setSearchQuery(query);
-              setPage(1);
-            }}
-            writeLink={
-              loading ? undefined : user ? '/community/write' : undefined
-            }
-          />
+    <Link href={`/community/${post.id}`} className="block w-full">
+      <div className="rounded-lg overflow-hidden border bg-bg-white border-gray-200 flex flex-col h-97.5 cursor-pointer hover:shadow-lg hover:-translate-y-1 transition-all duration-200">
+        {/* 이미지 영역 */}
+        <div className="relative w-full h-50 bg-btn-basic shrink-0">
+          {post.image_url ? (
+            <Image
+              src={post.image_url}
+              alt={post.title}
+              fill
+              sizes="(max-width: 768px) 100vw, 50vw"
+              loading="eager"
+              className="object-cover"
+            />
+          ) : (
+            <div className="w-full h-full flex items-center justify-center">
+              <span className="text-text-secondary text-sm">이미지 없음</span>
+            </div>
+          )}
+          <span
+            className={`absolute top-2 right-2 px-2 py-1 text-xs text-white rounded-full ${categoryInfo.color}`}
+          >
+            {categoryInfo.label}
+          </span>
         </div>
-      </div>
 
-      <div
-        style={{ paddingTop: `${headerHeight + 24}px` }}
-        className="pb-20 flex justify-center"
-      >
-        <div className="w-full max-w-7xl px-6">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            {visiblePosts.length > 0 ? (
-              visiblePosts.map((post) => (
-                <div
-                  key={post.id}
-                  id={post.id}
-                  onClick={() => sessionStorage.setItem('lastPostId', post.id)}
-                >
-                  <Postcard
-                    post={{
-                      ...post,
-                      nickname: post.nickname ?? '알 수 없음',
-                      avatar_url: post.avatar_url ?? '',
-                      image_url: post.image_url ?? '',
-                    }}
-                    userId={user?.id ?? ''}
-                  />
-                </div>
-              ))
-            ) : (
-              <div className="col-span-full flex flex-col items-center justify-center py-40 text-gray-400 font-light">
-                <p className="text-lg">조건에 맞는 게시글이 없습니다</p>
-                <p className="text-sm mt-2">새로운 소식을 들려주세요!</p>
-              </div>
-            )}
+        {/* 카드 내용 */}
+        <div className="p-4 flex flex-col gap-2 flex-1 overflow-hidden">
+          <h2 className="font-bold text-base line-clamp-1">{post.title}</h2>
+          <p className="text-sm text-text-secondary line-clamp-2">
+            {post.content}
+          </p>
+
+          <div className="flex-1" />
+
+          {/* 날짜 + 조회수 + 댓글수 */}
+          <div className="flex gap-3 text-xs text-text-secondary items-center">
+            <span>{formatDate(post.created_at)}</span>
+            <span>조회 {post.view_count}</span>
+            <span className="flex items-center gap-1">
+              <MessageCircle size={12} />
+              <span className="translate-y-px">{post.comment_count ?? 0}</span>
+            </span>
           </div>
+
+          <div className="border-t border-gray-200" />
+
+          {/* 프로필 + 좋아요 */}
+          <div className="flex items-center justify-between pt-2">
+            <div className="flex items-center gap-2">
+              <div className="relative w-6 h-6 shrink-0">
+                <Image
+                  src={post.avatar_url || '/basic.svg'}
+                  alt={post.nickname}
+                  fill
+                  sizes="24px"
+                  className="rounded-full object-cover"
+                />
+              </div>
+              <span className="text-sm">{post.nickname}</span>
+            </div>
 
             {/* 좋아요 버튼 */}
             <div className="w-12 flex items-center justify-end">
@@ -170,9 +120,9 @@ export default function CommunityClient({
                 </span>
               </button>
             </div>
-          )}
+          </div>
         </div>
       </div>
-    </main>
+    </Link>
   );
 }

--- a/src/utils/timeAgo.ts
+++ b/src/utils/timeAgo.ts
@@ -1,0 +1,8 @@
+export function timeAgo(dateStr: string) {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const min = Math.floor(diff / 60000);
+  if (min < 60) return `${min}분 전`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}시간 전`;
+  return `${Math.floor(hr / 24)}일 전`;
+}


### PR DESCRIPTION
## 📌 개요
커뮤니티 및 대회 페이지의 반복되는 UI를 공통 컴포넌트로 분리하고, 관련 페이지에 적용했습니다. 
좋아요 토글 UI 및 댓글 유효성 검사도 함께 개선했습니다.

---

## 💻 작업 사항
공통 컴포넌트 추출

ImageUpload — 이미지 업로드 UI 컴포넌트 추출, label prop으로 라벨 커스텀 가능 (기본값: 이미지 (선택))
PostFormActions — 취소/제출 버튼 쌍 컴포넌트 추출, submitLabel prop으로 버튼 텍스트 커스텀 가능
PostDetailCard — 게시글 카드 UI 컴포넌트 추출, headerActions 슬롯으로 수정·삭제·신고·공유 버튼 주입, `onLike` prop 유무로 좋아요 버튼 활성화/비활성화 전환, 아이콘은 항상 표시

---

페이지 적용

community/write/page.tsx — ImageUpload, PostFormActions, PostDetailCard(미리보기) 적용
community/[id]/edit/page.tsx — ImageUpload, PostFormActions 적용
community/[id]/page.tsx — PostDetailCard 적용
competitions/write/page.tsx — ImageUpload, PostFormActions 적용

---

기능 개선

좋아요 토글 시 Heart 아이콘(lucide-react) 으로 교체, isLiked 상태에 따라 fill-danger text-danger 토글 — PostCard와 동일한 스타일로 통일
댓글 빈값 제출 시 '댓글을 입력해주세요.' 에러 토스트 추가

---

기타 수정

PostDetailCard 헤더 액션 버튼에 [&_button]:cursor-pointer 공통 적용
게시글 미리보기 카드와 하단 버튼 사이 여백(mb-6) 추가
게시글 미리보기 role 뱃지 버그 수정 — category === 'promo'일 때만 manager, 나머지는 null
competitions/write/page.tsx에서 불필요한 Image import 제거

## 💡 관련 Issue

Closes #74 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #74 )
- [x] 불필요한 console.log를 제거했습니다.
- [x] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
