### PR TITLE
[Feat] 비밀번호 찾기 페이지 구현(API 유효성검사 및 UI)

### DIFF
--- a/src/app/(auth)/find-password/page.tsx
+++ b/src/app/(auth)/find-password/page.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Mail, Lock, User } from 'lucide-react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { z } from 'zod';
+import { supabase } from '@/lib/supabase';
+
+const step1Schema = z.object({
+  name: z.string().min(1, '이름을 입력해주세요.'),
+  email: z.string().email('올바른 이메일 형식으로 작성해주세요.'),
+});
+
+const step2Schema = z
+  .object({
+    password: z.string().min(6, '비밀번호는 6자 이상이어야 합니다.'),
+    confirmPassword: z.string().min(1, '비밀번호 확인을 입력해주세요.'),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: '비밀번호가 일치하지 않습니다.',
+    path: ['confirmPassword'],
+  });
+
+export default function FindPasswordPage() {
+  return <div>비밀번호 찾기</div>;
+}

--- a/src/app/(auth)/find-password/page.tsx
+++ b/src/app/(auth)/find-password/page.tsx
@@ -223,7 +223,7 @@ export default function FindPasswordPage() {
               type="submit"
               className="w-full bg-btn-focus text-btn-focus-text py-4 rounded-2xl font-bold text-lg hover:opacity-90 transition-all cursor-pointer"
             >
-              비밀번호 재설정
+              재설정 완료
             </button>
 
             <p className="text-center text-sm text-text-secondary">

--- a/src/app/(auth)/find-password/page.tsx
+++ b/src/app/(auth)/find-password/page.tsx
@@ -37,5 +37,39 @@ export default function FindPasswordPage() {
   }>({});
   const router = useRouter();
 
-  return <div>비밀번호 찾기</div>;
+  return (
+    <>
+      <p className="text-text-secondary text-sm font-medium text-center mb-6">
+        주짓수 커뮤니티에 오신 것을 환영합니다
+      </p>
+
+      <div className="max-w-150 w-full bg-bg-white rounded-[32px] p-8 shadow-sm border-none">
+        <h2 className="text-2xl font-bold text-center text-text-primary mb-8">
+          비밀번호 찾기
+        </h2>
+
+        {/* 탭 */}
+        <div className="flex mb-8 border-b border-gray-200">
+          <button
+            className={`flex-1 py-2 text-sm font-bold transition-all ${
+              step === 1
+                ? 'border-b-2 border-btn-focus text-btn-focus'
+                : 'text-text-secondary'
+            }`}
+          >
+            비밀번호 찾기
+          </button>
+          <button
+            className={`flex-1 py-2 text-sm font-bold transition-all ${
+              step === 2
+                ? 'border-b-2 border-btn-focus text-btn-focus'
+                : 'text-text-secondary'
+            }`}
+          >
+            비밀번호 재설정
+          </button>
+        </div>
+      </div>
+    </>
+  );
 }

