### PR TITLE
[feat] 대회일정 추가에서 미리보기 구현

### DIFF
--- a/src/app/(main)/competitions/write/page.tsx
+++ b/src/app/(main)/competitions/write/page.tsx
@@ -11,10 +11,12 @@ import {
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
 import ImageUpload from '@/components/community/ImageUpload';
 import PostFormActions from '@/components/community/PostFormActions';
+import CompetitionCard from '@/components/competition/CompetitionCard';
 
 export default function CompetitionWritePage() {
   const router = useRouter();
   const { user, loading } = useAuth();
+  const [tab, setTab] = useState<'write' | 'preview'>('write');
   const [name, setName] = useState('');
   const [location, setLocation] = useState('');
   const [eventDate, setEventDate] = useState('');
@@ -73,109 +75,161 @@ export default function CompetitionWritePage() {
         <h1 className="text-lg font-semibold">대회 추가</h1>
       </div>
 
-      {/* 대회 제목 */}
-      <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
-        <p className="text-sm text-gray-500 mb-2">대회 제목</p>
-        <input
-          type="text"
-          placeholder="예: 2026 서울 주짓수 챔피언십"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          className="w-full bg-gray-50 rounded-lg px-3 py-2 text-sm outline-none"
-        />
+      {/* 탭 */}
+      <div className="flex bg-gray-100 rounded-xl p-1 mb-6">
+        <button
+          onClick={() => setTab('write')}
+          className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
+            tab === 'write' ? 'bg-white text-black shadow-sm' : 'text-gray-500'
+          }`}
+        >
+          작성
+        </button>
+        <button
+          onClick={() => setTab('preview')}
+          className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
+            tab === 'preview'
+              ? 'bg-white text-black shadow-sm'
+              : 'text-gray-500'
+          }`}
+        >
+          미리보기
+        </button>
       </div>
 
-      {/* 대회 이미지 */}
-      <ImageUpload
-        preview={preview}
-        label="대회 이미지 (선택)"
-        onChange={(file, previewUrl) => {
-          setImageFile(file);
-          setPreview(previewUrl);
-        }}
-      />
+      {/* 작성 탭 */}
+      {tab === 'write' && (
+        <>
+          {/* 대회 제목 */}
+          <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
+            <p className="text-sm text-gray-500 mb-2">대회 제목</p>
+            <input
+              type="text"
+              placeholder="예: 2026 서울 주짓수 챔피언십"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="w-full bg-gray-50 rounded-lg px-3 py-2 text-sm outline-none"
+            />
+          </div>
 
-      {/* 대회 날짜 */}
-      <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
-        <p className="text-sm text-gray-500 mb-2">대회 날짜</p>
-        <div className="relative">
-          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
-            📅
-          </span>
-          <input
-            type="date"
-            value={eventDate}
-            min={today}
-            onChange={(e) => setEventDate(e.target.value)}
-            onClick={(e) => (e.target as HTMLInputElement).showPicker?.()}
-            className="w-full bg-gray-50 rounded-lg pl-9 pr-3 py-2 text-sm outline-none text-gray-700 cursor-pointer"
+          {/* 대회 이미지 */}
+          <ImageUpload
+            preview={preview}
+            label="대회 이미지 (선택)"
+            onChange={(file, previewUrl) => {
+              setImageFile(file);
+              setPreview(previewUrl);
+            }}
           />
-        </div>
-      </div>
 
-      {/* 신청 마감 날짜 */}
-      <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
-        <p className="text-sm text-gray-500 mb-2">신청 마감 날짜</p>
-        <div className="relative">
-          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
-            📅
-          </span>
-          <input
-            type="date"
-            value={applyDeadline}
-            min={today}
-            onChange={(e) => setApplyDeadline(e.target.value)}
-            onClick={(e) => (e.target as HTMLInputElement).showPicker?.()}
-            className="w-full bg-gray-50 rounded-lg pl-9 pr-3 py-2 text-sm outline-none text-gray-700 cursor-pointer"
-          />
-        </div>
-      </div>
+          {/* 대회 날짜 */}
+          <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
+            <p className="text-sm text-gray-500 mb-2">대회 날짜</p>
+            <div className="relative">
+              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
+                📅
+              </span>
+              <input
+                type="date"
+                value={eventDate}
+                min={today}
+                onChange={(e) => setEventDate(e.target.value)}
+                onClick={(e) => (e.target as HTMLInputElement).showPicker?.()}
+                className="w-full bg-gray-50 rounded-lg pl-9 pr-3 py-2 text-sm outline-none text-gray-700 cursor-pointer"
+              />
+            </div>
+          </div>
 
-      {/* 대회 장소 */}
-      <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
-        <p className="text-sm text-gray-500 mb-2">대회 장소</p>
-        <div className="relative">
-          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
-            📍
-          </span>
-          <input
-            type="text"
-            placeholder="예: 잠실 체육관"
-            value={location}
-            onChange={(e) => setLocation(e.target.value)}
-            className="w-full bg-gray-50 rounded-lg pl-9 pr-3 py-2 text-sm outline-none"
-          />
-        </div>
-      </div>
+          {/* 신청 마감 날짜 */}
+          <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
+            <p className="text-sm text-gray-500 mb-2">신청 마감 날짜</p>
+            <div className="relative">
+              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
+                📅
+              </span>
+              <input
+                type="date"
+                value={applyDeadline}
+                min={today}
+                onChange={(e) => setApplyDeadline(e.target.value)}
+                onClick={(e) => (e.target as HTMLInputElement).showPicker?.()}
+                className="w-full bg-gray-50 rounded-lg pl-9 pr-3 py-2 text-sm outline-none text-gray-700 cursor-pointer"
+              />
+            </div>
+          </div>
 
-      {/* 참가 신청 링크 */}
-      <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
-        <p className="text-sm text-gray-500 mb-2">참가 신청 링크</p>
-        <div className="relative">
-          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
-            🔗
-          </span>
-          <input
-            type="url"
-            placeholder="https://example.com/register"
-            value={applyUrl}
-            onChange={(e) => setApplyUrl(e.target.value)}
-            className="w-full bg-gray-50 rounded-lg pl-9 pr-3 py-2 text-sm outline-none"
-          />
-        </div>
-      </div>
+          {/* 대회 장소 */}
+          <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
+            <p className="text-sm text-gray-500 mb-2">대회 장소</p>
+            <div className="relative">
+              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
+                📍
+              </span>
+              <input
+                type="text"
+                placeholder="예: 잠실 체육관"
+                value={location}
+                onChange={(e) => setLocation(e.target.value)}
+                className="w-full bg-gray-50 rounded-lg pl-9 pr-3 py-2 text-sm outline-none"
+              />
+            </div>
+          </div>
 
-      {/* 대회 설명 */}
-      <div className="bg-white rounded-xl p-4 mb-6 shadow-sm">
-        <p className="text-sm text-gray-500 mb-2">대회 설명</p>
-        <textarea
-          placeholder="대회에 대한 상세 설명을 입력하세요"
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
-          rows={6}
-          className="w-full bg-gray-50 rounded-lg px-3 py-2 text-sm outline-none resize-none"
-        />
-      </div>
+          {/* 참가 신청 링크 */}
+          <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
+            <p className="text-sm text-gray-500 mb-2">참가 신청 링크</p>
+            <div className="relative">
+              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
+                🔗
+              </span>
+              <input
+                type="url"
+                placeholder="https://example.com/register"
+                value={applyUrl}
+                onChange={(e) => setApplyUrl(e.target.value)}
+                className="w-full bg-gray-50 rounded-lg pl-9 pr-3 py-2 text-sm outline-none"
+              />
+            </div>
+          </div>
+
+          {/* 대회 설명 */}
+          <div className="bg-white rounded-xl p-4 mb-6 shadow-sm">
+            <p className="text-sm text-gray-500 mb-2">대회 설명</p>
+            <textarea
+              placeholder="대회에 대한 상세 설명을 입력하세요"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={6}
+              className="w-full bg-gray-50 rounded-lg px-3 py-2 text-sm outline-none resize-none"
+            />
+          </div>
+        </>
+      )}
+
+      {/* 미리보기 탭 */}
+      {tab === 'preview' &&
+        (!name && !description ? (
+          <div className="flex flex-col items-center justify-center py-16 text-gray-400 mb-6">
+            <p className="text-sm">작성 탭에서 내용을 입력하면</p>
+            <p className="text-sm">여기서 미리볼 수 있어요.</p>
+          </div>
+        ) : (
+          <div className="mb-6">
+            <CompetitionCard
+              competition={{
+                id: 'preview',
+                name,
+                description,
+                image_url: preview ?? '',
+                event_data: eventDate,
+                apply_deadline: applyDeadline,
+                location,
+                participants: 0,
+                apply_url: applyUrl,
+              }}
+            />
+          </div>
+        ))}
 
       {/* 버튼 */}
       <PostFormActions


### PR DESCRIPTION
## 📌 개요

- 대회 일정 추가 페이지에 미리보기 기능을 추가했습니다.

## 💻 작업 사항

기능 추가
- competitions/write/page.tsx — 작성/미리보기 탭 추가, CompetitionCard를 활용해 입력한 내용을 실시간으로 미리볼 수 있도록 구현
- 미리보기 시 participants, id 등 DB 데이터가 필요한 필드는 더미값(0, 'preview')으로 처리

알려진 이슈
- 한글 입력 중 IME 조합이 완료되지 않은 상태(자음/모음만 입력한 상태)에서 미리보기 탭을 클릭하면 스크롤이 순간적으로 튀는 현상이 있습니다.
- 원인: 
  - 한글은 자음/모음이 조합되는 동안 브라우저 IME가 조합 중인 글자를 관리하는데, 탭 버튼 클릭 시 setTab으로 인한 리렌더링이 발생하면서 IME 조합 완료 이벤트와 충돌합니다. 
  - 이때 콘텐츠 높이가 변경되면서 브라우저가 스크롤 위치를 재계산해 튀는 현상이 발생합니다. 
  - window 기반 스크롤 구조와 폼이 길어 스크롤이 생기는 화면 크기에서만 나타납니다.
- 해결 방법: 마침표, 띄어쓰기 등으로 한글 조합을 완료한 후 탭을 전환하면 정상 동작합니다.
<img width="752" height="876" alt="20260507-0411-21 9503461" src="https://github.com/user-attachments/assets/e9549d47-8abe-4328-9e92-1e4651dd1a03" />


## 💡 관련 Issue

Closes #94 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #94 )
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
