### PR TITLE
[Feat] 관리자 대시보드 페이지 제작

### DIFF
--- a/src/app/(main)/admin/page.tsx
+++ b/src/app/(main)/admin/page.tsx
@@ -1,3 +1,29 @@
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+
+import AdminHeader from '@/components/admin/AdminHeader';
+
+// async function getAdminDashboard() {
+//   const cookieStore = await cookies();
+//   const supabase = createServerClient(
+//     process.env.NEXT_PUBLIC_SUPABASE_URL!,
+//     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+//     {
+//       cookies: {
+//         getAll() {
+//           return cookieStore.getAll();
+//         },
+//       },
+//     },
+//   );
+// }
+
 export default function AdminDashboardtPage() {
-  return <main className="w-full min-h-screen space-y-2">대쉬보드</main>;
+  // const postData = await getAdminDashboard();
+
+  return (
+    <main className="w-full min-h-screen space-y-2">
+      <AdminHeader page="dashboard" />
+    </main>
+  );
 }

--- a/src/app/(main)/admin/page.tsx
+++ b/src/app/(main)/admin/page.tsx
@@ -1,29 +1,14 @@
-import { createServerClient } from '@supabase/ssr';
-import { cookies } from 'next/headers';
-
 import AdminHeader from '@/components/admin/AdminHeader';
+import AdminDashboardCards from '@/components/admin/dashboard/AdminDashboardCards';
+import { getAdminDashboardData } from '@/lib/getAdminDashboardData';
 
