### PR TITLE
[Refactor] 게시글 페이지 서버/클라이언트 분리(SSR 방식)

### DIFF
--- a/src/app/(main)/community/[id]/edit/page.tsx
+++ b/src/app/(main)/community/[id]/edit/page.tsx
@@ -1,125 +1,40 @@
-'use client';
+import EditClient from '@/components/community/EditClient';
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+import { getPost } from '@/services/communityService';
+import { notFound, redirect } from 'next/navigation';
 
-import { useQueryClient } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import type { PostCategory } from '@/types/community';
-import LoadingSpinner from '@/components/common/LoadingSpinner';
-import { use } from 'react';
-import {
-  getPost,
-  updatePost,
-  uploadPostImage,
-} from '@/services/communityService';
-import { showErrorToast, showSuccessToast } from '@/lib/toast';
-import ImageUpload from '@/components/community/ImageUpload';
-import PostFormActions from '@/components/community/PostFormActions';
+async function getInitialData(id: string) {
+  const cookieStore = await cookies();
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { cookies: { getAll: () => cookieStore.getAll() } },
+  );
 
-export default function EditPage({
+  const [
+    post,
+    {
+      data: { user },
+    },
+  ] = await Promise.all([getPost(id), supabase.auth.getUser()]);
+
+  if (!user) redirect('/login');
+  if (!post) notFound();
+
+  // 본인 게시글만 수정 가능
+  if (post.user_id !== user.id) redirect(`/community/${id}`);
+
+  return { post };
+}
+
+export default async function EditPage({
   params,
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const { id } = use(params);
-  const router = useRouter();
-  const [title, setTitle] = useState('');
-  const [content, setContent] = useState('');
-  const [category, setCategory] = useState<PostCategory>('personal');
-  const [preview, setPreview] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [imageFile, setImageFile] = useState<File | null>(null);
-  const queryClient = useQueryClient();
+  const { id } = await params;
+  const { post } = await getInitialData(id);
 
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const post = await getPost(id);
-        setTitle(post.title);
-        setContent(post.content);
-        setCategory(post.category);
-        if (post.image_url) setPreview(post.image_url);
-      } catch (e) {
-        console.error(e);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-    load();
-  }, [id]);
-
-  const handleSubmit = async () => {
-    if (!title.trim() || !content.trim()) {
-      showErrorToast('제목과 내용을 모두 입력해주세요.');
-      return;
-    }
-    try {
-      let image_url: string | undefined;
-      if (imageFile) {
-        image_url = await uploadPostImage(imageFile);
-      }
-      await updatePost(id, { title, content, image_url });
-      queryClient.invalidateQueries({ queryKey: ['posts'] });
-      showSuccessToast('게시글이 수정되었습니다.', '✅');
-      router.push(`/community/${id}`);
-    } catch {
-      showErrorToast('게시글 수정에 실패했습니다.');
-    }
-  };
-
-  if (isLoading) return <LoadingSpinner />;
-
-  return (
-    <div className="max-w-5xl mx-auto p-6">
-      <div className="w-full flex items-center mb-6">
-        <h1 className="text-lg font-semibold mx-auto">게시글 수정</h1>
-      </div>
-
-      <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
-        <p className="text-sm text-gray-500 mb-2">게시글 유형</p>
-        <div className="py-2 px-3 rounded-lg text-sm font-medium bg-black text-white text-center">
-          {category === 'promo'
-            ? '도장 홍보'
-            : category === 'notice'
-              ? '공지'
-              : '일반 게시글'}
-        </div>
-      </div>
-
-      <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
-        <p className="text-sm text-gray-500 mb-2">제목</p>
-        <input
-          type="text"
-          placeholder="제목을 입력하세요"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          className="w-full bg-gray-50 rounded-lg px-3 py-2 text-sm outline-none"
-        />
-      </div>
-
-      <ImageUpload
-        preview={preview}
-        onChange={(file, previewUrl) => {
-          setImageFile(file);
-          setPreview(previewUrl);
-        }}
-      />
-
-      <div className="bg-white rounded-xl p-4 mb-6 shadow-sm">
-        <p className="text-sm text-gray-500 mb-2">내용</p>
-        <textarea
-          placeholder="내용을 입력하세요"
-          value={content}
-          onChange={(e) => setContent(e.target.value)}
-          rows={8}
-          className="w-full bg-gray-50 rounded-lg px-3 py-2 text-sm outline-none resize-none"
-        />
-      </div>
-
-      <PostFormActions
-        onCancel={() => router.back()}
-        onSubmit={handleSubmit}
-        submitLabel="수정하기"
-      />
-    </div>
-  );
+  return <EditClient id={id} initialPost={post} />;
 }

