### PR TITLE
[refactor] 대회일정, 상세, 작성, 수정 페이지 구조 변경 csr -> ssr

### DIFF
--- a/src/app/(main)/competitions/[id]/edit/page.tsx
+++ b/src/app/(main)/competitions/[id]/edit/page.tsx
@@ -1,131 +1,41 @@
-'use client';
+// app/(main)/competitions/[id]/edit/page.tsx (서버 컴포넌트)
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { getCompetition } from '@/services/competitionService';
+import CompetitionEditClient from '@/components/competition/CompetitionEditClient';
 
-import { use, useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import LoadingSpinner from '@/components/common/LoadingSpinner';
-import { useAuth } from '@/hooks/useAuth';
-import {
-  getCompetition,
-  updateCompetition,
-  uploadCompetitionImage,
-} from '@/services/competitionService';
-import { showErrorToast, showSuccessToast } from '@/lib/toast';
-import PostFormActions from '@/components/community/PostFormActions';
-import { useQueryClient } from '@tanstack/react-query';
-import CompetitionForm, {
-  CompetitionFormValues,
-} from '@/components/competition/CompetitionForm';
-
-const defaultValues: CompetitionFormValues = {
-  name: '',
-  location: '',
-  eventDate: '',
-  applyDeadline: '',
-  applyUrl: '',
-  description: '',
-  participants: '',
-  preview: null,
-  imageFile: null,
-};
-
-export default function CompetitionEditPage({
+export default async function CompetitionEditPage({
   params,
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const { id } = use(params);
-  const queryClient = useQueryClient();
-  const router = useRouter();
-  const { user, loading } = useAuth();
-  const [values, setValues] = useState<CompetitionFormValues>(defaultValues);
-  const [isLoading, setIsLoading] = useState(false);
-  const [dataLoaded, setDataLoaded] = useState(false);
+  const { id } = await params;
 
-  useEffect(() => {
-    if (
-      !loading &&
-      (!user || (user.role !== 'admin' && user.role !== 'manager'))
-    ) {
-      router.push('/competitions');
-    }
-  }, [user, loading, router]);
-
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const data = await getCompetition(id);
-        setValues({
-          name: data.name ?? '',
-          location: data.location ?? '',
-          eventDate: data.event_data ?? '',
-          applyDeadline: data.apply_deadline ?? '',
-          applyUrl: data.apply_url ?? '',
-          description: data.description ?? '',
-          participants: data.participants ? String(data.participants) : '',
-          preview: data.image_url ?? null,
-          imageFile: null,
-        });
-        setDataLoaded(true);
-      } catch (e) {
-        console.error(e);
-      }
-    };
-    load();
-  }, [id]);
-
-  const handleSubmit = async () => {
-    if (
-      !values.name.trim() ||
-      !values.location.trim() ||
-      !values.eventDate ||
-      !values.applyDeadline
-    ) {
-      showErrorToast('필수 항목을 모두 입력해주세요.');
-      return;
-    }
-    setIsLoading(true);
-    try {
-      let image_url: string | undefined = values.preview ?? undefined;
-      if (values.imageFile) {
-        image_url = await uploadCompetitionImage(values.imageFile);
-      }
-      await updateCompetition(id, {
-        name: values.name,
-        location: values.location,
-        event_data: values.eventDate,
-        apply_deadline: values.applyDeadline,
-        apply_url: values.applyUrl.startsWith('http')
-          ? values.applyUrl
-          : `https://${values.applyUrl}`,
-        description: values.description,
-        image_url,
-        participants: values.participants ? Number(values.participants) : 0,
-      });
-      showSuccessToast('대회일정이 수정되었습니다.', '✅');
-      await queryClient.invalidateQueries({ queryKey: ['competition'] });
-      router.push(`/competitions/${id}`);
-    } catch {
-      showErrorToast('대회 수정에 실패했습니다.');
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  if (loading || isLoading || !dataLoaded) return <LoadingSpinner />;
-
-  return (
-    <div className="max-w-2xl mx-auto p-6">
-      <div className="relative w-full flex items-center justify-center mb-6">
-        <h1 className="text-lg font-semibold">대회 수정</h1>
-      </div>
-
-      <CompetitionForm values={values} onChange={setValues} />
-
-      <PostFormActions
-        onCancel={() => router.back()}
-        onSubmit={handleSubmit}
-        submitLabel="수정하기"
-      />
-    </div>
+  const cookieStore = await cookies();
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { cookies: { getAll: () => cookieStore.getAll() } },
   );
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect('/login');
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single();
+
+  if (profile?.role !== 'admin' && profile?.role !== 'manager') {
+    redirect('/competitions');
+  }
+
+  const competition = await getCompetition(id);
+
+  return <CompetitionEditClient competition={competition} />;
 }

--- a/src/app/(main)/competitions/[id]/page.tsx
+++ b/src/app/(main)/competitions/[id]/page.tsx
@@ -1,179 +1,41 @@
-'use client';
-
-import { use, useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
+// app/(main)/competitions/[id]/page.tsx (서버 컴포넌트)
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+import { notFound } from 'next/navigation';
 import { getCompetition } from '@/services/competitionService';
-import { supabase } from '@/lib/supabase';
-import { showErrorToast, showSuccessToast } from '@/lib/toast';
-import type { Competition } from '@/types/competition';
-import LoadingSpinner from '@/components/common/LoadingSpinner';
-import Image from 'next/image';
-import { useQueryClient } from '@tanstack/react-query';
-import CompetitionDetailCard from '@/components/competition/CompetitionDetailCard';
-import { handleShare } from '@/utils/share';
+import CompetitionDetailClient from '@/components/competition/CompetitionDetailClient';
 
-export default function CompetitionDetailPage({
+export default async function CompetitionDetailPage({
   params,
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const { id } = use(params);
-  const router = useRouter();
+  const { id } = await params;
 
-  const queryClient = useQueryClient();
+  const cookieStore = await cookies();
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { cookies: { getAll: () => cookieStore.getAll() } },
+  );
 
-  const [competition, setCompetition] = useState<Competition | null>(null);
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
-  const [userId, setUserId] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
+  const competition = await getCompetition(id);
+  if (!competition) notFound();
 
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const [
-          competitionData,
-
-          {
-            data: { user },
-          },
-        ] = await Promise.all([getCompetition(id), supabase.auth.getUser()]);
-
-        setCompetition(competitionData);
-
-        setUserId(user?.id ?? null);
-
-        // 조회수 증가
-        await supabase
-          .from('competition')
-          .update({ view_count: (competitionData.view_count ?? 0) + 1 })
-          .eq('id', id);
-      } catch (e) {
-        console.error(e);
-      } finally {
-        setLoading(false);
-      }
-    };
-    load();
-  }, [id]);
-
-  const handleDeletePost = async () => {
-    if (!confirm('대회 게시글을 삭제하시겠습니까?')) return;
-    try {
-      await supabase.from('competition').delete().eq('id', id);
-      showSuccessToast('삭제되었습니다.', '🗑️');
-      await queryClient.invalidateQueries({ queryKey: ['competition'] });
-      router.push('/competitions');
-    } catch (e) {
-      console.error(e);
-    }
-  };
-
-  if (loading)
-    return (
-      <div className="flex justify-center p-20">
-        <LoadingSpinner />
-      </div>
-    );
-  if (!competition)
-    return (
-      <div className="flex justify-center p-20 text-gray-400">
-        게시글을 찾을 수 없습니다.
-      </div>
-    );
-
-  const isOwner = userId === competition.user_id;
-  const status = competition.apply_deadline
-    ? competition.apply_deadline < new Date().toISOString().split('T')[0]
-      ? '모집완료'
-      : '모집중'
-    : '모집중';
+  // 조회수 증가
+  await supabase
+    .from('competition')
+    .update({ view_count: (competition.view_count ?? 0) + 1 })
+    .eq('id', id);
 
   return (
-    <div className="max-w-2xl mx-auto p-4 space-y-4">
-      {/* 뒤로가기 */}
-      <button
-        onClick={() => router.push('/competitions')}
-        className="flex items-center gap-2 px-2.5 py-2 border-2 border-white bg-white text-black text-sm font-medium rounded-xl hover:bg-(--color-btn-focus) hover:text-white transition-colors duration-200 cursor-pointer"
-      >
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-          <path
-            d="M10 12L6 8L10 4"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
-        목록으로
-      </button>
-
-      {/* 게시글 카드 */}
-      <CompetitionDetailCard
-        data={{
-          name: competition.name,
-          image_url: competition.image_url,
-          description: competition.description,
-          event_data: competition.event_data,
-          location: competition.location,
-          apply_deadline: competition.apply_deadline,
-          created_at: competition.created_at,
-          view_count: competition.view_count,
-          nickname: competition.nickname,
-          avatar_url: competition.avatar_url,
-          role: competition.role,
-        }}
-        headerActions={
-          <>
-            {isOwner && (
-              <>
-                <button
-                  title="수정하기"
-                  onClick={() => router.push(`/competitions/${id}/edit`)}
-                  className="cursor-pointer"
-                >
-                  <Image src="/postEdit.svg" alt="" width={30} height={30} />
-                </button>
-                <button
-                  title="삭제하기"
-                  onClick={handleDeletePost}
-                  className="cursor-pointer"
-                >
-                  <Image src="/postDelete.svg" alt="" width={32} height={32} />
-                </button>
-              </>
-            )}
-            <button
-              title="공유하기"
-              onClick={() => {
-                handleShare(competition.name);
-              }}
-              className="w-8 h-8 flex items-center justify-center cursor-pointer"
-            >
-              <Image src="/postShare.svg" alt="" width={18} height={18} />
-            </button>
-          </>
-        }
-      />
-
-      {/* 신청하기 버튼 */}
-
-      <a
-        href={
-          competition.apply_url?.startsWith('http')
-            ? competition.apply_url
-            : `https://${competition.apply_url}`
-        }
-        target="_blank"
-        rel="noopener noreferrer"
-        className={`block w-full py-4 text-center text-sm font-bold text-white rounded-2xl transition-all
-          ${
-            status === '모집완료'
-              ? 'bg-gray-400 cursor-not-allowed pointer-events-none'
-              : 'bg-[#2c2c2c] hover:bg-black'
-          }`}
-      >
-        {status === '모집완료' ? '모집 완료' : '대회 신청하기'}
-      </a>
-    </div>
+    <CompetitionDetailClient
+      competition={competition}
+      userId={user?.id ?? null}
+    />
   );
 }

--- a/src/app/(main)/competitions/write/page.tsx
+++ b/src/app/(main)/competitions/write/page.tsx
@@ -1,151 +1,33 @@
-'use client';
+// app/(main)/competitions/write/page.tsx (서버 컴포넌트)
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import CompetitionWriteClient from '@/components/competition/CompetitionWriteClient';
 
-import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import LoadingSpinner from '@/components/common/LoadingSpinner';
-import { useAuth } from '@/hooks/useAuth';
-import {
-  createCompetition,
-  uploadCompetitionImage,
-} from '@/services/competitionService';
-import { showErrorToast, showSuccessToast } from '@/lib/toast';
-import PostFormActions from '@/components/community/PostFormActions';
-import { useQueryClient } from '@tanstack/react-query';
-import CompetitionForm, {
-  CompetitionFormValues,
-} from '@/components/competition/CompetitionForm';
-import CompetitionDetailCard from '@/components/competition/CompetitionDetailCard';
-
-const defaultValues: CompetitionFormValues = {
-  name: '',
-  location: '',
-  eventDate: '',
-  applyDeadline: '',
-  applyUrl: '',
-  description: '',
-  participants: '',
-  preview: null,
-  imageFile: null,
-};
-
-export default function CompetitionWritePage() {
-  const queryClient = useQueryClient();
-  const router = useRouter();
-  const { user, loading } = useAuth();
-  const [tab, setTab] = useState<'write' | 'preview'>('write');
-  const [values, setValues] = useState<CompetitionFormValues>(defaultValues);
-  const [isLoading, setIsLoading] = useState(false);
-
-  useEffect(() => {
-    if (
-      !loading &&
-      (!user || (user.role !== 'admin' && user.role !== 'manager'))
-    ) {
-      router.push('/competitions');
-    }
-  }, [user, loading, router]);
-
-  const handleSubmit = async () => {
-    if (
-      !values.name.trim() ||
-      !values.location.trim() ||
-      !values.eventDate ||
-      !values.applyDeadline
-    ) {
-      showErrorToast('필수 항목을 모두 입력해주세요.');
-      return;
-    }
-    setIsLoading(true);
-    try {
-      let image_url: string | undefined;
-      if (values.imageFile) {
-        image_url = await uploadCompetitionImage(values.imageFile);
-      }
-      await createCompetition({
-        name: values.name,
-        location: values.location,
-        event_data: values.eventDate,
-        apply_deadline: values.applyDeadline,
-        apply_url: values.applyUrl.startsWith('http')
-          ? values.applyUrl
-          : `https://${values.applyUrl}`,
-        description: values.description,
-        image_url,
-        participants: values.participants ? Number(values.participants) : 0,
-        user_id: user?.id,
-      });
-      showSuccessToast('대회일정이 추가되었습니다.', '🏆');
-      await queryClient.invalidateQueries({ queryKey: ['competition'] });
-      router.push('/competitions');
-    } catch {
-      showErrorToast('대회 추가에 실패했습니다.');
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  if (loading || isLoading) return <LoadingSpinner />;
-
-  return (
-    <div className="max-w-2xl mx-auto p-6">
-      <div className="relative w-full flex items-center justify-center mb-6">
-        <h1 className="text-lg font-semibold">대회 추가</h1>
-      </div>
-
-      {/* 탭 */}
-      <div className="flex bg-gray-100 rounded-xl p-1 mb-6">
-        <button
-          onClick={() => setTab('write')}
-          className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
-            tab === 'write' ? 'bg-white text-black shadow-sm' : 'text-gray-500'
-          }`}
-        >
-          작성
-        </button>
-        <button
-          onClick={() => setTab('preview')}
-          className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
-            tab === 'preview'
-              ? 'bg-white text-black shadow-sm'
-              : 'text-gray-500'
-          }`}
-        >
-          미리보기
-        </button>
-      </div>
-
-      {/* 작성 탭 */}
-      {tab === 'write' && (
-        <CompetitionForm values={values} onChange={setValues} />
-      )}
-
-      {/* 미리보기 탭 */}
-      {tab === 'preview' &&
-        (!values.name && !values.description ? (
-          <div className="flex flex-col items-center justify-center py-16 text-gray-400 mb-6">
-            <p className="text-sm">작성 탭에서 내용을 입력하면</p>
-            <p className="text-sm">여기서 미리볼 수 있어요.</p>
-          </div>
-        ) : (
-          <div className="mb-6">
-            <CompetitionDetailCard
-              data={{
-                name: values.name,
-                image_url: values.preview,
-                description: values.description,
-                event_data: values.eventDate,
-                location: values.location,
-                apply_deadline: values.applyDeadline,
-              }}
-            />
-          </div>
-        ))}
-
-      <PostFormActions
-        onCancel={() => router.back()}
-        onSubmit={handleSubmit}
-        submitLabel="추가하기"
-      />
-    </div>
+export default async function CompetitionWritePage() {
+  const cookieStore = await cookies();
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { cookies: { getAll: () => cookieStore.getAll() } },
   );
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect('/login');
+
+  // 프로필에서 role 확인
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single();
+
+  if (profile?.role !== 'admin' && profile?.role !== 'manager') {
+    redirect('/competitions');
+  }
+
+  return <CompetitionWriteClient userId={user.id} />;
 }

--- a/src/components/competition/CompetitionClient.tsx
+++ b/src/components/competition/CompetitionClient.tsx
@@ -79,7 +79,7 @@ export default function CompetitionClient({
             setActiveTab={setActiveTab}
             searchQuery={searchQuery}
             setSearchQuery={setSearchQuery}
-            writeLink={isManager || isAdmin ? '/competitions/write' : undefined}
+            writeLink={isAdmin ? '/competitions/write' : undefined}
             writeLinkText="일정추가"
           />
         </div>

--- a/src/components/competition/CompetitionDetailClient.tsx
+++ b/src/components/competition/CompetitionDetailClient.tsx
@@ -1,0 +1,128 @@
+// components/competition/CompetitionDetailClient.tsx
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { supabase } from '@/lib/supabase';
+import { showSuccessToast } from '@/lib/toast';
+import { useQueryClient } from '@tanstack/react-query';
+import { getStatus } from '@/utils/formatDate';
+import { handleShare } from '@/utils/share';
+import type { Competition } from '@/types/competition';
+import CompetitionDetailCard from '@/components/competition/CompetitionDetailCard';
+import Image from 'next/image';
+
+interface CompetitionDetailClientProps {
+  competition: Competition;
+  userId: string | null;
+}
+
+export default function CompetitionDetailClient({
+  competition,
+  userId,
+}: CompetitionDetailClientProps) {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { id } = competition;
+
+  const isOwner = userId === competition.user_id;
+  const status = getStatus(competition.apply_deadline);
+
+  const handleDeletePost = async () => {
+    if (!confirm('대회 게시글을 삭제하시겠습니까?')) return;
+    try {
+      await supabase.from('competition').delete().eq('id', id);
+      showSuccessToast('삭제되었습니다.', '🗑️');
+      await queryClient.invalidateQueries({ queryKey: ['competition'] });
+      router.push('/competitions');
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto p-4 space-y-4">
+      {/* 뒤로가기 */}
+      <button
+        onClick={() => router.push('/competitions')}
+        className="flex items-center gap-2 px-2.5 py-2 border-2 border-white bg-white text-black text-sm font-medium rounded-xl hover:bg-(--color-btn-focus) hover:text-white transition-colors duration-200 cursor-pointer"
+      >
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+          <path
+            d="M10 12L6 8L10 4"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+        목록으로
+      </button>
+
+      {/* 게시글 카드 */}
+      <CompetitionDetailCard
+        data={{
+          name: competition.name,
+          image_url: competition.image_url,
+          description: competition.description,
+          event_data: competition.event_data,
+          location: competition.location,
+          apply_deadline: competition.apply_deadline,
+          created_at: competition.created_at,
+          view_count: competition.view_count,
+          nickname: competition.nickname,
+          avatar_url: competition.avatar_url,
+          role: competition.role,
+        }}
+        headerActions={
+          <>
+            {isOwner && (
+              <>
+                <button
+                  title="수정하기"
+                  onClick={() => router.push(`/competitions/${id}/edit`)}
+                  className="cursor-pointer"
+                >
+                  <Image src="/postEdit.svg" alt="" width={30} height={30} />
+                </button>
+                <button
+                  title="삭제하기"
+                  onClick={handleDeletePost}
+                  className="cursor-pointer"
+                >
+                  <Image src="/postDelete.svg" alt="" width={32} height={32} />
+                </button>
+              </>
+            )}
+            <button
+              title="공유하기"
+              onClick={() => handleShare()}
+              className="w-8 h-8 flex items-center justify-center cursor-pointer"
+            >
+              <Image src="/postShare.svg" alt="" width={18} height={18} />
+            </button>
+          </>
+        }
+      />
+
+      {/* 신청하기 버튼 */}
+
+      <a
+        href={
+          competition.apply_url?.startsWith('http')
+            ? competition.apply_url
+            : `https://${competition.apply_url}`
+        }
+        target="_blank"
+        rel="noopener noreferrer"
+        className={`block w-full py-4 text-center text-sm font-bold text-white rounded-2xl transition-all
+          ${
+            status === '모집완료'
+              ? 'bg-gray-400 cursor-not-allowed pointer-events-none'
+              : 'bg-[#2c2c2c] hover:bg-black'
+          }`}
+      >
+        {status === '모집완료' ? '모집 완료' : '대회 신청하기'}
+      </a>
+    </div>
+  );
+}

--- a/src/components/competition/CompetitionEditClient.tsx
+++ b/src/components/competition/CompetitionEditClient.tsx
@@ -1,0 +1,98 @@
+// components/competition/CompetitionEditClient.tsx
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import LoadingSpinner from '@/components/common/LoadingSpinner';
+import {
+  updateCompetition,
+  uploadCompetitionImage,
+} from '@/services/competitionService';
+import { showErrorToast, showSuccessToast } from '@/lib/toast';
+import PostFormActions from '@/components/community/PostFormActions';
+import { useQueryClient } from '@tanstack/react-query';
+import CompetitionForm, {
+  CompetitionFormValues,
+} from '@/components/competition/CompetitionForm';
+import type { Competition } from '@/types/competition';
+
+interface CompetitionEditClientProps {
+  competition: Competition;
+}
+
+export default function CompetitionEditClient({
+  competition,
+}: CompetitionEditClientProps) {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+  const [values, setValues] = useState<CompetitionFormValues>({
+    name: competition.name ?? '',
+    location: competition.location ?? '',
+    eventDate: competition.event_data ?? '',
+    applyDeadline: competition.apply_deadline ?? '',
+    applyUrl: competition.apply_url ?? '',
+    description: competition.description ?? '',
+    participants: competition.participants
+      ? String(competition.participants)
+      : '',
+    preview: competition.image_url ?? null,
+    imageFile: null,
+  });
+
+  const handleSubmit = async () => {
+    if (
+      !values.name.trim() ||
+      !values.location.trim() ||
+      !values.eventDate ||
+      !values.applyDeadline
+    ) {
+      showErrorToast('필수 항목을 모두 입력해주세요.');
+      return;
+    }
+    setIsLoading(true);
+    try {
+      let image_url: string | undefined = values.preview ?? undefined;
+      if (values.imageFile) {
+        image_url = await uploadCompetitionImage(values.imageFile);
+      }
+      await updateCompetition(competition.id, {
+        name: values.name,
+        location: values.location,
+        event_data: values.eventDate,
+        apply_deadline: values.applyDeadline,
+        apply_url: values.applyUrl.startsWith('http')
+          ? values.applyUrl
+          : `https://${values.applyUrl}`,
+        description: values.description,
+        image_url,
+        participants: values.participants ? Number(values.participants) : 0,
+      });
+      showSuccessToast('대회일정이 수정되었습니다.', '✅');
+      await queryClient.invalidateQueries({ queryKey: ['competition'] });
+      router.push(`/competitions/${competition.id}`);
+    } catch {
+      showErrorToast('대회 수정에 실패했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (isLoading) return <LoadingSpinner />;
+
+  return (
+    <div className="max-w-2xl mx-auto p-6">
+      <div className="relative w-full flex items-center justify-center mb-6">
+        <h1 className="text-lg font-semibold">대회 수정</h1>
+      </div>
+
+      <CompetitionForm values={values} onChange={setValues} />
+
+      <PostFormActions
+        onCancel={() => router.back()}
+        onSubmit={handleSubmit}
+        submitLabel="수정하기"
+      />
+    </div>
+  );
+}

--- a/src/components/competition/CompetitionWriteClient.tsx
+++ b/src/components/competition/CompetitionWriteClient.tsx
@@ -1,0 +1,141 @@
+// components/competition/CompetitionWriteClient.tsx
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import LoadingSpinner from '@/components/common/LoadingSpinner';
+import {
+  createCompetition,
+  uploadCompetitionImage,
+} from '@/services/competitionService';
+import { showErrorToast, showSuccessToast } from '@/lib/toast';
+import PostFormActions from '@/components/community/PostFormActions';
+import { useQueryClient } from '@tanstack/react-query';
+import CompetitionForm, {
+  CompetitionFormValues,
+} from '@/components/competition/CompetitionForm';
+import CompetitionDetailCard from '@/components/competition/CompetitionDetailCard';
+
+const defaultValues: CompetitionFormValues = {
+  name: '',
+  location: '',
+  eventDate: '',
+  applyDeadline: '',
+  applyUrl: '',
+  description: '',
+  participants: '',
+  preview: null,
+  imageFile: null,
+};
+
+export default function CompetitionWriteClient({ userId }: { userId: string }) {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const [tab, setTab] = useState<'write' | 'preview'>('write');
+  const [values, setValues] = useState<CompetitionFormValues>(defaultValues);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = async () => {
+    if (
+      !values.name.trim() ||
+      !values.location.trim() ||
+      !values.eventDate ||
+      !values.applyDeadline
+    ) {
+      showErrorToast('필수 항목을 모두 입력해주세요.');
+      return;
+    }
+    setIsLoading(true);
+    try {
+      let image_url: string | undefined;
+      if (values.imageFile) {
+        image_url = await uploadCompetitionImage(values.imageFile);
+      }
+      await createCompetition({
+        name: values.name,
+        location: values.location,
+        event_data: values.eventDate,
+        apply_deadline: values.applyDeadline,
+        apply_url: values.applyUrl.startsWith('http')
+          ? values.applyUrl
+          : `https://${values.applyUrl}`,
+        description: values.description,
+        image_url,
+        participants: values.participants ? Number(values.participants) : 0,
+        user_id: userId,
+      });
+      showSuccessToast('대회일정이 추가되었습니다.', '🏆');
+      await queryClient.invalidateQueries({ queryKey: ['competition'] });
+      router.push('/competitions');
+    } catch {
+      showErrorToast('대회 추가에 실패했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (isLoading) return <LoadingSpinner />;
+
+  return (
+    <div className="max-w-2xl mx-auto p-6">
+      <div className="relative w-full flex items-center justify-center mb-6">
+        <h1 className="text-lg font-semibold">대회 추가</h1>
+      </div>
+
+      {/* 탭 */}
+      <div className="flex bg-gray-100 rounded-xl p-1 mb-6">
+        <button
+          onClick={() => setTab('write')}
+          className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
+            tab === 'write' ? 'bg-white text-black shadow-sm' : 'text-gray-500'
+          }`}
+        >
+          작성
+        </button>
+        <button
+          onClick={() => setTab('preview')}
+          className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
+            tab === 'preview'
+              ? 'bg-white text-black shadow-sm'
+              : 'text-gray-500'
+          }`}
+        >
+          미리보기
+        </button>
+      </div>
+
+      {/* 작성 탭 */}
+      {tab === 'write' && (
+        <CompetitionForm values={values} onChange={setValues} />
+      )}
+
+      {/* 미리보기 탭 */}
+      {tab === 'preview' &&
+        (!values.name && !values.description ? (
+          <div className="flex flex-col items-center justify-center py-16 text-gray-400 mb-6">
+            <p className="text-sm">작성 탭에서 내용을 입력하면</p>
+            <p className="text-sm">여기서 미리볼 수 있어요.</p>
+          </div>
+        ) : (
+          <div className="mb-6">
+            <CompetitionDetailCard
+              data={{
+                name: values.name,
+                image_url: values.preview,
+                description: values.description,
+                event_data: values.eventDate,
+                location: values.location,
+                apply_deadline: values.applyDeadline,
+              }}
+            />
+          </div>
+        ))}
+
+      <PostFormActions
+        onCancel={() => router.back()}
+        onSubmit={handleSubmit}
+        submitLabel="추가하기"
+      />
+    </div>
+  );
+}

--- a/src/utils/share.ts
+++ b/src/utils/share.ts
@@ -1,11 +1,11 @@
 import { showSuccessToast, showErrorToast } from '@/lib/toast';
 
-export async function handleShare(title: string) {
+export async function handleShare() {
   const url = window.location.href;
 
   if (navigator.share && /Mobi|Android/i.test(navigator.userAgent)) {
     try {
-      await navigator.share({ title, url });
+      await navigator.share({ url });
     } catch {
       // 취소 무시
     }


### PR DESCRIPTION
## 📌 개요

- 대회일정, 상세, 작성, 수정 페이지 구조 변경 csr -> ssr

## 💻 작업 사항
SSR 구조 전환
변경 내용

- 작성 페이지
app/(main)/competitions/write/page.tsx → 서버 컴포넌트로 전환
서버에서 유저 권한(admin/manager) 확인 후 미인가 시 리다이렉트

components/competition/CompetitionWriteClient.tsx 신규 생성
기존 클라이언트 로직 분리, userId를 props로 주입받아 처리

- 수정 페이지
app/(main)/competitions/[id]/edit/page.tsx → 서버 컴포넌트로 전환
서버에서 유저 권한 확인 및 기존 대회 데이터 fetch

components/competition/CompetitionEditClient.tsx 신규 생성
기존 데이터를 props로 받아 초기값 설정, useEffect 제거

- 상세 페이지
app/(main)/competitions/[id]/page.tsx → 서버 컴포넌트로 전환
서버에서 유저 정보 및 대회 데이터 fetch, 조회수 증가 처리

components/competition/CompetitionDetailClient.tsx 신규 생성
삭제/공유 등 이벤트 처리만 담당

- 개선 효과
권한 체크가 서버에서 이루어져 보안 강화
클라이언트에서 useAuth, useEffect 데이터 로딩 제거로 코드 간소화
초기 데이터 로딩 시 로딩 스피너 없이 바로 렌더링 가능
<img width="1168" height="658" alt="스크린샷 2026-05-08 시간: 10 23 42" src="https://github.com/user-attachments/assets/567fef38-84b4-4f41-a21d-ce34266d1d6e" />
<img width="1200" height="750" alt="스크린샷 2026-05-08 시간: 10 23 54" src="https://github.com/user-attachments/assets/5a5e65cd-b187-4de6-878d-246c5dc64fd3" />
<img width="1198" height="756" alt="스크린샷 2026-05-08 시간: 10 24 05" src="https://github.com/user-attachments/assets/6c8690b0-7eff-432d-8903-1e2035152203" />
<img width="1281" height="789" alt="스크린샷 2026-05-08 시간: 10 24 15" src="https://github.com/user-attachments/assets/25c70d33-cdc4-45e6-a7b9-0c095f7b0545" />

## 💡 관련 Issue

Closes #105 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #105 )
- [x] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