--- a/src/app/(auth)/find-password/page.tsx
+++ b/src/app/(auth)/find-password/page.tsx
@@ -69,6 +69,76 @@ export default function FindPasswordPage() {
             비밀번호 재설정
           </button>
         </div>
+        {step === 1 ? (
+          <form
+            className="space-y-5"
+            onSubmit={(e) => {
+              e.preventDefault();
+            }}
+          >
+            {/* 이름 */}
+            <div>
+              <label className="block text-sm font-medium text-text-primary mb-2">
+                이름
+              </label>
+              <div className="relative">
+                <User className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-text-secondary" />
+                <input
+                  type="text"
+                  placeholder="이름을 입력하세요"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  className="w-full bg-input-bg border-none rounded-2xl py-4 pl-12 pr-4 text-base text-input-text focus:ring-2 focus:ring-btn-focus outline-none transition-all"
+                />
+              </div>
+              <p className="text-danger text-sm mt-1 h-5">
+                {errors.name ?? ''}
+              </p>
+            </div>
+
+            {/* 이메일 */}
+            <div>
+              <label className="block text-sm font-medium text-text-primary mb-2">
+                이메일
+              </label>
+              <div className="relative">
+                <Mail className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-text-secondary" />
+                <input
+                  type="email"
+                  placeholder="이메일을 입력하세요"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  className="w-full bg-input-bg border-none rounded-2xl py-4 pl-12 pr-4 text-base text-input-text focus:ring-2 focus:ring-btn-focus outline-none transition-all"
+                />
+              </div>
+              <p className="text-danger text-sm mt-1 h-5">
+                {errors.email ?? ''}
+              </p>
+            </div>
+
+            <p className="text-danger text-sm text-center h-5">
+              {errors.server ?? ''}
+            </p>
+
+            <button
+              type="submit"
+              className="w-full bg-btn-focus text-btn-focus-text py-4 rounded-2xl font-bold text-lg hover:opacity-90 transition-all cursor-pointer"
+            >
+              비밀번호 재설정
+            </button>
+
+            <p className="text-center text-sm text-text-secondary">
+              로그인으로 돌아가기{' '}
+              <Link
+                href="/login"
+                className="font-bold hover:underline"
+                style={{ color: 'var(--color-auth-register)' }}
+              >
+                로그인
+              </Link>
+            </p>
+          </form>
+        ) : null}
       </div>
     </>
   );

--- a/src/app/(auth)/find-password/page.tsx
+++ b/src/app/(auth)/find-password/page.tsx
@@ -47,28 +47,7 @@ export default function FindPasswordPage() {
       return;
     }
     setErrors({});
-    const handleStep2 = async () => {
-      const result = step2Schema.safeParse({ password, confirmPassword });
-      if (!result.success) {
-        const fieldErrors = result.error.flatten().fieldErrors;
-        setErrors({
-          password: fieldErrors.password?.[0],
-          confirmPassword: fieldErrors.confirmPassword?.[0],
-        });
-        return;
-      }
-      setErrors({});
 
-      const { error } = await supabase.auth.updateUser({ password });
-      if (error) {
-        setErrors({
-          server: '비밀번호 재설정에 실패했습니다. 다시 시도해주세요.',
-        });
-        return;
-      }
-
-      router.push('/login');
-    };
     const { data, error } = await supabase
       .from('profiles')
       .select('id')
@@ -85,7 +64,28 @@ export default function FindPasswordPage() {
 
     setStep(2);
   };
