### PR TITLE
[Feat] 캐싱전략 및 메타데이터 생성 (커뮤니티, 대회일정 - (상세, 글쓰기, 수정 등), 도장찾기), any 타입 수정

### DIFF
--- a/src/app/(main)/community/page.tsx
+++ b/src/app/(main)/community/page.tsx
@@ -1,8 +1,19 @@
-// app/(main)/community/page.tsx - 서버 컴포넌트
 import CommunityClient from '@/components/community/CommunityClient';
 import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
 import type { Post } from '@/types/community';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: '커뮤니티 | Black Belt BJJ',
+  description: '주짓수 수련자들의 이야기, 기술 분석, 도장 정보를 나누는 공간',
+  openGraph: {
+    title: '커뮤니티 | Black Belt BJJ',
+    description: '주짓수 수련자들의 이야기, 기술 분석, 도장 정보를 나누는 공간',
+  },
+};
+
+export const dynamic = 'force-dynamic';
 
 async function getPosts(): Promise<Post[]> {
   const cookieStore = await cookies();
@@ -33,6 +44,5 @@ async function getPosts(): Promise<Post[]> {
 
 export default async function CommunityPage() {
   const initialPosts = await getPosts();
-
   return <CommunityClient initialPosts={initialPosts} />;
 }

--- a/src/app/(main)/competitions/[id]/edit/page.tsx
+++ b/src/app/(main)/competitions/[id]/edit/page.tsx
@@ -1,9 +1,25 @@
-// app/(main)/competitions/[id]/edit/page.tsx (서버 컴포넌트)
 import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { getCompetition } from '@/services/competitionService';
 import CompetitionEditClient from '@/components/competition/CompetitionEditClient';
+import type { Metadata } from 'next';
+
+export const dynamic = 'force-dynamic';
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const competition = await getCompetition(id);
+
+  return {
+    title: `${competition?.name ?? '대회'} 수정 | Black Belt BJJ`,
+    description: `${competition?.name ?? '대회'} 정보를 수정합니다`,
+  };
+}
 
 export default async function CompetitionEditPage({
   params,
@@ -22,7 +38,6 @@ export default async function CompetitionEditPage({
   const {
     data: { user },
   } = await supabase.auth.getUser();
-
   if (!user) redirect('/login');
 
   const { data: profile } = await supabase

--- a/src/app/(main)/competitions/[id]/page.tsx
+++ b/src/app/(main)/competitions/[id]/page.tsx
@@ -1,9 +1,34 @@
-// app/(main)/competitions/[id]/page.tsx (서버 컴포넌트)
 import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
 import { notFound } from 'next/navigation';
 import { getCompetition } from '@/services/competitionService';
 import CompetitionDetailClient from '@/components/competition/CompetitionDetailClient';
+import type { Metadata } from 'next';
+
+export const dynamic = 'force-dynamic';
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const competition = await getCompetition(id);
+
+  if (!competition) {
+    return { title: '대회를 찾을 수 없습니다 | Black Belt BJJ' };
+  }
+
+  return {
+    title: `${competition.name} | Black Belt BJJ`,
+    description: competition.description ?? '주짓수 대회 상세 정보',
+    openGraph: {
+      title: `${competition.name} | Black Belt BJJ`,
+      description: competition.description ?? '주짓수 대회 상세 정보',
+      images: competition.image_url ? [{ url: competition.image_url }] : [],
+    },
+  };
+}
 
 export default async function CompetitionDetailPage({
   params,
@@ -26,7 +51,6 @@ export default async function CompetitionDetailPage({
   const competition = await getCompetition(id);
   if (!competition) notFound();
 
-  // 조회수 증가
   await supabase
     .from('competition')
     .update({ view_count: (competition.view_count ?? 0) + 1 })

--- a/src/app/(main)/competitions/page.tsx
+++ b/src/app/(main)/competitions/page.tsx
@@ -1,8 +1,18 @@
 import CompetitionClient from '@/components/competition/CompetitionClient';
 import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
+import type { Metadata } from 'next';
 
-export const revalidate = 0; // 추가 — 캐시 안 씀
+export const metadata: Metadata = {
+  title: '대회일정 | Black Belt BJJ',
+  description: '전국 주짓수 대회 일정을 한눈에 확인하세요',
+  openGraph: {
+    title: '대회일정 | Black Belt BJJ',
+    description: '전국 주짓수 대회 일정을 한눈에 확인하세요',
+  },
+};
+
+export const dynamic = 'force-dynamic';
 
 export default async function CompetitionsPage() {
   const cookieStore = await cookies();

--- a/src/app/(main)/competitions/write/page.tsx
+++ b/src/app/(main)/competitions/write/page.tsx
@@ -1,8 +1,15 @@
-// app/(main)/competitions/write/page.tsx (서버 컴포넌트)
 import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import CompetitionWriteClient from '@/components/competition/CompetitionWriteClient';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: '대회 추가 | Black Belt BJJ',
+  description: '새로운 주짓수 대회 일정을 등록하세요',
+};
+
+export const dynamic = 'force-dynamic';
 
 export default async function CompetitionWritePage() {
   const cookieStore = await cookies();
@@ -15,10 +22,8 @@ export default async function CompetitionWritePage() {
   const {
     data: { user },
   } = await supabase.auth.getUser();
-
   if (!user) redirect('/login');
 
-  // 프로필에서 role 확인
   const { data: profile } = await supabase
     .from('profiles')
     .select('role')

--- a/src/app/(main)/dojangs/page.tsx
+++ b/src/app/(main)/dojangs/page.tsx
@@ -1,6 +1,18 @@
 import DojangClient from '@/components/dojang/DojangClient';
 import { cookies } from 'next/headers';
 import { createServerClient } from '@supabase/ssr';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: '도장찾기 | Black Belt BJJ',
+  description: '전국 주짓수 도장을 지도에서 찾아보세요. 인증 도장 정보 제공',
+  openGraph: {
+    title: '도장찾기 | Black Belt BJJ',
+    description: '전국 주짓수 도장을 지도에서 찾아보세요. 인증 도장 정보 제공',
+  },
+};
+
+export const revalidate = 3600; // 도장 정보는 자주 안 바뀌므로 1시간 캐시
 
 export default async function DojangsPage() {
   const cookieStore = await cookies();

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,5 +1,18 @@
 import ScrollToTop from '@/components/common/ScrollToTop';
 import Sidebar from '@/components/layout/Sidebar';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Black Belt BJJ',
+  description:
+    '주짓수 수련자를 위한 올인원 커뮤니티. 커뮤니티, 대회일정, 도장찾기',
+  openGraph: {
+    siteName: 'Black Belt BJJ',
+    title: 'Black Belt BJJ',
+    description: '주짓수 수련자를 위한 올인원 커뮤니티',
+    type: 'website',
+  },
+};
 
 export default function MainLayout({
   children,

--- a/src/lib/getCompetitions.ts
+++ b/src/lib/getCompetitions.ts
@@ -7,9 +7,9 @@ export async function getCompetitions() {
     .order('event_data', { ascending: true });
   if (error) throw error;
 
-  return data.map((competition: any) => ({
+  return data.map((competition) => ({
     ...competition,
-    comment_count: competition.comments[0].count,
+    comment_count: (competition.comments as { count: number }[])[0]?.count ?? 0,
     comments: undefined,
   }));
 }

--- a/src/services/communityService.ts
+++ b/src/services/communityService.ts
@@ -8,11 +8,15 @@ export async function getPosts() {
     .order('created_at', { ascending: false });
 
   if (error) throw error;
-  return data.map((post: any) => ({
+
+  return data.map((post) => ({
     ...post,
-    comment_count: post.comments[0].count,
-    nickname: post.profiles?.nickname,
-    avatar_url: post.profiles?.avatar_url,
+    comment_count: (post.comments as { count: number }[])[0]?.count ?? 0,
+    nickname: (post.profiles as { nickname: string; avatar_url: string } | null)
+      ?.nickname,
+    avatar_url: (
+      post.profiles as { nickname: string; avatar_url: string } | null
+    )?.avatar_url,
     profiles: undefined,
   }));
 }
@@ -81,6 +85,13 @@ export async function uploadPostImage(file: File): Promise<string> {
   return data.publicUrl;
 }
 
+interface CommentProfile {
+  nickname: string;
+  avatar_url: string;
+  belt_level: string;
+  role: string;
+}
+
 export async function getComments(postId: string) {
   const { data, error } = await supabase
     .from('comments')
@@ -90,12 +101,12 @@ export async function getComments(postId: string) {
 
   if (error) throw error;
 
-  return data.map((comment: any) => ({
+  return data.map((comment) => ({
     ...comment,
-    nickname: comment.profiles?.nickname,
-    avatar_url: comment.profiles?.avatar_url,
-    belt_level: comment.profiles?.belt_level,
-    role: comment.profiles?.role,
+    nickname: (comment.profiles as CommentProfile | null)?.nickname,
+    avatar_url: (comment.profiles as CommentProfile | null)?.avatar_url,
+    belt_level: (comment.profiles as CommentProfile | null)?.belt_level,
+    role: (comment.profiles as CommentProfile | null)?.role,
     profiles: undefined,
   })) as Comment[];
 }


### PR DESCRIPTION
## 📌 개요

- 메타데이터 및 캐싱 전략 추가

## 💻 작업 사항
<img width="447" height="238" alt="스크린샷 2026-05-11 시간: 13 17 05" src="https://github.com/user-attachments/assets/31265e1c-2f29-4914-b79f-9eb56b530641" />

- 캐싱 전략 추가
페이지별 렌더링 전략
force-dynamic 적용 페이지

community/page.tsx
competitions/page.tsx
competitions/[id]/page.tsx
competitions/write/page.tsx
competitions/[id]/edit/page.tsx

매 요청마다 서버에서 새로 실행. supabase.auth.getUser()로 유저 정보를 확인하거나 실시간 데이터가 필요한 페이지에 적용.

revalidate = 3600 적용 페이지

dojangs/page.tsx

도장 정보는 자주 바뀌지 않아서 1시간 캐시를 적용. 불필요한 DB 조회를 줄일 수 있습니다.
메타데이터 추가
정적 메타데이터 — 고정된 제목/설명

community/page.tsx
competitions/page.tsx
competitions/write/page.tsx
dojangs/page.tsx

동적 메타데이터 — 데이터 기반으로 생성 (generateMetadata)

competitions/[id]/page.tsx — 대회명/설명/이미지로 메타데이터 생성
competitions/[id]/edit/page.tsx — 대회명 기반 메타데이터 생성

효과

SEO 개선 (검색엔진이 페이지 내용 파악 가능)
카카오톡/슬랙 링크 공유 시 미리보기 카드 표시
브라우저 탭 제목 표시
유저별 맞춤 데이터 정확히 반영

- any 타입 제거
수정된 파일
services/communityService.ts

getPosts — post.comments, post.profiles 에 인라인 타입 캐스팅 적용
getComments — CommentProfile 인터페이스 추가 후 타입 캐스팅 적용

lib/getCompetitions.ts

getCompetitions — competition.comments 에 인라인 타입 캐스팅 적용

* 예외
components/dojang/DojangClient.tsx

mapInstance, markersRef — 네이버 지도 SDK가 공식 TypeScript 타입을 제공하지 않아 any 유지
window.naver — 서드파티 SDK 특성상 any + eslint-disable 유지

## 💡 관련 Issue

Closes #122 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #122 )
- [x] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