--- a/src/app/(main)/community/[id]/page.tsx
+++ b/src/app/(main)/community/[id]/page.tsx
@@ -1,439 +1,55 @@
-'use client';
-
-import { useQueryClient } from '@tanstack/react-query';
-import { use, useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
+// 서버 컴포넌트
+import PostDetailClient from '@/components/community/PostDetailClient';
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
 import {
   getPost,
   getComments,
-  createComment,
-  deletePost,
-  deleteComment,
   incrementViewCount,
 } from '@/services/communityService';
-import { reportPost, ReportReason } from '@/services/reportService';
-import { supabase } from '@/lib/supabase';
-import type { Post, Comment } from '@/types/community';
-import Image from 'next/image';
-import LoadingSpinner from '@/components/common/LoadingSpinner';
-import { useAuth } from '@/hooks/useAuth';
-import { useLike } from '@/hooks/useLike';
-import { showErrorToast, showSuccessToast } from '@/lib/toast';
-import ReportModal from '@/components/community/ReportModal';
-import PostDetailCard, {
-  PostDetailCardData,
-} from '@/components/community/PostDetailCard';
-import { timeAgo } from '@/utils/timeAgo';
+import { notFound } from 'next/navigation';
 
-export default function PostDetailPage({
+async function getInitialData(id: string) {
+  const cookieStore = await cookies();
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { cookies: { getAll: () => cookieStore.getAll() } },
+  );
+
+  const [
+    post,
+    comments,
+    {
+      data: { user },
+    },
+  ] = await Promise.all([
+    getPost(id),
+    getComments(id),
+    supabase.auth.getUser(),
+  ]);
+
+  if (!post) notFound();
+
+  await incrementViewCount(id);
+
+  return { post, comments, userId: user?.id ?? null };
+}
+
+export default async function PostDetailPage({
   params,
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const { id } = use(params);
-  const router = useRouter();
-  const [post, setPost] = useState<Post | null>(null);
-  const [comments, setComments] = useState<Comment[]>([]);
-  const [comment, setComment] = useState('');
-  const [userId, setUserId] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [editingCommentId, setEditingCommentId] = useState<string | null>(null);
-  const [editingContent, setEditingContent] = useState('');
-  const { user } = useAuth();
-  const { likeCount, isLiked, toggle } = useLike(id, user?.id ?? '');
-  const queryClient = useQueryClient();
-
-  const [reportModalOpen, setReportModalOpen] = useState(false);
-
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const [
-          postData,
-          commentsData,
-          {
-            data: { user },
-          },
-        ] = await Promise.all([
-          getPost(id),
-          getComments(id),
-          supabase.auth.getUser(),
-        ]);
-        setPost(postData);
-        setComments(commentsData);
-        setUserId(user?.id ?? null);
-        await incrementViewCount(id);
-      } catch (e) {
-        console.error(e);
-      } finally {
-        setLoading(false);
-      }
-    };
-    load();
-  }, [id]);
-
-  const handleCommentSubmit = async () => {
-    if (!userId) {
-      showErrorToast('로그인이 필요합니다.');
-      return;
-    }
-    if (!comment.trim()) {
-      showErrorToast('댓글을 입력해주세요.');
-      return;
-    }
-    try {
-      const newComment = await createComment({
-        post_id: id,
-        user_id: userId,
-        content: comment,
-      });
-      setComments((prev) => [...prev, newComment]);
-      setComment('');
-    } catch (e) {
-      console.error(e);
-    }
-  };
-
-  const handleDeletePost = async () => {
-    if (!confirm('게시글을 삭제하시겠습니까?')) return;
-    try {
-      await deletePost(id);
-      queryClient.invalidateQueries({ queryKey: ['posts'] });
-      showSuccessToast('게시글이 삭제되었습니다.', '🗑️');
-      router.push('/community');
-    } catch (e) {
-      console.error(e);
-    }
-  };
-
-  const handleEditComment = async (commentId: string) => {
-    if (!editingContent.trim()) return;
-    try {
-      await supabase
-        .from('comments')
-        .update({ content: editingContent })
-        .eq('id', commentId);
-      setComments((prev) =>
-        prev.map((c) =>
-          c.id === commentId ? { ...c, content: editingContent } : c,
-        ),
-      );
-      setEditingCommentId(null);
-      setEditingContent('');
-      showSuccessToast('댓글이 수정되었습니다.', '✅');
-    } catch (e) {
-      console.error(e);
-    }
-  };
-
-  const handleDeleteComment = async (commentId: string) => {
-    if (!confirm('댓글을 삭제하시겠습니까?')) return;
-    try {
-      await deleteComment(commentId);
-      setComments((prev) => prev.filter((c) => c.id !== commentId));
-      showSuccessToast('댓글이 삭제되었습니다.', '🗑️');
-    } catch (e) {
-      console.error(e);
-    }
-  };
-
-  // ── 신고 제출 핸들러 ──
-  const handleReportSubmit = async (reason: ReportReason) => {
-    if (!userId) {
-      showErrorToast('로그인이 필요합니다.');
-      return;
-    }
-    try {
-      await reportPost(userId, id, reason);
-      showSuccessToast('신고가 접수되었습니다.', '🚨');
-      setReportModalOpen(false);
-    } catch (e: unknown) {
-      if (e instanceof Error && e.message === 'ALREADY_REPORTED') {
-        showErrorToast('이미 신고한 게시물입니다.');
-        setReportModalOpen(false);
-      } else {
-        showErrorToast('신고 처리 중 오류가 발생했습니다.');
-      }
-    }
-  };
-
-  if (loading)
-    return (
-      <div className="flex justify-center p-20">
-        <LoadingSpinner />
-      </div>
-    );
-  if (!post)
-    return (
-      <div className="flex justify-center p-20 text-gray-400">
-        게시글을 찾을 수 없습니다.
-      </div>
-    );
-
-  const isOwner = userId === post.user_id;
-
-  const handleShare = async () => {
-    const url = window.location.href;
-    const title = post?.title ?? '';
-
-    if (navigator.share && /Mobi|Android/i.test(navigator.userAgent)) {
-      try {
-        await navigator.share({ title, url });
-      } catch {
-        // 취소 무시
-      }
-    } else {
-      try {
-        await navigator.clipboard.writeText(url);
-        showSuccessToast('링크가 복사되었습니다!', '🔗');
-      } catch {
-        showErrorToast('복사에 실패했습니다.');
-      }
-    }
-  };
-
-  const postDetailCardData: PostDetailCardData = {
-    nickname: post.nickname ?? '알 수 없음',
-    avatar_url: post.avatar_url,
-    role: post.role,
-    created_at: post.created_at,
-    title: post.title,
-    image_url: post.image_url,
-    content: post.content,
-    likeCount: likeCount ?? 0,
-    commentCount: comments.length,
-    view_count: post.view_count,
-  };
+  const { id } = await params;
+  const { post, comments, userId } = await getInitialData(id);
 
   return (
-    <div className="max-w-2xl mx-auto p-4 space-y-4">
-      {/* 뒤로가기 */}
-      <button
-        onClick={() => router.push(`/community`)}
-        className="flex items-center gap-2 px-2.5 py-2 border-2 border-white bg-white text-black text-sm font-medium rounded-xl hover:bg-(--color-btn-focus) hover:text-white transition-colors duration-200 cursor-pointer"
-      >
-        <svg
-          width="16"
-          height="16"
-          viewBox="0 0 16 16"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M10 12L6 8L10 4"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
-        목록으로
-      </button>
-
-      {/* ── 게시글 카드 ── */}
-      <PostDetailCard
-        post={postDetailCardData}
-        isLiked={isLiked}
-        onLike={() => {
-          if (!userId) {
-            showErrorToast('로그인이 필요합니다.');
-            return;
-          }
-          toggle();
-        }}
-        headerActions={
-          <>
-            {isOwner ? (
-              <>
-                <button
-                  title="수정하기"
-                  onClick={() => router.push(`/community/${id}/edit`)}
-                >
-                  <Image src="/postEdit.svg" alt="" width={30} height={30} />
-                </button>
-                <button title="삭제하기" onClick={handleDeletePost}>
-                  <Image src="/postDelete.svg" alt="" width={32} height={32} />
-                </button>
-              </>
-            ) : (
-              <button
-                title="신고하기"
-                onClick={() => setReportModalOpen(true)}
-                className="w-8 h-8 flex items-center justify-center"
-              >
-                <Image src="/postReport.svg" alt="" width={27} height={27} />
-              </button>
-            )}
-            <button
-              title="공유하기"
-              onClick={handleShare}
-              className="w-8 h-8 flex items-center justify-center"
-            >
-              <Image src="/postShare.svg" alt="" width={18} height={18} />
-            </button>
-          </>
-        }
-      />
-
-      {/* ── 댓글 카드 ── */}
-      <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden">
-        <div className="px-5 pt-5 pb-3 flex items-center gap-2 border-b border-gray-100">
-          <Image
-            src="/postComment.svg"
-            alt="댓글"
-            width={16}
-            height={16}
-            className="opacity-40"
-          />
-          <h2 className="text-sm font-semibold text-gray-800">댓글</h2>
-        </div>
-
-        {/* 댓글 입력 */}
-        <div className="px-5 py-4">
-          <div className="flex items-center gap-2">
-            <label htmlFor="comment-input" className="sr-only">
-              댓글 입력
-            </label>
-            <input
-              type="text"
-              id="comment-input"
-              placeholder="댓글을 입력하세요..."
-              value={comment}
-              onChange={(e) => setComment(e.target.value)}
-              onKeyDown={(e) => e.key === 'Enter' && handleCommentSubmit()}
-              className="flex-1 bg-gray-50 border border-gray-200 rounded-xl px-4 py-2.5 text-sm outline-none focus:border-gray-400 transition-colors placeholder:text-gray-400"
-            />
-            <button
-              onClick={handleCommentSubmit}
-              className="w-10 h-10 flex items-center justify-center shrink-0 transition-colors cursor-pointer"
-            >
-              <Image
-                src="/postCommentSubmit.svg"
-                alt="전송"
-                width={30}
-                height={30}
-              />
-            </button>
-          </div>
-        </div>
-
-        {/* 댓글 목록 */}
-        <div className="px-5 pb-5 space-y-4">
-          {comments.map((c, index) => (
-            <div key={c.id}>
-              {index > 0 && <div className="border-t border-gray-50 mb-4" />}
-              <div className="flex gap-3">
-                <div className="w-8 h-8 rounded-full bg-gray-200 shrink-0 overflow-hidden">
-                  {c.avatar_url && (
-                    <Image
-                      src={c.avatar_url}
-                      alt={`${c.nickname} 프로필 이미지`}
-                      width={32}
-                      height={32}
-                      className="w-full h-full object-cover"
-                    />
-                  )}
-                </div>
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-1.5 mb-1">
-                    <span className="text-sm font-semibold text-gray-900">
-                      {c.nickname}
-                    </span>
-                    {c.belt_level && (
-                      <span className="text-xs text-gray-400">
-                        {c.belt_level}
-                      </span>
-                    )}
-                  </div>
-                  {editingCommentId === c.id ? (
-                    <div className="flex items-center gap-2 mt-1">
-                      <label
-                        htmlFor={`edit-comment-${c.id}`}
-                        className="sr-only"
-                      >
-                        댓글 수정 입력
-                      </label>
-                      <input
-                        id={`edit-comment-${c.id}`}
-                        type="text"
-                        value={editingContent}
-                        onChange={(e) => setEditingContent(e.target.value)}
-                        onKeyDown={(e) =>
-                          e.key === 'Enter' && handleEditComment(c.id)
-                        }
-                        className="flex-1 bg-gray-50 border border-gray-200 rounded-xl px-3 py-1.5 text-sm outline-none focus:border-gray-400"
-                        autoFocus
-                      />
-                      <button
-                        onClick={() => handleEditComment(c.id)}
-                        className="text-xs text-blue-500 font-medium"
-                      >
-                        저장
-                      </button>
-                      <button
-                        onClick={() => setEditingCommentId(null)}
-                        className="text-xs text-gray-400"
-                      >
-                        취소
-                      </button>
-                    </div>
-                  ) : (
-                    <p className="text-sm text-gray-700 leading-relaxed">
-                      {c.content}
-                    </p>
-                  )}
-                  <div className="flex items-center gap-3 mt-1.5">
-                    <span className="flex items-center gap-1 text-xs text-gray-400">
-                      <Image
-                        src="/postTime.svg"
-                        alt=""
-                        aria-hidden="true"
-                        width={11}
-                        height={11}
-                        className="opacity-50"
-                      />
-                      {timeAgo(c.created_at)}
-                    </span>
-                    {userId === c.user_id && (
-                      <>
-                        <button
-                          onClick={() => {
-                            setEditingCommentId(c.id);
-                            setEditingContent(c.content);
-                          }}
-                          aria-label={`${c.nickname}의 댓글 수정`}
-                          className="text-xs text-gray-400 hover:text-gray-600 transition-colors"
-                        >
-                          수정
-                        </button>
-                        <button
-                          onClick={() => handleDeleteComment(c.id)}
-                          aria-label={`${c.nickname}의 댓글 삭제`}
-                          className="flex items-center gap-1 text-xs text-red-400 hover:text-red-600 transition-colors"
-                        >
-                          삭제
-                        </button>
-                      </>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </div>
-          ))}
-          {comments.length === 0 && (
-            <p className="text-center text-sm text-gray-400 py-4">
-              첫 번째 댓글을 남겨보세요!
-            </p>
-          )}
-        </div>
-      </div>
-
-      {/* ── 신고 모달 ── */}
-      <ReportModal
-        isOpen={reportModalOpen}
-        onClose={() => setReportModalOpen(false)}
-        onSubmit={handleReportSubmit}
-      />
-    </div>
+    <PostDetailClient
+      id={id}
+      initialPost={post}
+      initialComments={comments}
+      userId={userId}
+    />
   );
 }

--- a/src/app/(main)/community/write/page.tsx
+++ b/src/app/(main)/community/write/page.tsx
@@ -1,192 +1,34 @@
-'use client';
+// 서버 컴포넌트
+import WriteClient from '@/components/community/WriteClient';
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
 
-import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import type { PostCategory } from '@/types/community';
-import LoadingSpinner from '@/components/common/LoadingSpinner';
-import { supabase } from '@/lib/supabase';
-import { createPost, uploadPostImage } from '@/services/communityService';
-import { useAuth } from '@/hooks/useAuth';
-import { useQueryClient } from '@tanstack/react-query';
-import { showErrorToast, showSuccessToast } from '@/lib/toast';
-import ImageUpload from '@/components/community/ImageUpload';
-import PostFormActions from '@/components/community/PostFormActions';
-import PostDetailCard from '@/components/community/PostDetailCard';
-
-export default function WritePage() {
-  const router = useRouter();
-  const [tab, setTab] = useState<'write' | 'preview'>('write');
-  const [title, setTitle] = useState('');
-  const [content, setContent] = useState('');
-  const [preview, setPreview] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const [imageFile, setImageFile] = useState<File | null>(null);
-  const { user, loading } = useAuth();
-  const [category, setCategory] = useState<PostCategory>('personal');
-  const queryClient = useQueryClient();
-
-  useEffect(() => {
-    if (!loading && !user) {
-      router.push('/login');
-    }
-  }, [user, loading, router]);
-
-  if (loading || isLoading) return <LoadingSpinner />;
-
-  const handleSubmit = async () => {
-    if (!title.trim() || !content.trim()) {
-      showErrorToast('제목과 내용을 모두 입력해주세요.');
-      return;
-    }
-    setIsLoading(true);
-    try {
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      if (!user) throw new Error('로그인이 필요합니다.');
-
-      let image_url: string | undefined;
-      if (imageFile) {
-        image_url = await uploadPostImage(imageFile);
-      }
-
-      await createPost({
-        category,
-        title,
-        content,
-        image_url,
-        user_id: user.id,
-      });
-      queryClient.invalidateQueries({ queryKey: ['posts'] });
-      showSuccessToast('게시글이 업로드되었습니다.', '📝');
-      router.push('/community');
-    } catch {
-      showErrorToast('게시글 작성에 실패했습니다.');
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  return (
-    <div className="max-w-5xl mx-auto p-6">
-      <div className="w-full flex items-center mb-6">
-        <h1 className="text-lg font-semibold mx-auto">게시글 작성</h1>
-      </div>
-
-      {/* ✅ 탭 버튼 추가 */}
-      <div className="flex bg-gray-100 rounded-xl p-1 mb-6">
-        <button
-          onClick={() => setTab('write')}
-          className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
-            tab === 'write' ? 'bg-white text-black shadow-sm' : 'text-gray-500'
-          }`}
-        >
-          작성
-        </button>
-        <button
-          onClick={() => setTab('preview')}
-          className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
-            tab === 'preview'
-              ? 'bg-white text-black shadow-sm'
-              : 'text-gray-500'
-          }`}
-        >
-          미리보기
-        </button>
-      </div>
-
-      {/* ✅ 작성 탭 */}
-      {tab === 'write' && (
-        <>
-          <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
-            <p className="text-sm text-gray-500 mb-2">게시글 유형</p>
-            {user?.role === 'manager' ? (
-              <div className="flex gap-2">
-                {(['personal', 'promo'] as PostCategory[]).map((type) => (
-                  <button
-                    key={type}
-                    onClick={() => setCategory(type)}
-                    className={`flex-1 py-2 rounded-lg text-sm font-medium cursor-pointer transition-colors ${
-                      category === type
-                        ? 'bg-black text-white'
-                        : 'bg-gray-100 text-gray-600'
-                    }`}
-                  >
-                    {type === 'personal' ? '일반 게시글' : '도장 홍보'}
-                  </button>
-                ))}
-              </div>
-            ) : (
-              <div className="py-2 px-3 rounded-lg text-sm font-medium bg-black text-white text-center">
-                {user?.role === 'admin' ? '공지' : '일반 게시글'}
-              </div>
-            )}
-          </div>
-
-          <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
-            <p className="text-sm text-gray-500 mb-2">제목</p>
-            <input
-              type="text"
-              placeholder="제목을 입력하세요"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              className="w-full bg-gray-50 rounded-lg px-3 py-2 text-sm outline-none"
-            />
-          </div>
-
-          <ImageUpload
-            preview={preview}
-            onChange={(file, previewUrl) => {
-              setImageFile(file);
-              setPreview(previewUrl);
-            }}
-          />
-
-          <div className="bg-white rounded-xl p-4 mb-6 shadow-sm">
-            <p className="text-sm text-gray-500 mb-2">내용</p>
-            <textarea
-              placeholder="내용을 입력하세요"
-              value={content}
-              onChange={(e) => setContent(e.target.value)}
-              rows={8}
-              className="w-full bg-gray-50 rounded-lg px-3 py-2 text-sm outline-none resize-none"
-            />
-          </div>
-        </>
-      )}
-
-      {/* ✅ 미리보기 탭 */}
-      {tab === 'preview' &&
-        (!title && !content ? (
-          <div className="flex flex-col items-center justify-center py-16 text-gray-400 mb-6">
-            <p className="text-sm">작성 탭에서 내용을 입력하면</p>
-            <p className="text-sm">여기서 미리볼 수 있어요.</p>
-          </div>
-        ) : (
-          <div className="mb-6">
-            <PostDetailCard
-              post={{
-                nickname: user?.name ?? '알 수 없음',
-                avatar_url: user?.image ?? null,
-                role: category === 'promo' ? 'manager' : (user?.role ?? null),
-                created_at: new Date().toISOString(),
-                title,
-                image_url: preview,
-                content,
-                likeCount: 0,
-                commentCount: 0,
-                view_count: 0,
-              }}
-            />
-          </div>
-        ))}
-
-      {/* 하단 버튼 */}
-      <PostFormActions
-        onCancel={() => router.back()}
-        onSubmit={handleSubmit}
-        submitLabel="작성하기"
-      />
-    </div>
+async function getUser() {
+  const cookieStore = await cookies();
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+      },
+    },
   );
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  return user;
+}
+
+export default async function WritePage() {
+  const user = await getUser();
+
+  // 서버에서 미인증 차단 — 클라이언트 useEffect 불필요
+  if (!user) redirect('/login');
+
+  return <WriteClient />;
 }

