### PR TITLE
[Feat] LimitedInput / LimitedTextarea 공통 컴포넌트 추가 및 적용

### DIFF
--- a/src/components/common/LimitedInput.tsx
+++ b/src/components/common/LimitedInput.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+
+interface LimitedInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  maxLength: number;
+  warnAt?: number; // 생략 시 maxLength의 80%
+  placeholder?: string;
+  label?: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function LimitedInput({
+  value,
+  onChange,
+  maxLength,
+  warnAt,
+  placeholder,
+  label,
+  disabled,
+  className,
+}: LimitedInputProps) {
+  const threshold = warnAt ?? Math.floor(maxLength * 0.8);
+  const len = value.length;
+  const isWarn = len >= threshold && len < maxLength;
+  const isError = len >= maxLength;
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onChange(e.target.value.slice(0, maxLength));
+    },
+    [onChange, maxLength],
+  );
+
+  const counterColor = isError
+    ? 'text-red-500'
+    : isWarn
+      ? 'text-yellow-500'
+      : 'text-gray-400';
+
+  const borderColor = isError
+    ? 'border-red-400 focus:ring-red-400'
+    : isWarn
+      ? 'border-yellow-400 focus:ring-yellow-400'
+      : 'border-gray-300 focus:ring-blue-400';
+
+  return (
+    <div className={className}>
+      {label && (
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          {label}
+        </label>
+      )}
+      <div className="relative">
+        <input
+          type="text"
+          value={value}
+          onChange={handleChange}
+          placeholder={placeholder}
+          disabled={disabled}
+          maxLength={maxLength}
+          className={`w-full pr-20 px-3 py-2 text-sm border rounded-lg
+            focus:outline-none focus:ring-1 transition-colors
+            disabled:bg-gray-50 disabled:text-gray-400
+            ${borderColor}`}
+        />
+        <span
+          className={`absolute right-3 top-1/2 -translate-y-1/2 text-xs ${counterColor}`}
+        >
+          {len.toLocaleString()} / {maxLength.toLocaleString()}
+        </span>
+      </div>
+      {isError && (
+        <p className="mt-1 text-xs text-red-500">
+          최대 {maxLength.toLocaleString()}자까지 입력할 수 있어요
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/common/LimitedInput.tsx
+++ b/src/components/common/LimitedInput.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback } from 'react';
 
 interface LimitedInputProps {
+  id?: string;
   value: string;
   onChange: (value: string) => void;
   maxLength: number;
@@ -14,6 +15,7 @@ interface LimitedInputProps {
 }
 
 export function LimitedInput({
+  id,
   value,
   onChange,
   maxLength,
@@ -56,6 +58,7 @@ export function LimitedInput({
       )}
       <div className="relative">
         <input
+          id={id}
           type="text"
           value={value}
           onChange={handleChange}

--- a/src/components/common/LimitedInput.tsx
+++ b/src/components/common/LimitedInput.tsx
@@ -12,6 +12,7 @@ interface LimitedInputProps {
   label?: string;
   disabled?: boolean;
   className?: string;
+  'aria-required'?: boolean | 'true' | 'false';
 }
 
 export function LimitedInput({
@@ -24,6 +25,7 @@ export function LimitedInput({
   label,
   disabled,
   className,
+  'aria-required': ariaRequired,
 }: LimitedInputProps) {
   const threshold = warnAt ?? Math.floor(maxLength * 0.8);
   const len = value.length;
@@ -58,6 +60,7 @@ export function LimitedInput({
       )}
       <div className="relative">
         <input
+          aria-required={ariaRequired}
           id={id}
           type="text"
           value={value}

--- a/src/components/common/LimitedTextarea.tsx
+++ b/src/components/common/LimitedTextarea.tsx
@@ -3,6 +3,7 @@
 import { useCallback } from 'react';
 
 interface LimitedTextareaProps {
+  id?: string;
   value: string;
   onChange: (value: string) => void;
   maxLength: number;
@@ -13,9 +14,11 @@ interface LimitedTextareaProps {
   allowNewline?: boolean; // false면 댓글처럼 줄바꿈 차단
   disabled?: boolean;
   className?: string;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
 }
 
 export function LimitedTextarea({
+  id,
   value,
   onChange,
   maxLength,
@@ -26,6 +29,7 @@ export function LimitedTextarea({
   allowNewline = true,
   disabled,
   className,
+  onKeyDown,
 }: LimitedTextareaProps) {
   const threshold = warnAt ?? Math.floor(maxLength * 0.8);
   const len = value.length;
@@ -44,8 +48,9 @@ export function LimitedTextarea({
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       if (!allowNewline && e.key === 'Enter') e.preventDefault();
+      onKeyDown?.(e); // 외부 onKeyDown 실행
     },
-    [allowNewline],
+    [allowNewline, onKeyDown],
   );
 
   const counterColor = isError
@@ -69,6 +74,7 @@ export function LimitedTextarea({
       )}
       <div className="relative">
         <textarea
+          id={id}
           value={value}
           onChange={handleChange}
           onKeyDown={handleKeyDown}

--- a/src/components/common/LimitedTextarea.tsx
+++ b/src/components/common/LimitedTextarea.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useCallback } from 'react';
+
+interface LimitedTextareaProps {
+  value: string;
+  onChange: (value: string) => void;
+  maxLength: number;
+  warnAt?: number;
+  placeholder?: string;
+  label?: string;
+  rows?: number;
+  allowNewline?: boolean; // false면 댓글처럼 줄바꿈 차단
+  disabled?: boolean;
+  className?: string;
+}
+
+export function LimitedTextarea({
+  value,
+  onChange,
+  maxLength,
+  warnAt,
+  placeholder,
+  label,
+  rows = 4,
+  allowNewline = true,
+  disabled,
+  className,
+}: LimitedTextareaProps) {
+  const threshold = warnAt ?? Math.floor(maxLength * 0.8);
+  const len = value.length;
+  const isWarn = len >= threshold && len < maxLength;
+  const isError = len >= maxLength;
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      let next = e.target.value.slice(0, maxLength);
+      if (!allowNewline) next = next.replace(/\n/g, '');
+      onChange(next);
+    },
+    [onChange, maxLength, allowNewline],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (!allowNewline && e.key === 'Enter') e.preventDefault();
+    },
+    [allowNewline],
+  );
+
+  const counterColor = isError
+    ? 'text-red-500'
+    : isWarn
+      ? 'text-yellow-500'
+      : 'text-gray-400';
+
+  const borderColor = isError
+    ? 'border-red-400 focus:ring-red-400'
+    : isWarn
+      ? 'border-yellow-400 focus:ring-yellow-400'
+      : 'border-gray-300 focus:ring-blue-400';
+
+  return (
+    <div className={className}>
+      {label && (
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          {label}
+        </label>
+      )}
+      <div className="relative">
+        <textarea
+          value={value}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          disabled={disabled}
+          rows={rows}
+          className={`w-full px-3 py-2 pb-6 text-sm border rounded-lg resize-none
+            focus:outline-none focus:ring-1 transition-colors
+            disabled:bg-gray-50 disabled:text-gray-400
+            ${borderColor}`}
+        />
+        <span className={`absolute right-3 bottom-2 text-xs ${counterColor}`}>
+          {len.toLocaleString()} / {maxLength.toLocaleString()}
+        </span>
+      </div>
+      {isError && (
+        <p className="mt-1 text-xs text-red-500">
+          최대 {maxLength.toLocaleString()}자까지 입력할 수 있어요
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/community/EditClient.tsx
+++ b/src/components/community/EditClient.tsx
@@ -8,6 +8,8 @@ import { updatePost, uploadPostImage } from '@/services/communityService';
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
 import ImageUpload from '@/components/community/ImageUpload';
 import PostFormActions from '@/components/community/PostFormActions';
+import { LimitedInput } from '../common/LimitedInput';
+import { LimitedTextarea } from '../common/LimitedTextarea';
 
 interface Props {
   id: string;
@@ -72,13 +74,12 @@ export default function EditClient({ id, initialPost }: Props) {
         >
           제목
         </label>
-        <input
+        <LimitedInput
           id="post-title"
-          type="text"
-          placeholder="제목을 입력하세요"
           value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          className="w-full bg-gray-50 rounded-lg px-3 py-2 text-sm outline-none"
+          onChange={setTitle}
+          maxLength={35}
+          placeholder="제목을 입력하세요"
         />
       </div>
 
@@ -97,13 +98,13 @@ export default function EditClient({ id, initialPost }: Props) {
         >
           내용
         </label>
-        <textarea
+        <LimitedTextarea
           id="post-content"
-          placeholder="내용을 입력하세요"
           value={content}
-          onChange={(e) => setContent(e.target.value)}
+          onChange={setContent}
+          maxLength={5000}
           rows={8}
-          className="w-full bg-gray-50 rounded-lg px-3 py-2 text-sm outline-none resize-none"
+          placeholder="내용을 입력하세요"
         />
       </div>
 

--- a/src/components/community/PostDetailClient.tsx
+++ b/src/components/community/PostDetailClient.tsx
@@ -20,6 +20,7 @@ import PostDetailCard, {
   PostDetailCardData,
 } from '@/components/community/PostDetailCard';
 import { timeAgo } from '@/utils/timeAgo';
+import { LimitedTextarea } from '../common/LimitedTextarea';
 
 interface Props {
   id: string;
@@ -260,14 +261,16 @@ export default function PostDetailClient({
             <label htmlFor="comment-input" className="sr-only">
               댓글 입력
             </label>
-            <input
-              type="text"
+            <LimitedTextarea
               id="comment-input"
-              placeholder="댓글을 입력하세요..."
               value={comment}
-              onChange={(e) => setComment(e.target.value)}
+              onChange={setComment}
+              maxLength={300}
+              allowNewline={false}
+              rows={1}
+              placeholder="댓글을 입력하세요..."
+              className="flex-1"
               onKeyDown={(e) => e.key === 'Enter' && handleCommentSubmit()}
-              className="flex-1 bg-gray-50 border border-gray-200 rounded-xl px-4 py-2.5 text-sm outline-none focus:border-gray-400 transition-colors placeholder:text-gray-400"
             />
             <button
               onClick={handleCommentSubmit}
@@ -321,16 +324,17 @@ export default function PostDetailClient({
                       >
                         댓글 수정 입력
                       </label>
-                      <input
+                      <LimitedTextarea
                         id={`edit-comment-${c.id}`}
-                        type="text"
                         value={editingContent}
-                        onChange={(e) => setEditingContent(e.target.value)}
+                        onChange={setEditingContent}
+                        maxLength={300}
+                        allowNewline={false}
+                        rows={1}
+                        className="flex-1"
                         onKeyDown={(e) =>
                           e.key === 'Enter' && handleEditComment(c.id)
-                        }
-                        className="flex-1 bg-gray-50 border border-gray-200 rounded-xl px-3 py-1.5 text-sm outline-none focus:border-gray-400"
-                        autoFocus
+                        } // 추가
                       />
                       <button
                         onClick={() => handleEditComment(c.id)}

--- a/src/components/community/WriteClient.tsx
+++ b/src/components/community/WriteClient.tsx
@@ -11,6 +11,8 @@ import { showErrorToast, showSuccessToast } from '@/lib/toast';
 import ImageUpload from '@/components/community/ImageUpload';
 import PostFormActions from '@/components/community/PostFormActions';
 import PostDetailCard from '@/components/community/PostDetailCard';
+import { LimitedInput } from '../common/LimitedInput';
+import { LimitedTextarea } from '../common/LimitedTextarea';
 
 export default function WriteClient() {
   const router = useRouter();
@@ -127,13 +129,12 @@ export default function WriteClient() {
             >
               제목
             </label>
-            <input
+            <LimitedInput
               id="post-title"
-              type="text"
-              placeholder="제목을 입력하세요"
               value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              className="w-full bg-gray-50 rounded-lg px-3 py-2 text-sm outline-none"
+              onChange={setTitle}
+              maxLength={35}
+              placeholder="제목을 입력하세요"
             />
           </div>
 
@@ -152,13 +153,13 @@ export default function WriteClient() {
             >
               내용
             </label>
-            <textarea
+            <LimitedTextarea
               id="post-content"
-              placeholder="내용을 입력하세요"
               value={content}
-              onChange={(e) => setContent(e.target.value)}
+              onChange={setContent}
+              maxLength={5000}
               rows={8}
-              className="w-full bg-gray-50 rounded-lg px-3 py-2 text-sm outline-none resize-none"
+              placeholder="내용을 입력하세요"
             />
           </div>
         </>

--- a/src/components/competition/CompetitionForm.tsx
+++ b/src/components/competition/CompetitionForm.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import ImageUpload from '@/components/community/ImageUpload';
+import { LimitedInput } from '../common/LimitedInput';
+import { LimitedTextarea } from '../common/LimitedTextarea';
 
 export interface CompetitionFormValues {
   name: string;
@@ -45,14 +47,13 @@ export default function CompetitionForm({
           </span>
           <span className="sr-only">(필수)</span>
         </label>
-        <input
+        <LimitedInput
           id="competition-name"
-          type="text"
-          placeholder="예: 2026 서울 주짓수 챔피언십"
           value={values.name}
-          onChange={(e) => update('name', e.target.value)}
+          onChange={(v) => update('name', v)}
+          maxLength={35}
+          placeholder="예: 2026 서울 주짓수 챔피언십"
           aria-required="true"
-          className="w-full bg-gray-50 rounded-lg px-3 py-2 text-sm outline-none"
         />
       </div>
 
@@ -211,13 +212,13 @@ export default function CompetitionForm({
         >
           대회 설명
         </label>
-        <textarea
+        <LimitedTextarea
           id="competition-description"
-          placeholder="대회에 대한 상세 설명을 입력하세요"
           value={values.description}
-          onChange={(e) => update('description', e.target.value)}
+          onChange={(v) => update('description', v)}
+          maxLength={5000}
           rows={6}
-          className="w-full bg-gray-50 rounded-lg px-3 py-2 text-sm outline-none resize-none"
+          placeholder="대회에 대한 상세 설명을 입력하세요"
         />
       </div>
     </div>


### PR DESCRIPTION
## 📌 개요

- 글자수 제한이 필요한 입력 필드를 공통 컴포넌트로 분리하고, 커뮤니티 및 대회 일정 페이지에 적용했습니다.

## 💻 작업 사항

### 신규 파일
components/common/LimitedInput.tsx
components/common/LimitedTextarea.tsx

---

### 변경 파일
components/community/WriteClient.tsx — 제목 35자, 내용 5,000자
components/community/EditClient.tsx — 제목 35자, 내용 5,000자
components/community/PostDetailClient.tsx — 댓글 300자, 줄바꿈 차단, Enter 제출
components/competition/CompetitionForm.tsx — 대회 제목 35자, 대회 설명 5,000자

---

### 주요 기능
- 글자수 카운터 표시 (현재 / 최대)
- 80% 도달 시 경고 색상 (yellow), 최대 도달 시 에러 색상 (red)
- warnAt prop으로 경고 타이밍 커스텀 가능
- allowNewline={false} 로 줄바꿈 차단 (댓글 용)
- onKeyDown prop으로 Enter 제출 등 외부 핸들러 연결 가능

<img width="1112" height="320" alt="20260508-0830-43 4455953" src="https://github.com/user-attachments/assets/3bd04c70-53f9-4276-a625-759e610f41bf" />
<img width="1040" height="867" alt="image" src="https://github.com/user-attachments/assets/b9f7d098-7d11-47f0-ab47-fdd42fb676bb" />

---

미적용 (추후 PR 예정)
- 마이페이지 프로필 설정 (닉네임 10자, 자기소개 200자) — 구현 완료 후 적용 예정
- 댓글 어뷰징 방지 로직 (쿨타임, 중복 차단, 연속 작성 제한) — 별도 PR 예정

## 💡 관련 Issue

Closes #115 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #115 )
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