+  const handleStep2 = async () => {
+    const result = step2Schema.safeParse({ password, confirmPassword });
+    if (!result.success) {
+      const fieldErrors = result.error.flatten().fieldErrors;
+      setErrors({
+        password: fieldErrors.password?.[0],
+        confirmPassword: fieldErrors.confirmPassword?.[0],
+      });
+      return;
+    }
+    setErrors({});
 
+    const { error } = await supabase.auth.updateUser({ password });
+    if (error) {
+      setErrors({
+        server: '비밀번호 재설정에 실패했습니다. 다시 시도해주세요.',
+      });
+      return;
+    }
+
+    router.push('/login');
+  };
   return (
     <>
       <p className="text-text-secondary text-sm font-medium text-center mb-6">

--- a/src/app/(auth)/find-password/page.tsx
+++ b/src/app/(auth)/find-password/page.tsx
@@ -1,3 +1,0 @@
-export default function Page() {
-  return <div>블벨</div>;
-}

--- a/src/app/(auth)/find-password/page.tsx
+++ b/src/app/(auth)/find-password/page.tsx
@@ -47,7 +47,28 @@ export default function FindPasswordPage() {
       return;
     }
     setErrors({});
+    const handleStep2 = async () => {
+      const result = step2Schema.safeParse({ password, confirmPassword });
+      if (!result.success) {
+        const fieldErrors = result.error.flatten().fieldErrors;
+        setErrors({
+          password: fieldErrors.password?.[0],
+          confirmPassword: fieldErrors.confirmPassword?.[0],
+        });
+        return;
+      }
+      setErrors({});
 
+      const { error } = await supabase.auth.updateUser({ password });
+      if (error) {
+        setErrors({
+          server: '비밀번호 재설정에 실패했습니다. 다시 시도해주세요.',
+        });
+        return;
+      }
+
+      router.push('/login');
+    };
     const { data, error } = await supabase
       .from('profiles')
       .select('id')
@@ -172,6 +193,7 @@ export default function FindPasswordPage() {
             className="space-y-5"
             onSubmit={(e) => {
               e.preventDefault();
+              handleStep2();
             }}
           >
             {/* 새 비밀번호 */}

--- a/src/app/(auth)/find-password/page.tsx
+++ b/src/app/(auth)/find-password/page.tsx
@@ -57,7 +57,7 @@ export default function FindPasswordPage() {
 
     if (error || !data) {
       setErrors({
-        server: '입력하신 이메일로 가입된 계정을 찾을 수 없습니다.',
+        server: '이름 또는 이메일이 올바르지 않습니다.',
       });
       return;
     }

--- a/src/app/(auth)/find-password/page.tsx
+++ b/src/app/(auth)/find-password/page.tsx
@@ -23,5 +23,19 @@ const step2Schema = z
   });
 
 export default function FindPasswordPage() {
+  const [step, setStep] = useState<1 | 2>(1);
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [errors, setErrors] = useState<{
+    name?: string;
+    email?: string;
+    password?: string;
+    confirmPassword?: string;
+    server?: string;
+  }>({});
+  const router = useRouter();
+
   return <div>비밀번호 찾기</div>;
 }

--- a/src/app/(auth)/find-password/page.tsx
+++ b/src/app/(auth)/find-password/page.tsx
@@ -36,6 +36,34 @@ export default function FindPasswordPage() {
     server?: string;
   }>({});
   const router = useRouter();
+  const handleStep1 = async () => {
+    const result = step1Schema.safeParse({ name, email });
+    if (!result.success) {
+      const fieldErrors = result.error.flatten().fieldErrors;
+      setErrors({
+        name: fieldErrors.name?.[0],
+        email: fieldErrors.email?.[0],
+      });
+      return;
+    }
+    setErrors({});
+
+    const { data, error } = await supabase
+      .from('profiles')
+      .select('id')
+      .eq('email_value', email)
+      .eq('name', name)
+      .single();
+
+    if (error || !data) {
+      setErrors({
+        server: '입력하신 이메일로 가입된 계정을 찾을 수 없습니다.',
+      });
+      return;
+    }
+
+    setStep(2);
+  };
 
   return (
     <>
@@ -74,6 +102,7 @@ export default function FindPasswordPage() {
             className="space-y-5"
             onSubmit={(e) => {
               e.preventDefault();
+              handleStep1();
             }}
           >
             {/* 이름 */}

--- a/src/app/(auth)/find-password/page.tsx
+++ b/src/app/(auth)/find-password/page.tsx
@@ -167,7 +167,76 @@ export default function FindPasswordPage() {
               </Link>
             </p>
           </form>
-        ) : null}
+        ) : (
+          <form
+            className="space-y-5"
+            onSubmit={(e) => {
+              e.preventDefault();
+            }}
+          >
+            {/* 새 비밀번호 */}
+            <div>
+              <label className="block text-sm font-medium text-text-primary mb-2">
+                새 비밀번호
+              </label>
+              <div className="relative">
+                <Lock className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-text-secondary" />
+                <input
+                  type="password"
+                  placeholder="새 비밀번호를 입력하세요"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  className="w-full bg-input-bg border-none rounded-2xl py-4 pl-12 pr-4 text-base text-input-text focus:ring-2 focus:ring-btn-focus outline-none transition-all"
+                />
+              </div>
+              <p className="text-danger text-sm mt-1 h-5">
+                {errors.password ?? ''}
+              </p>
+            </div>
+
+            {/* 비밀번호 확인 */}
+            <div>
+              <label className="block text-sm font-medium text-text-primary mb-2">
+                비밀번호 확인
+              </label>
+              <div className="relative">
+                <Lock className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-text-secondary" />
+                <input
+                  type="password"
+                  placeholder="비밀번호를 다시 입력하세요"
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  className="w-full bg-input-bg border-none rounded-2xl py-4 pl-12 pr-4 text-base text-input-text focus:ring-2 focus:ring-btn-focus outline-none transition-all"
+                />
+              </div>
+              <p className="text-danger text-sm mt-1 h-5">
+                {errors.confirmPassword ?? ''}
+              </p>
+            </div>
+
+            <p className="text-danger text-sm text-center h-5">
+              {errors.server ?? ''}
+            </p>
+
+            <button
+              type="submit"
+              className="w-full bg-btn-focus text-btn-focus-text py-4 rounded-2xl font-bold text-lg hover:opacity-90 transition-all cursor-pointer"
+            >
+              비밀번호 재설정
+            </button>
+
+            <p className="text-center text-sm text-text-secondary">
+              로그인으로 돌아가기{' '}
+              <Link
+                href="/login"
+                className="font-bold hover:underline"
+                style={{ color: 'var(--color-auth-register)' }}
+              >
+                로그인
+              </Link>
+            </p>
+          </form>
+        )}
       </div>
     </>
   );

