### PR TITLE
[Refactor] [Feat] 홈페이지 웹접근성 수정 및 키보드 포커스 스타일 전역 적용

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -173,3 +173,9 @@
     scrollbar-gutter: stable;
   }
 }
+
+:focus-visible {
+  outline: 2px solid var(--color-btn-focus);
+  outline-offset: 2px;
+  border-radius: 0.5rem;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,11 +5,19 @@ export default function Home() {
   // throw Error('test');
 
   return (
-    <main className="min-h-screen bg-white flex flex-col items-center justify-center px-6 py-16 relative overflow-hidden">
+    <main
+      aria-label="블랙벨트 홈"
+      className="min-h-screen bg-white flex flex-col items-center justify-center px-6 py-16 relative overflow-hidden"
+    >
       {/* 로고 */}
       <div className="flex flex-col items-center mb-6 animate-fade-in">
         <div className="mb-4 relative">
-          <Image src="/blackbelt.svg" alt="로고" width={170} height={170} />
+          <Image
+            src="/blackbelt.svg"
+            alt="블랙벨트 로고"
+            width={170}
+            height={170}
+          />
         </div>
 
         {/* 타이틀 */}
@@ -44,43 +52,58 @@ export default function Home() {
       </div>
 
       {/* 네비게이션 버튼 */}
-      <div className="flex flex-wrap justify-center gap-3 mt-2">
-        <Link
-          href="/community"
-          className="flex items-center gap-2 px-5 py-2.5 border-2 border-btn-focus text-black text-sm font-medium rounded-xl hover:bg-btn-focus hover:text-white transition-colors duration-200"
-        >
-          <Image src="/whitebelt.svg" alt="흰 벨트" width={35} height={35} />
-          <span>커뮤니티</span>
-        </Link>
+      <nav aria-label="주요 메뉴">
+        <div className="flex flex-wrap justify-center gap-3 mt-2">
+          <Link
+            href="/community"
+            className="flex items-center gap-2 px-5 py-2.5 border-2 border-btn-focus text-black text-sm font-medium rounded-xl hover:bg-btn-focus hover:text-white transition-colors duration-200"
+          >
+            <Image
+              src="/whitebelt.svg"
+              alt=""
+              width={35}
+              height={35}
+              aria-hidden="true"
+            />
+            <span>커뮤니티</span>
+          </Link>
 
-        <Link
-          href="/dojangs"
-          className="flex items-center gap-2 px-5 py-2.5 border-2 border-btn-focus text-black text-sm font-medium rounded-xl hover:bg-btn-focus hover:text-white transition-colors duration-200"
-        >
-          <Image src="/brownbelt.svg" alt="흰 벨트" width={35} height={35} />
-          <span>도장 찾기</span>
-        </Link>
+          <Link
+            href="/dojangs"
+            className="flex items-center gap-2 px-5 py-2.5 border-2 border-btn-focus text-black text-sm font-medium rounded-xl hover:bg-btn-focus hover:text-white transition-colors duration-200"
+          >
+            <Image
+              src="/brownbelt.svg"
+              alt=""
+              width={35}
+              height={35}
+              aria-hidden="true"
+            />
+            <span>도장 찾기</span>
+          </Link>
 
-        <Link
-          href="/competitions"
-          className="flex items-center gap-2 px-5 py-2.5 border-2 border-btn-focus text-black text-sm font-medium rounded-xl hover:bg-btn-focus hover:text-white transition-colors duration-200"
-        >
-          <Image
-            src="/blackbeltcompetiton.svg"
-            alt="흰 벨트"
-            width={35}
-            height={35}
-          />
-          <span>대회 일정</span>
-        </Link>
+          <Link
+            href="/competitions"
+            className="flex items-center gap-2 px-5 py-2.5 border-2 border-btn-focus text-black text-sm font-medium rounded-xl hover:bg-btn-focus hover:text-white transition-colors duration-200"
+          >
+            <Image
+              src="/blackbeltcompetiton.svg"
+              alt=""
+              width={35}
+              height={35}
+              aria-hidden="true"
+            />
+            <span>대회 일정</span>
+          </Link>
 
-        <Link
-          href="/login"
-          className="flex items-center gap-2 px-5 py-2.5 border-2 border-btn-focus text-black text-sm font-medium rounded-xl hover:bg-btn-focus hover:text-white transition-colors duration-200"
-        >
-          <span>로그인</span>
-        </Link>
-      </div>
+          <Link
+            href="/login"
+            className="flex items-center gap-2 px-5 py-2.5 border-2 border-btn-focus text-black text-sm font-medium rounded-xl hover:bg-btn-focus hover:text-white transition-colors duration-200"
+          >
+            <span>로그인</span>
+          </Link>
+        </div>
+      </nav>
     </main>
   );
 }


### PR DESCRIPTION
## 📌 개요

-홈페이지 웹 접근성(A11y)을 개선하고 키보드 탭 포커스 스타일을 전역 적용했습니다.

## 💻 작업 사항

홈페이지 접근성 개선 (app/(main)/page.tsx)
- <main> 태그에 aria-label="블랙벨트 홈" 추가
- 네비게이션 링크를 <nav aria-label="주요 메뉴">로 감싸 스크린 리더 대응
- 링크 내 장식용 이미지에 alt="", aria-hidden="true" 처리(링크 텍스트와 중복 읽힘 방지)
- 로고 이미지 alt를 "블랙벨트 로고"로 구체화

---

키보드 포커스 스타일 전역 적용 (globals.css)
- :focus-visible 스타일 추가 — 키보드 탭 이동 시 현재 포커스 위치를 시각적으로 명확하게 표시
- 마우스 클릭 시에는 포커스 링이 나타나지 않아 시각적 노이즈 없음
- 프로젝트 전체 페이지에 일관된 포커스 스타일 적용

## 💡 관련 Issue

Closes #100 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #100 )
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