--- a/src/components/community/EditClient.tsx
+++ b/src/components/community/EditClient.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useQueryClient } from '@tanstack/react-query';
+import type { Post, PostCategory } from '@/types/community';
+import { updatePost, uploadPostImage } from '@/services/communityService';
+import { showErrorToast, showSuccessToast } from '@/lib/toast';
+import ImageUpload from '@/components/community/ImageUpload';
+import PostFormActions from '@/components/community/PostFormActions';
+
+interface Props {
+  id: string;
+  initialPost: Post;
+}
+
+export default function EditClient({ id, initialPost }: Props) {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const [title, setTitle] = useState(initialPost.title);
+  const [content, setContent] = useState(initialPost.content);
+  const [category] = useState<PostCategory>(initialPost.category); // 수정 불가
+  const [preview, setPreview] = useState<string | null>(
+    initialPost.image_url ?? null,
+  );
+  const [imageFile, setImageFile] = useState<File | null>(null);
+
+  const handleSubmit = async () => {
+    if (!title.trim() || !content.trim()) {
+      showErrorToast('제목과 내용을 모두 입력해주세요.');
+      return;
+    }
+
+    try {
+      const image_url = imageFile
+        ? await uploadPostImage(imageFile)
+        : undefined;
+      await updatePost(id, { title, content, image_url });
+      queryClient.invalidateQueries({ queryKey: ['posts'] });
+      showSuccessToast('게시글이 수정되었습니다.', '✅');
+      router.push(`/community/${id}`);
+    } catch {
+      showErrorToast('게시글 수정에 실패했습니다.');
+    }
+  };
+
+  return (
+    <div className="max-w-5xl mx-auto p-6">
+      <div className="w-full flex items-center mb-6">
+        <h1 className="text-lg font-semibold mx-auto">게시글 수정</h1>
+      </div>
+
+      <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
+        <p className="text-sm text-gray-500 mb-2">게시글 유형</p>
+        <div className="py-2 px-3 rounded-lg text-sm font-medium bg-black text-white text-center">
+          {category === 'promo'
+            ? '도장 홍보'
+            : category === 'notice'
+              ? '공지'
+              : '일반 게시글'}
+        </div>
+      </div>
+
+      <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
+        <p className="text-sm text-gray-500 mb-2">제목</p>
+        <input
+          type="text"
+          placeholder="제목을 입력하세요"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className="w-full bg-gray-50 rounded-lg px-3 py-2 text-sm outline-none"
+        />
+      </div>
+
+      <ImageUpload
+        preview={preview}
+        onChange={(file, previewUrl) => {
+          setImageFile(file);
+          setPreview(previewUrl);
+        }}
+      />
+
+      <div className="bg-white rounded-xl p-4 mb-6 shadow-sm">
+        <p className="text-sm text-gray-500 mb-2">내용</p>
+        <textarea
+          placeholder="내용을 입력하세요"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          rows={8}
+          className="w-full bg-gray-50 rounded-lg px-3 py-2 text-sm outline-none resize-none"
+        />
+      </div>
+
+      <PostFormActions
+        onCancel={() => router.back()}
+        onSubmit={handleSubmit}
+        submitLabel="수정하기"
+      />
+    </div>
+  );
+}