-// async function getAdminDashboard() {
-//   const cookieStore = await cookies();
-//   const supabase = createServerClient(
-//     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-//     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-//     {
-//       cookies: {
-//         getAll() {
-//           return cookieStore.getAll();
-//         },
-//       },
-//     },
-//   );
-// }
-
-export default function AdminDashboardtPage() {
-  // const postData = await getAdminDashboard();
+export default async function AdminDashboardPage() {
+  const dashboardData = await getAdminDashboardData();
 
   return (
-    <main className="w-full min-h-screen space-y-2">
+    <main className="min-h-screen w-full pt-28 space-y-8">
       <AdminHeader page="dashboard" />
+      <AdminDashboardCards data={dashboardData} />
     </main>
   );
 }

--- a/src/app/(main)/admin/support/page.tsx
+++ b/src/app/(main)/admin/support/page.tsx
@@ -4,6 +4,7 @@ import { cookies } from 'next/headers';
 import AdminHeader from '@/components/admin/AdminHeader';
 import AdminSupportTableClient from '@/components/admin/support/AdminSupportTableClient';
 import type {
+  SupportSection,
   SupportDojangQueryRow,
   SupportPostQueryRow,
   SupportProfileQueryRow,
@@ -143,8 +144,22 @@ async function getAdminSupportData() {
   };
 }
 
-export default async function AdminSupportPage() {
+function getInitialSupportSection(
+  sectionParam: string | string[] | undefined,
+): SupportSection {
+  const section = Array.isArray(sectionParam) ? sectionParam[0] : sectionParam;
+
+  return section === 'reports' ? 'reports' : 'dojang';
+}
+
+export default async function AdminSupportPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ section?: string | string[] | undefined }>;
+}) {
+  const resolvedSearchParams = await searchParams;
   const data = await getAdminSupportData();
+  const initialSection = getInitialSupportSection(resolvedSearchParams.section);
 
   return (
     <main className="min-h-screen w-full pt-28 space-y-2">
@@ -152,6 +167,7 @@ export default async function AdminSupportPage() {
       <AdminSupportTableClient
         dojangVerifications={data.dojangVerifications}
         reports={data.reports}
+        initialSection={initialSection}
       />
     </main>
   );

--- a/src/components/admin/dashboard/AdminDashboardCards.tsx
+++ b/src/components/admin/dashboard/AdminDashboardCards.tsx
@@ -1,0 +1,136 @@
+import { cn } from '@/lib/utils';
+
+import { ALERT_METRICS, OVERVIEW_METRICS } from './constants';
+import type {
+  AdminDashboardData,
+  DashboardCardTone,
+  DashboardMetricConfig,
+} from './types';
+
+interface AdminDashboardCardsProps {
+  data: AdminDashboardData;
+}
+
+const toneClassMap: Record<DashboardCardTone, string> = {
+  slate: 'bg-zinc-900 text-white ring-zinc-900/10',
+  blue: 'bg-blue-600 text-white ring-blue-600/10',
+  green: 'bg-emerald-600 text-white ring-emerald-600/10',
+  amber: 'bg-amber-500 text-white ring-amber-500/10',
+  red: 'bg-red-500 text-white ring-red-500/10',
+};
+
+const cardAccentClassMap: Record<DashboardCardTone, string> = {
+  slate: 'bg-zinc-100 text-zinc-700',
+  blue: 'bg-blue-50 text-blue-600',
+  green: 'bg-emerald-50 text-emerald-600',
+  amber: 'bg-amber-50 text-amber-600',
+  red: 'bg-red-50 text-red-500',
+};
+
+const numberFormatter = new Intl.NumberFormat('ko-KR');
+
+function DashboardMetricCard({
+  config,
+  value,
+}: {
+  config: DashboardMetricConfig;
+  value: number;
+}) {
+  const Icon = config.icon;
+
+  return (
+    <article className="group relative overflow-hidden rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm transition-transform duration-200 hover:-translate-y-0.5">
+      <div
+        className={cn(
+          'mb-6 inline-flex rounded-2xl p-3 ring-1',
+          cardAccentClassMap[config.tone],
+          toneClassMap[config.tone].split(' ')[2],
+        )}
+      >
+        <Icon className="size-5" />
+      </div>
+
+      <div className="space-y-3">
+        <div className="space-y-1">
+          <p className="text-sm font-medium text-zinc-500">{config.label}</p>
+          <p className="text-xs text-zinc-400">{config.description}</p>
+        </div>
+
+        <div className="flex items-end gap-2">
+          <strong className="text-4xl font-semibold tracking-tight text-zinc-950">
+            {numberFormatter.format(value)}
+          </strong>
+          <span className="pb-1 text-sm font-medium text-zinc-500">
+            {config.suffix}
+          </span>
+        </div>
+      </div>
+
+      <div
+        className={cn(
+          'pointer-events-none absolute inset-x-0 top-0 h-1',
+          toneClassMap[config.tone].split(' ')[0],
+        )}
+      />
+    </article>
+  );
+}
+
+function DashboardSection({
+  title,
+  description,
+  metrics,
+  data,
+  columnsClassName,
+}: {
+  title: string;
+  description: string;
+  metrics: readonly DashboardMetricConfig[];
+  data: AdminDashboardData;
+  columnsClassName: string;
+}) {
+  return (
+    <section className="space-y-5">
+      <div className="space-y-1 px-1">
+        <h2 className="text-xl font-semibold tracking-tight text-zinc-950">
+          {title}
+        </h2>
+        <p className="text-sm text-zinc-500">{description}</p>
+      </div>
+
+      <div className={cn('grid gap-4', columnsClassName)}>
+        {metrics.map((metric) => (
+          <DashboardMetricCard
+            key={metric.key}
+            config={metric}
+            value={data[metric.key]}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default function AdminDashboardCards({
+  data,
+}: AdminDashboardCardsProps) {
+  return (
+    <div className="space-y-10 px-6 pb-8">
+      <DashboardSection
+        title="전체 통계"
+        description="서비스의 핵심 지표를 한눈에 확인할 수 있습니다."
+        metrics={OVERVIEW_METRICS}
+        data={data}
+        columnsClassName="md:grid-cols-2 xl:grid-cols-4"
+      />
+
+      <DashboardSection
+        title="알림"
+        description="지금 바로 확인이 필요한 운영 항목입니다."
+        metrics={ALERT_METRICS}
+        data={data}
+        columnsClassName="md:grid-cols-2"
+      />
+    </div>
+  );
+}

--- a/src/components/admin/dashboard/AdminDashboardCards.tsx
+++ b/src/components/admin/dashboard/AdminDashboardCards.tsx
@@ -11,20 +11,20 @@ interface AdminDashboardCardsProps {
   data: AdminDashboardData;
 }
 
-const toneClassMap: Record<DashboardCardTone, string> = {
-  slate: 'bg-zinc-900 text-white ring-zinc-900/10',
-  blue: 'bg-blue-600 text-white ring-blue-600/10',
-  green: 'bg-emerald-600 text-white ring-emerald-600/10',
-  amber: 'bg-amber-500 text-white ring-amber-500/10',
-  red: 'bg-red-500 text-white ring-red-500/10',
+const iconToneClassMap: Record<DashboardCardTone, string> = {
+  slate: 'bg-zinc-100 text-zinc-700 ring-zinc-200',
+  blue: 'bg-blue-50 text-blue-600 ring-blue-100',
+  green: 'bg-emerald-50 text-emerald-600 ring-emerald-100',
+  amber: 'bg-amber-50 text-amber-600 ring-amber-100',
+  red: 'bg-red-50 text-red-500 ring-red-100',
 };
 
-const cardAccentClassMap: Record<DashboardCardTone, string> = {
-  slate: 'bg-zinc-100 text-zinc-700',
-  blue: 'bg-blue-50 text-blue-600',
-  green: 'bg-emerald-50 text-emerald-600',
-  amber: 'bg-amber-50 text-amber-600',
-  red: 'bg-red-50 text-red-500',
+const topLineClassMap: Record<DashboardCardTone, string> = {
+  slate: 'bg-zinc-900',
+  blue: 'bg-blue-600',
+  green: 'bg-emerald-600',
+  amber: 'bg-amber-500',
+  red: 'bg-red-500',
 };
 
 const numberFormatter = new Intl.NumberFormat('ko-KR');
@@ -43,8 +43,7 @@ function DashboardMetricCard({
       <div
         className={cn(
           'mb-6 inline-flex rounded-2xl p-3 ring-1',
-          cardAccentClassMap[config.tone],
-          toneClassMap[config.tone].split(' ')[2],
+          iconToneClassMap[config.tone]
         )}
       >
         <Icon className="size-5" />
@@ -53,7 +52,6 @@ function DashboardMetricCard({
       <div className="space-y-3">
         <div className="space-y-1">
           <p className="text-sm font-medium text-zinc-500">{config.label}</p>
-          <p className="text-xs text-zinc-400">{config.description}</p>
         </div>
 
         <div className="flex items-end gap-2">
@@ -69,7 +67,7 @@ function DashboardMetricCard({
       <div
         className={cn(
           'pointer-events-none absolute inset-x-0 top-0 h-1',
-          toneClassMap[config.tone].split(' ')[0],
+          topLineClassMap[config.tone],
         )}
       />
     </article>

--- a/src/components/admin/dashboard/AdminDashboardCards.tsx
+++ b/src/components/admin/dashboard/AdminDashboardCards.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 import { cn } from '@/lib/utils';
 
 import { ALERT_METRICS, OVERVIEW_METRICS } from './constants';
@@ -37,13 +39,16 @@ function DashboardMetricCard({
   value: number;
 }) {
   const Icon = config.icon;
-
-  return (
-    <article className="group relative overflow-hidden rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm transition-transform duration-200 hover:-translate-y-0.5">
+  const cardClassName = cn(
+    'group relative overflow-hidden rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm transition-transform duration-200',
+    config.href ? 'block cursor-pointer hover:-translate-y-0.5 hover:shadow-md' : '',
+  );
+  const cardContent = (
+    <article className={cardClassName}>
       <div
         className={cn(
           'mb-6 inline-flex rounded-2xl p-3 ring-1',
-          iconToneClassMap[config.tone]
+          iconToneClassMap[config.tone],
         )}
       >
         <Icon className="size-5" />
@@ -72,6 +77,12 @@ function DashboardMetricCard({
       />
     </article>
   );
+
+  if (config.href) {
+    return <Link href={config.href}>{cardContent}</Link>;
+  }
+
+  return cardContent;
 }
 
 function DashboardSection({
@@ -113,7 +124,7 @@ export default function AdminDashboardCards({
   data,
 }: AdminDashboardCardsProps) {
   return (
-    <div className="space-y-10 px-6 pb-8">
+    <div className="space-y-10 px-6 pt-8 pb-8">
       <DashboardSection
         title="전체 통계"
         description="서비스의 핵심 지표를 한눈에 확인할 수 있습니다."

--- a/src/components/admin/dashboard/constants.ts
+++ b/src/components/admin/dashboard/constants.ts
@@ -46,7 +46,7 @@ export const ALERT_METRICS = [
     label: '승인 대기 도장',
     suffix: '건',
     icon: BellRing,
-    tone: 'amber',
+    tone: 'blue',
   },
   {
     key: 'pendingReportsCount',

--- a/src/components/admin/dashboard/constants.ts
+++ b/src/components/admin/dashboard/constants.ts
@@ -7,6 +7,8 @@ import {
   Users,
 } from 'lucide-react';
 
+import { ROUTES } from '@/constants/routes';
+
 import type { DashboardMetricConfig } from './types';
 
 export const OVERVIEW_METRICS = [
@@ -47,6 +49,7 @@ export const ALERT_METRICS = [
     suffix: '건',
     icon: BellRing,
     tone: 'blue',
+    href: `${ROUTES.ADMIN_SUPPORT}?section=dojang`,
   },
   {
     key: 'pendingReportsCount',
@@ -54,5 +57,6 @@ export const ALERT_METRICS = [
     suffix: '건',
     icon: ShieldAlert,
     tone: 'red',
+    href: `${ROUTES.ADMIN_SUPPORT}?section=reports`,
   },
 ] as const satisfies readonly DashboardMetricConfig[];

--- a/src/components/admin/dashboard/constants.ts
+++ b/src/components/admin/dashboard/constants.ts
@@ -1,0 +1,58 @@
+import {
+  BellRing,
+  FileText,
+  ShieldAlert,
+  Store,
+  UserPlus,
+  Users,
+} from 'lucide-react';
+
+import type { DashboardMetricConfig } from './types';
+
+export const OVERVIEW_METRICS = [
+  {
+    key: 'generalUsersCount',
+    label: '일반 유저 수',
+    suffix: '명',
+    icon: Users,
+    tone: 'slate',
+  },
+  {
+    key: 'dojangCount',
+    label: '도장 수',
+    suffix: '개',
+    icon: Store,
+    tone: 'blue',
+  },
+  {
+    key: 'postCount',
+    label: '게시글 수',
+    suffix: '개',
+    icon: FileText,
+    tone: 'green',
+  },
+  {
+    key: 'todaySignupsCount',
+    label: '오늘 가입자',
+    suffix: '명',
+    icon: UserPlus,
+    tone: 'amber',
+  },
+] as const satisfies readonly DashboardMetricConfig[];
+
+export const ALERT_METRICS = [
+  {
+    key: 'pendingDojangCount',
+    label: '승인 대기 도장',
+    suffix: '건',
+    icon: BellRing,
+    tone: 'amber',
+  },
+  {
+    key: 'pendingReportsCount',
+    label: '미처리 신고',
+    suffix: '건',
+    icon: ShieldAlert,
+    tone: 'red',
+  },
+] as const satisfies readonly DashboardMetricConfig[];

--- a/src/components/admin/dashboard/types.ts
+++ b/src/components/admin/dashboard/types.ts
@@ -1,0 +1,22 @@
+import type { LucideIcon } from 'lucide-react';
+
+export interface AdminDashboardData {
+  generalUsersCount: number;
+  dojangCount: number;
+  postCount: number;
+  todaySignupsCount: number;
+  pendingDojangCount: number;
+  pendingReportsCount: number;
+}
+
+export type AdminDashboardMetricKey = keyof AdminDashboardData;
+
+export type DashboardCardTone = 'slate' | 'blue' | 'green' | 'amber' | 'red';
+
+export interface DashboardMetricConfig {
+  key: AdminDashboardMetricKey;
+  label: string;
+  suffix: string;
+  icon: LucideIcon;
+  tone: DashboardCardTone;
+}

--- a/src/components/admin/dashboard/types.ts
+++ b/src/components/admin/dashboard/types.ts
@@ -19,4 +19,5 @@ export interface DashboardMetricConfig {
   suffix: string;
   icon: LucideIcon;
   tone: DashboardCardTone;
+  href?: string;
 }

--- a/src/components/admin/support/AdminSupportTableClient.tsx
+++ b/src/components/admin/support/AdminSupportTableClient.tsx
@@ -28,6 +28,7 @@ import {
 interface AdminSupportTableClientProps {
   dojangVerifications: AdminDojangVerificationRow[];
   reports: AdminReportRow[];
+  initialSection: SupportSection;
 }
 
 const DOJANG_COLUMNS: AdminTableColumn<AdminDojangVerificationRow>[] = [
@@ -105,8 +106,10 @@ const REPORT_COLUMNS: AdminTableColumn<AdminReportRow>[] = [
 export default function AdminSupportTableClient({
   dojangVerifications,
   reports,
+  initialSection,
 }: AdminSupportTableClientProps) {
-  const [activeSection, setActiveSection] = useState<SupportSection>('dojang');
+  const [activeSection, setActiveSection] =
+    useState<SupportSection>(initialSection);
   const [searchQuery, setSearchQuery] = useState('');
 
   const filteredDojangVerifications = useMemo(() => {

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -6,6 +6,7 @@ export const ROUTES = {
   FIND_PASSWORD: "/find-password",
   MYPAGE: "/mypage",
   ADMIN: "/admin",
+  ADMIN_SUPPORT: "/admin/support",
   DOJANGS: "/dojangs",
   COMPETITIONS: "/competitions",
   COMMUNITY: "/community",

--- a/src/lib/getAdminDashboardData.ts
+++ b/src/lib/getAdminDashboardData.ts
@@ -1,0 +1,97 @@
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+
+import type { AdminDashboardData } from '@/components/admin/dashboard/types';
+
+function getTodayStartIso() {
+  const todayStart = new Date();
+
+  todayStart.setHours(0, 0, 0, 0);
+
+  return todayStart.toISOString();
+}
+
+function normalizeCount(count: number | null) {
+  return count ?? 0;
+}
+
+export async function getAdminDashboardData(): Promise<AdminDashboardData> {
+  const cookieStore = await cookies();
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+      },
+    },
+  );
+
+  const todayStartIso = getTodayStartIso();
+
+  const [
+    generalUsersResult,
+    dojangResult,
+    postsResult,
+    todaySignupsResult,
+    pendingDojangsResult,
+    pendingReportsResult,
+  ] = await Promise.all([
+    supabase
+      .from('profiles')
+      .select('*', { count: 'exact', head: true })
+      .eq('role', 'user'),
+    supabase
+      .from('profiles')
+      .select('*', { count: 'exact', head: true })
+      .eq('role', 'manager'),
+    supabase.from('posts').select('*', { count: 'exact', head: true }),
+    supabase
+      .from('profiles')
+      .select('*', { count: 'exact', head: true })
+      .gte('created_at', todayStartIso),
+    supabase
+      .from('dojang')
+      .select('*', { count: 'exact', head: true })
+      .eq('dojang_status', 'pending'),
+    supabase
+      .from('reports')
+      .select('*', { count: 'exact', head: true })
+      .eq('reports_status', 'pending'),
+  ]);
+
+  if (generalUsersResult.error) {
+    throw new Error(generalUsersResult.error.message);
+  }
+
+  if (dojangResult.error) {
+    throw new Error(dojangResult.error.message);
+  }
+
+  if (postsResult.error) {
+    throw new Error(postsResult.error.message);
+  }
+
+  if (todaySignupsResult.error) {
+    throw new Error(todaySignupsResult.error.message);
+  }
+
+  if (pendingDojangsResult.error) {
+    throw new Error(pendingDojangsResult.error.message);
+  }
+
+  if (pendingReportsResult.error) {
+    throw new Error(pendingReportsResult.error.message);
+  }
+
+  return {
+    generalUsersCount: normalizeCount(generalUsersResult.count),
+    dojangCount: normalizeCount(dojangResult.count),
+    postCount: normalizeCount(postsResult.count),
+    todaySignupsCount: normalizeCount(todaySignupsResult.count),
+    pendingDojangCount: normalizeCount(pendingDojangsResult.count),
+    pendingReportsCount: normalizeCount(pendingReportsResult.count),
+  };
+}


### PR DESCRIPTION
<!--
  PR 작성 가이드
  - 리뷰어를 존중하는 표현을 사용해주세요.
  - 변경 의도와 주요 내용을 명확하게 작성해주세요.
 -->

## 📌 개요
- 관리자 대시보드 페이지 제작

## 💻 작업 사항
- 관리자 대시보드 페이지를 서버 컴포넌트 중심으로 구현했습니다.
- 대시보드 전용 데이터 조회 함수를 분리해 전체 통계와 알림 데이터를 서버에서 집계하도록 구성했습니다.
<br />

- 대시보드 카드 UI를 공통 섹션/카드 구조로 분리해 가독성과 재사용성을 높였습니다.
- 전체 통계 카드에 일반 유저 수, 도장 수, 게시글 수, 오늘 가입자를 표시했습니다.
- 알림 카드에 승인 대기 도장 수와 미처리 신고 수를 표시했습니다.
<br />

- 고객지원 페이지가 `searchParams`를 받아 초기 필터를 설정할 수 있도록 개선했습니다.
- 승인 대기 도장 카드 클릭 시 고객지원 페이지의 도장 인증 탭으로 이동하도록 연결했습니다.
- 미처리 신고 카드 클릭 시 고객지원 페이지의 신고 내역 탭으로 이동하도록 연결했습니다.

<img width="1914" height="1007" alt="스크린샷 2026-05-11 오전 9 05 24" src="https://github.com/user-attachments/assets/47a1c7a3-adc4-4d1c-88ac-9d68d14ed2f8" />

## 💡 관련 Issue

Closes #112

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #)
- [x] 불필요한 console.log를 제거했습니다.
- [x] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