--- a/src/app/(auth)/find-password/page.tsx
+++ b/src/app/(auth)/find-password/page.tsx
@@ -94,30 +94,9 @@ export default function FindPasswordPage() {
 
       <div className="max-w-150 w-full bg-bg-white rounded-[32px] p-8 shadow-sm border-none">
         <h2 className="text-2xl font-bold text-center text-text-primary mb-8">
-          비밀번호 찾기
+          {step === 1 ? '비밀번호 찾기' : '비밀번호 재설정'}
         </h2>
 
-        {/* 탭 */}
-        <div className="flex mb-8 border-b border-gray-200">
-          <button
-            className={`flex-1 py-2 text-sm font-bold transition-all ${
-              step === 1
-                ? 'border-b-2 border-btn-focus text-btn-focus'
-                : 'text-text-secondary'
-            }`}
-          >
-            비밀번호 찾기
-          </button>
-          <button
-            className={`flex-1 py-2 text-sm font-bold transition-all ${
-              step === 2
-                ? 'border-b-2 border-btn-focus text-btn-focus'
-                : 'text-text-secondary'
-            }`}
-          >
-            비밀번호 재설정
-          </button>
-        </div>
         {step === 1 ? (
           <form
             className="space-y-5"

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -162,7 +162,7 @@ export default function LoginPage() {
               </span>
             </label>
             <Link
-              href="/forgot-password"
+              href="/find-password"
               className="text-sm font-bold hover:underline text-[#4f74e8]"
             >
               비밀번호 찾기


### PR DESCRIPTION
## 📌 개요

비밀번호 찾기 페이지를 구현했습니다.
이메일 발송 방식이 아닌 이름 + 이메일 입력 후 비밀번호 재설정하는 방식으로 구현했습니다.

## 💻 작업 사항

-  비밀번호 찾기 페이지 UI 구현 (로그인 UI 재사용)
-  이름 + 이메일 입력 폼 구현
-  유효성 검사 및 오류 메세지 표시
-  비밀번호 재설정 폼 UI 구현
-  로그인 페이지 비밀번호 찾기 링크 경로 수정

- 비밀번호 찾기에서 정보 입력 후 비밀번호 재설정 버튼 누르면 비밀번호 재설정으로 이동함

<img width="843" height="823" alt="스크린샷 2026-05-09 10 40 39" src="https://github.com/user-attachments/assets/b9423391-8e47-4632-8a12-57cd7d80ae2e" />

<img width="739" height="827" alt="스크린샷 2026-05-09 10 40 28" src="https://github.com/user-attachments/assets/4f5d49b4-281b-47ab-af15-299fba956330" />



## 💡 관련 Issue

Closes #110


## 미완료 (비밀번호 변경 방법은 추후 의논후 새로운 이슈로 작업할 예정)

- [ ] 비밀번호 재설정 완료 기능
  - 로그인이 안 된 상태에서 비밀번호 변경이 안 됨
  - SUPABASE_SERVICE_ROLE_KEY 및 API Route 설정 필요
  - 추후 팀원과 상의 후 진행 예정

## 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #110)
- [x] 불필요한 console.log를 제거했습니다.
- [ ] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