--- a/src/components/community/PostDetailClient.tsx
+++ b/src/components/community/PostDetailClient.tsx
@@ -1,0 +1,396 @@
+'use client';
+
+import { useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  createComment,
+  deletePost,
+  deleteComment,
+} from '@/services/communityService';
+import { reportPost, ReportReason } from '@/services/reportService';
+import { supabase } from '@/lib/supabase';
+import type { Post, Comment } from '@/types/community';
+import Image from 'next/image';
+import { useAuth } from '@/hooks/useAuth';
+import { useLike } from '@/hooks/useLike';
+import { showErrorToast, showSuccessToast } from '@/lib/toast';
+import ReportModal from '@/components/community/ReportModal';
+import PostDetailCard, {
+  PostDetailCardData,
+} from '@/components/community/PostDetailCard';
+import { timeAgo } from '@/utils/timeAgo';
+
+interface Props {
+  id: string;
+  initialPost: Post;
+  initialComments: Comment[];
+  userId: string | null;
+}
+
+export default function PostDetailClient({
+  id,
+  initialPost,
+  initialComments,
+  userId,
+}: Props) {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+  const { likeCount, isLiked, toggle } = useLike(id, user?.id ?? '');
+
+  const [post] = useState<Post>(initialPost);
+  const [comments, setComments] = useState<Comment[]>(initialComments);
+  const [comment, setComment] = useState('');
+  const [editingCommentId, setEditingCommentId] = useState<string | null>(null);
+  const [editingContent, setEditingContent] = useState('');
+  const [reportModalOpen, setReportModalOpen] = useState(false);
+
+  const isOwner = userId === post.user_id;
+
+  const handleCommentSubmit = async () => {
+    if (!userId) {
+      showErrorToast('로그인이 필요합니다.');
+      return;
+    }
+    if (!comment.trim()) {
+      showErrorToast('댓글을 입력해주세요.');
+      return;
+    }
+    try {
+      const newComment = await createComment({
+        post_id: id,
+        user_id: userId,
+        content: comment,
+      });
+      setComments((prev) => [...prev, newComment]);
+      setComment('');
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const handleDeletePost = async () => {
+    if (!confirm('게시글을 삭제하시겠습니까?')) return;
+    try {
+      await deletePost(id);
+      queryClient.invalidateQueries({ queryKey: ['posts'] });
+      showSuccessToast('게시글이 삭제되었습니다.', '🗑️');
+      router.push('/community');
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const handleEditComment = async (commentId: string) => {
+    if (!editingContent.trim()) return;
+    try {
+      await supabase
+        .from('comments')
+        .update({ content: editingContent })
+        .eq('id', commentId);
+      setComments((prev) =>
+        prev.map((c) =>
+          c.id === commentId ? { ...c, content: editingContent } : c,
+        ),
+      );
+      setEditingCommentId(null);
+      setEditingContent('');
+      showSuccessToast('댓글이 수정되었습니다.', '✅');
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const handleDeleteComment = async (commentId: string) => {
+    if (!confirm('댓글을 삭제하시겠습니까?')) return;
+    try {
+      await deleteComment(commentId);
+      setComments((prev) => prev.filter((c) => c.id !== commentId));
+      showSuccessToast('댓글이 삭제되었습니다.', '🗑️');
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const handleReportSubmit = async (reason: ReportReason) => {
+    if (!userId) {
+      showErrorToast('로그인이 필요합니다.');
+      return;
+    }
+    try {
+      await reportPost(userId, id, reason);
+      showSuccessToast('신고가 접수되었습니다.', '🚨');
+      setReportModalOpen(false);
+    } catch (e: unknown) {
+      if (e instanceof Error && e.message === 'ALREADY_REPORTED') {
+        showErrorToast('이미 신고한 게시물입니다.');
+        setReportModalOpen(false);
+      } else {
+        showErrorToast('신고 처리 중 오류가 발생했습니다.');
+      }
+    }
+  };
+
+  const handleShare = async () => {
+    const url = window.location.href;
+    const title = post.title ?? '';
+    if (navigator.share && /Mobi|Android/i.test(navigator.userAgent)) {
+      try {
+        await navigator.share({ title, url });
+      } catch {}
+    } else {
+      try {
+        await navigator.clipboard.writeText(url);
+        showSuccessToast('링크가 복사되었습니다!', '🔗');
+      } catch {
+        showErrorToast('복사에 실패했습니다.');
+      }
+    }
+  };
+
+  const postDetailCardData: PostDetailCardData = {
+    nickname: post.nickname ?? '알 수 없음',
+    avatar_url: post.avatar_url,
+    role: post.role,
+    created_at: post.created_at,
+    title: post.title,
+    image_url: post.image_url,
+    content: post.content,
+    likeCount: likeCount ?? 0,
+    commentCount: comments.length,
+    view_count: post.view_count,
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto p-4 space-y-4">
+      {/* 뒤로가기 */}
+      <button
+        onClick={() => router.push('/community')}
+        className="flex items-center gap-2 px-2.5 py-2 border-2 border-white bg-white text-black text-sm font-medium rounded-xl hover:bg-(--color-btn-focus) hover:text-white transition-colors duration-200 cursor-pointer"
+      >
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 16 16"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M10 12L6 8L10 4"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+        목록으로
+      </button>
+
+      {/* 게시글 카드 */}
+      <PostDetailCard
+        post={postDetailCardData}
+        isLiked={isLiked}
+        onLike={() => {
+          if (!userId) {
+            showErrorToast('로그인이 필요합니다.');
+            return;
+          }
+          toggle();
+        }}
+        headerActions={
+          <>
+            {isOwner ? (
+              <>
+                <button
+                  title="수정하기"
+                  onClick={() => router.push(`/community/${id}/edit`)}
+                >
+                  <Image src="/postEdit.svg" alt="" width={30} height={30} />
+                </button>
+                <button title="삭제하기" onClick={handleDeletePost}>
+                  <Image src="/postDelete.svg" alt="" width={32} height={32} />
+                </button>
+              </>
+            ) : (
+              <button
+                title="신고하기"
+                onClick={() => setReportModalOpen(true)}
+                className="w-8 h-8 flex items-center justify-center"
+              >
+                <Image src="/postReport.svg" alt="" width={27} height={27} />
+              </button>
+            )}
+            <button
+              title="공유하기"
+              onClick={handleShare}
+              className="w-8 h-8 flex items-center justify-center"
+            >
+              <Image src="/postShare.svg" alt="" width={18} height={18} />
+            </button>
+          </>
+        }
+      />
+
+      {/* 댓글 카드 */}
+      <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden">
+        <div className="px-5 pt-5 pb-3 flex items-center gap-2 border-b border-gray-100">
+          <Image
+            src="/postComment.svg"
+            alt="댓글"
+            width={16}
+            height={16}
+            className="opacity-40"
+          />
+          <h2 className="text-sm font-semibold text-gray-800">댓글</h2>
+        </div>
+
+        {/* 댓글 입력 */}
+        <div className="px-5 py-4">
+          <div className="flex items-center gap-2">
+            <label htmlFor="comment-input" className="sr-only">
+              댓글 입력
+            </label>
+            <input
+              type="text"
+              id="comment-input"
+              placeholder="댓글을 입력하세요..."
+              value={comment}
+              onChange={(e) => setComment(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && handleCommentSubmit()}
+              className="flex-1 bg-gray-50 border border-gray-200 rounded-xl px-4 py-2.5 text-sm outline-none focus:border-gray-400 transition-colors placeholder:text-gray-400"
+            />
+            <button
+              onClick={handleCommentSubmit}
+              className="w-10 h-10 flex items-center justify-center shrink-0 transition-colors cursor-pointer"
+            >
+              <Image
+                src="/postCommentSubmit.svg"
+                alt="전송"
+                width={30}
+                height={30}
+              />
+            </button>
+          </div>
+        </div>
+
+        {/* 댓글 목록 */}
+        <div className="px-5 pb-5 space-y-4">
+          {comments.map((c, index) => (
+            <div key={c.id}>
+              {index > 0 && <div className="border-t border-gray-50 mb-4" />}
+              <div className="flex gap-3">
+                <div className="w-8 h-8 rounded-full bg-gray-200 shrink-0 overflow-hidden">
+                  {c.avatar_url && (
+                    <Image
+                      src={c.avatar_url}
+                      alt={`${c.nickname} 프로필 이미지`}
+                      width={32}
+                      height={32}
+                      className="w-full h-full object-cover"
+                    />
+                  )}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-1.5 mb-1">
+                    <span className="text-sm font-semibold text-gray-900">
+                      {c.nickname}
+                    </span>
+                    {c.belt_level && (
+                      <span className="text-xs text-gray-400">
+                        {c.belt_level}
+                      </span>
+                    )}
+                  </div>
+                  {editingCommentId === c.id ? (
+                    <div className="flex items-center gap-2 mt-1">
+                      <label
+                        htmlFor={`edit-comment-${c.id}`}
+                        className="sr-only"
+                      >
+                        댓글 수정 입력
+                      </label>
+                      <input
+                        id={`edit-comment-${c.id}`}
+                        type="text"
+                        value={editingContent}
+                        onChange={(e) => setEditingContent(e.target.value)}
+                        onKeyDown={(e) =>
+                          e.key === 'Enter' && handleEditComment(c.id)
+                        }
+                        className="flex-1 bg-gray-50 border border-gray-200 rounded-xl px-3 py-1.5 text-sm outline-none focus:border-gray-400"
+                        autoFocus
+                      />
+                      <button
+                        onClick={() => handleEditComment(c.id)}
+                        className="text-xs text-blue-500 font-medium"
+                      >
+                        저장
+                      </button>
+                      <button
+                        onClick={() => setEditingCommentId(null)}
+                        className="text-xs text-gray-400"
+                      >
+                        취소
+                      </button>
+                    </div>
+                  ) : (
+                    <p className="text-sm text-gray-700 leading-relaxed">
+                      {c.content}
+                    </p>
+                  )}
+                  <div className="flex items-center gap-3 mt-1.5">
+                    <span className="flex items-center gap-1 text-xs text-gray-400">
+                      <Image
+                        src="/postTime.svg"
+                        alt=""
+                        aria-hidden="true"
+                        width={11}
+                        height={11}
+                        className="opacity-50"
+                      />
+                      {timeAgo(c.created_at)}
+                    </span>
+                    {userId === c.user_id && (
+                      <>
+                        <button
+                          onClick={() => {
+                            setEditingCommentId(c.id);
+                            setEditingContent(c.content);
+                          }}
+                          aria-label={`${c.nickname}의 댓글 수정`}
+                          className="text-xs text-gray-400 hover:text-gray-600 transition-colors"
+                        >
+                          수정
+                        </button>
+                        <button
+                          onClick={() => handleDeleteComment(c.id)}
+                          aria-label={`${c.nickname}의 댓글 삭제`}
+                          className="flex items-center gap-1 text-xs text-red-400 hover:text-red-600 transition-colors"
+                        >
+                          삭제
+                        </button>
+                      </>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+          {comments.length === 0 && (
+            <p className="text-center text-sm text-gray-400 py-4">
+              첫 번째 댓글을 남겨보세요!
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* 신고 모달 */}
+      <ReportModal
+        isOpen={reportModalOpen}
+        onClose={() => setReportModalOpen(false)}
+        onSubmit={handleReportSubmit}
+      />
+    </div>
+  );
+}

--- a/src/components/community/WriteClient.tsx
+++ b/src/components/community/WriteClient.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import type { PostCategory } from '@/types/community';
+import LoadingSpinner from '@/components/common/LoadingSpinner';
+import { createPost, uploadPostImage } from '@/services/communityService';
+import { useAuth } from '@/hooks/useAuth';
+import { useQueryClient } from '@tanstack/react-query';
+import { showErrorToast, showSuccessToast } from '@/lib/toast';
+import ImageUpload from '@/components/community/ImageUpload';
+import PostFormActions from '@/components/community/PostFormActions';
+import PostDetailCard from '@/components/community/PostDetailCard';
+
+export default function WriteClient() {
+  const router = useRouter();
+  const [tab, setTab] = useState<'write' | 'preview'>('write');
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [preview, setPreview] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const { user } = useAuth();
+  const [category, setCategory] = useState<PostCategory>('personal');
+  const queryClient = useQueryClient();
+
+  const handleSubmit = async () => {
+    if (!title.trim() || !content.trim()) {
+      showErrorToast('제목과 내용을 모두 입력해주세요.');
+      return;
+    }
+    if (!user) return;
+
+    setIsLoading(true);
+    try {
+      const image_url = imageFile
+        ? await uploadPostImage(imageFile)
+        : undefined;
+
+      await createPost({
+        category,
+        title,
+        content,
+        image_url,
+        user_id: user.id,
+      });
+      queryClient.invalidateQueries({ queryKey: ['posts'] });
+      showSuccessToast('게시글이 업로드되었습니다.', '📝');
+      router.push('/community');
+    } catch {
+      showErrorToast('게시글 작성에 실패했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (isLoading) return <LoadingSpinner />;
+
+  return (
+    <div className="max-w-5xl mx-auto p-6">
+      <div className="w-full flex items-center mb-6">
+        <h1 className="text-lg font-semibold mx-auto">게시글 작성</h1>
+      </div>
+
+      {/* ✅ 탭 버튼 추가 */}
+      <div className="flex bg-gray-100 rounded-xl p-1 mb-6">
+        <button
+          onClick={() => setTab('write')}
+          className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
+            tab === 'write' ? 'bg-white text-black shadow-sm' : 'text-gray-500'
+          }`}
+        >
+          작성
+        </button>
+        <button
+          onClick={() => setTab('preview')}
+          className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
+            tab === 'preview'
+              ? 'bg-white text-black shadow-sm'
+              : 'text-gray-500'
+          }`}
+        >
+          미리보기
+        </button>
+      </div>
+
+      {/* ✅ 작성 탭 */}
+      {tab === 'write' && (
+        <>
+          <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
+            <p className="text-sm text-gray-500 mb-2">게시글 유형</p>
+            {user?.role === 'manager' ? (
+              <div className="flex gap-2">
+                {(['personal', 'promo'] as PostCategory[]).map((type) => (
+                  <button
+                    key={type}
+                    onClick={() => setCategory(type)}
+                    className={`flex-1 py-2 rounded-lg text-sm font-medium cursor-pointer transition-colors ${
+                      category === type
+                        ? 'bg-black text-white'
+                        : 'bg-gray-100 text-gray-600'
+                    }`}
+                  >
+                    {type === 'personal' ? '일반 게시글' : '도장 홍보'}
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <div className="py-2 px-3 rounded-lg text-sm font-medium bg-black text-white text-center">
+                {user?.role === 'admin' ? '공지' : '일반 게시글'}
+              </div>
+            )}
+          </div>
+
+          <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
+            <p className="text-sm text-gray-500 mb-2">제목</p>
+            <input
+              type="text"
+              placeholder="제목을 입력하세요"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="w-full bg-gray-50 rounded-lg px-3 py-2 text-sm outline-none"
+            />
+          </div>
+
+          <ImageUpload
+            preview={preview}
+            onChange={(file, previewUrl) => {
+              setImageFile(file);
+              setPreview(previewUrl);
+            }}
+          />
+
+          <div className="bg-white rounded-xl p-4 mb-6 shadow-sm">
+            <p className="text-sm text-gray-500 mb-2">내용</p>
+            <textarea
+              placeholder="내용을 입력하세요"
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              rows={8}
+              className="w-full bg-gray-50 rounded-lg px-3 py-2 text-sm outline-none resize-none"
+            />
+          </div>
+        </>
+      )}
+
+      {/* ✅ 미리보기 탭 */}
+      {tab === 'preview' &&
+        (!title && !content ? (
+          <div className="flex flex-col items-center justify-center py-16 text-gray-400 mb-6">
+            <p className="text-sm">작성 탭에서 내용을 입력하면</p>
+            <p className="text-sm">여기서 미리볼 수 있어요.</p>
+          </div>
+        ) : (
+          <div className="mb-6">
+            <PostDetailCard
+              post={{
+                nickname: user?.name ?? '알 수 없음',
+                avatar_url: user?.image ?? null,
+                role: category === 'promo' ? 'manager' : (user?.role ?? null),
+                created_at: new Date().toISOString(),
+                title,
+                image_url: preview,
+                content,
+                likeCount: 0,
+                commentCount: 0,
+                view_count: 0,
+              }}
+            />
+          </div>
+        ))}
+
+      {/* 하단 버튼 */}
+      <PostFormActions
+        onCancel={() => router.back()}
+        onSubmit={handleSubmit}
+        submitLabel="작성하기"
+      />
+    </div>
+  );
+}

--- a/src/utils/timeAgo.ts
+++ b/src/utils/timeAgo.ts
@@ -1,6 +1,7 @@
 export function timeAgo(dateStr: string) {
-  const diff = Date.now() - new Date(dateStr).getTime();
+  const diff = Math.max(0, Date.now() - new Date(dateStr).getTime());
   const min = Math.floor(diff / 60000);
+  if (min < 1) return '방금 전';
   if (min < 60) return `${min}분 전`;
   const hr = Math.floor(min / 60);
   if (hr < 24) return `${hr}시간 전`;


### PR DESCRIPTION
## 📌 개요

-커뮤니티 게시글 작성/상세/수정 페이지를 서버 컴포넌트와 클라이언트 컴포넌트로 분리했습니다. 
기존 커뮤니티 목록 페이지(community/page.tsx → CommunityClient)와 동일한 패턴으로 통일했습니다.

## 💻 작업 사항
구조 변경
기존 'use client'단일 페이지를 아래와 같이 분리했습니다.

페이지 | 서버 컴포넌트 | 클라이언트 컴포넌트
-- | -- | --
작성 | community/write/page.tsx | WriteClient.tsx (신규)
상세 | community/[id]/page.tsx | PostDetailClient.tsx (신규)
수정 | community/[id]/edit/page.tsx | EditClient.tsx (신규)


개선 사항
- 서버에서 인증/권한 체크 → 미인증 시 `useEffect` 없이 즉시 `redirect`
- 서버에서 초기 데이터 `fetch` → 클라이언트 `loading` 상태 및 `useEffect` 제거
- `supabase.auth.getUser()` 이중 호출 제거 `useAuth`의 `user` 직접 사용)
- 수정 페이지에서 타인 게시글 URL 직접 접근 차단 `post.user_id !== user.id`
- `timeAgo` 음수 `diff` 처리 추가 → 댓글 작성 직후 "-1분 전" 버그 수정, "방금 전" 표시

## 💡 관련 Issue

Closes #95 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #95 )
- [x] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
