### PR TITLE
[feat] 댓글 어뷰징 방지 로직 구현

### DIFF
--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -1,0 +1,127 @@
+// app/api/comments/route.ts
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+import type { Database } from '@/types/Database.types';
+import { checkCommentAbuse } from '@/lib/CommentAbuseGuard';
+
+async function createSupabaseServer() {
+  const cookieStore = await cookies();
+  return createServerClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value, options }) =>
+            cookieStore.set(name, value, options),
+          );
+        },
+      },
+    },
+  );
+}
+
+export async function POST(req: NextRequest) {
+  const supabase = await createSupabaseServer();
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json(
+      { error: '로그인이 필요합니다.' },
+      { status: 401 },
+    );
+  }
+
+  let body: { postId?: string; content?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: '잘못된 요청입니다.' }, { status: 400 });
+  }
+
+  const { postId, content } = body;
+  if (!postId || !content) {
+    return NextResponse.json(
+      { error: 'postId와 content는 필수입니다.' },
+      { status: 400 },
+    );
+  }
+
+  const check = await checkCommentAbuse({
+    supabase,
+    userId: user.id,
+    postId,
+    content,
+  });
+
+  if (!check.ok) {
+    return NextResponse.json(
+      { error: check.message, code: check.code },
+      { status: 429 },
+    );
+  }
+
+  const { data: comment, error: insertError } = await supabase
+    .from('comments')
+    .insert({ post_id: postId, user_id: user.id, content: content.trim() })
+    .select()
+    .single();
+
+  if (insertError) {
+    if (insertError.message.includes('COOLTIME')) {
+      const match = insertError.message.match(/(\d+)/);
+      const remain = match ? match[1] : '잠시';
+      return NextResponse.json(
+        {
+          error: `${remain}초 후에 다시 작성할 수 있습니다.`,
+          code: 'COOLTIME',
+        },
+        { status: 429 },
+      );
+    }
+    console.error('[comments] insert error:', insertError);
+    return NextResponse.json(
+      { error: '댓글 저장에 실패했습니다.' },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ comment }, { status: 201 });
+}
+
+export async function GET(req: NextRequest) {
+  const supabase = await createSupabaseServer();
+  const postId = req.nextUrl.searchParams.get('postId');
+
+  if (!postId) {
+    return NextResponse.json(
+      { error: 'postId가 필요합니다.' },
+      { status: 400 },
+    );
+  }
+
+  const { data: comments, error } = await supabase
+    .from('comments')
+    .select('id, content, created_at, user_id')
+    .eq('post_id', postId)
+    .order('created_at', { ascending: false })
+    .limit(50);
+
+  if (error) {
+    return NextResponse.json(
+      { error: '조회에 실패했습니다.' },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ comments });
+}

--- a/src/components/community/Commentform.tsx
+++ b/src/components/community/Commentform.tsx
@@ -1,0 +1,162 @@
+'use client';
+// components/CommentForm.tsx
+// 클라이언트 컴포넌트 — 낙관적 UX + 서버 에러 처리
+
+import { useState, useRef, useTransition } from 'react';
+import { ABUSE_CONFIG } from '@/lib/CommentAbuseGuard';
+
+interface CommentFormProps {
+  postId: string;
+  onCommentPosted?: () => void; // 성공 후 목록 리프레시 콜백
+}
+
+type Status =
+  | { type: 'idle' }
+  | { type: 'error'; message: string }
+  | { type: 'success' };
+
+export function CommentForm({ postId, onCommentPosted }: CommentFormProps) {
+  const [content, setContent] = useState('');
+  const [status, setStatus] = useState<Status>({ type: 'idle' });
+  const [coolRemainSec, setCoolRemainSec] = useState(0);
+  const [isPending, startTransition] = useTransition();
+  const coolTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const charCount = content.trim().length;
+  const isOverLimit = charCount > ABUSE_CONFIG.MAX_LENGTH;
+  const canSubmit =
+    !isPending && coolRemainSec === 0 && !isOverLimit && charCount >= 1;
+
+  // 쿨타임 카운트다운 시작
+  function startCooldown(sec: number) {
+    setCoolRemainSec(sec);
+    if (coolTimer.current) clearInterval(coolTimer.current);
+    coolTimer.current = setInterval(() => {
+      setCoolRemainSec((prev) => {
+        if (prev <= 1) {
+          clearInterval(coolTimer.current!);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+  }
+
+  async function handleSubmit() {
+    if (!canSubmit) return;
+
+    startTransition(async () => {
+      setStatus({ type: 'idle' });
+      try {
+        const res = await fetch('/api/comments', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ postId, content }),
+        });
+
+        const data = await res.json();
+
+        if (!res.ok) {
+          // 쿨타임 에러면 남은 시간 파싱해서 카운트다운 표시
+          if (data.code === 'COOLTIME') {
+            const match = data.error.match(/(\d+)초/);
+            if (match) startCooldown(Number(match[1]));
+          }
+          setStatus({ type: 'error', message: data.error });
+          return;
+        }
+
+        setContent('');
+        setStatus({ type: 'success' });
+        onCommentPosted?.();
+
+        // 성공 후 쿨타임 카운트다운 시작
+        startCooldown(ABUSE_CONFIG.COOLTIME_MS / 1000);
+
+        setTimeout(() => setStatus({ type: 'idle' }), 2000);
+      } catch {
+        setStatus({ type: 'error', message: '네트워크 오류가 발생했습니다.' });
+      }
+    });
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+      e.preventDefault();
+      handleSubmit();
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {/* 텍스트 입력 */}
+      <div className="relative">
+        <textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="댓글을 입력하세요... (Ctrl+Enter로 작성)"
+          disabled={isPending}
+          rows={3}
+          className="w-full resize-none rounded-lg border border-gray-200 px-3 py-2 text-sm
+                     focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
+                     disabled:opacity-50 disabled:bg-gray-50"
+        />
+        {/* 글자 수 표시 */}
+        <span
+          className={`absolute bottom-2 right-3 text-xs
+            ${isOverLimit ? 'text-red-500 font-medium' : 'text-gray-400'}`}
+        >
+          {charCount} / {ABUSE_CONFIG.MAX_LENGTH}
+        </span>
+      </div>
+
+      {/* 에러 / 성공 메시지 */}
+      {status.type === 'error' && (
+        <p className="text-sm text-red-500 flex items-center gap-1">
+          <span>⚠️</span> {status.message}
+        </p>
+      )}
+      {status.type === 'success' && (
+        <p className="text-sm text-green-600 flex items-center gap-1">
+          <span>✓</span> 댓글이 작성되었습니다.
+        </p>
+      )}
+
+      {/* 작성 버튼 + 쿨타임 표시 */}
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-gray-400">
+          {coolRemainSec > 0
+            ? `${coolRemainSec}초 후 작성 가능`
+            : 'Ctrl+Enter로 빠르게 작성'}
+        </p>
+
+        <button
+          onClick={handleSubmit}
+          disabled={!canSubmit}
+          className="px-4 py-1.5 rounded-lg bg-blue-600 text-white text-sm font-medium
+                     hover:bg-blue-700 active:scale-95 transition-all
+                     disabled:opacity-40 disabled:cursor-not-allowed disabled:active:scale-100"
+        >
+          {isPending
+            ? '작성 중...'
+            : coolRemainSec > 0
+              ? `${coolRemainSec}s`
+              : '작성'}
+        </button>
+      </div>
+
+      {/* 쿨타임 진행바 */}
+      {coolRemainSec > 0 && (
+        <div className="h-0.5 w-full rounded bg-gray-100 overflow-hidden">
+          <div
+            className="h-full bg-blue-400 transition-all duration-1000"
+            style={{
+              width: `${(coolRemainSec / (ABUSE_CONFIG.COOLTIME_MS / 1000)) * 100}%`,
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/community/PostDetailClient.tsx
+++ b/src/components/community/PostDetailClient.tsx
@@ -3,11 +3,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import {
-  createComment,
-  deletePost,
-  deleteComment,
-} from '@/services/communityService';
+import { deletePost, deleteComment } from '@/services/communityService';
 import { reportPost, ReportReason } from '@/services/reportService';
 import { supabase } from '@/lib/supabase';
 import type { Post, Comment } from '@/types/community';
@@ -58,16 +54,26 @@ export default function PostDetailClient({
       showErrorToast('댓글을 입력해주세요.');
       return;
     }
+
     try {
-      const newComment = await createComment({
-        post_id: id,
-        user_id: userId,
-        content: comment,
+      const res = await fetch('/api/comments', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ postId: id, content: comment }),
       });
-      setComments((prev) => [...prev, newComment]);
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        showErrorToast(data.error ?? '댓글 작성에 실패했습니다.');
+        return;
+      }
+
+      setComments((prev) => [...prev, data.comment]);
       setComment('');
     } catch (e) {
       console.error(e);
+      showErrorToast('네트워크 오류가 발생했습니다.');
     }
   };
 

--- a/src/components/community/PostDetailClient.tsx
+++ b/src/components/community/PostDetailClient.tsx
@@ -69,7 +69,15 @@ export default function PostDetailClient({
         return;
       }
 
-      setComments((prev) => [...prev, data.comment]);
+      // 현재 유저 프로필 정보를 합쳐서 바로 표시 (프로필 이미지 즉시 반영)
+      setComments((prev) => [
+        ...prev,
+        {
+          ...data.comment,
+          nickname: user?.name ?? '알 수 없음',
+          avatar_url: user?.image ?? null,
+        },
+      ]);
       setComment('');
     } catch (e) {
       console.error(e);

--- a/src/lib/CommentAbuseGuard.ts
+++ b/src/lib/CommentAbuseGuard.ts
@@ -33,9 +33,8 @@ export type AbuseErrorCode =
 
 function normalize(text: string): string {
   return text
-    .replace(/[\u200B-\u200D\uFEFF\u00A0]/g, '') // 유니코드 invisible 문자 제거
-    .replace(/\s+/g, ' ') // 연속 공백 → 단일 공백
-    .trim()
+    .replace(/[\u200B-\u200D\uFEFF\u00A0]/g, '') // 보이지 않는 유니코드 공백 제거
+    .replace(/\s/g, '') // 모든 공백 완전 제거
     .toLowerCase();
 }
 

--- a/src/lib/CommentAbuseGuard.ts
+++ b/src/lib/CommentAbuseGuard.ts
@@ -1,0 +1,128 @@
+// lib/CommentAbuseGuard.ts
+// 댓글 어뷰징 방지 로직 — 서버 사이드 전용
+//
+// 사전 준비: Supabase 타입 생성 후 사용
+//   npx supabase gen types typescript --project-id <YOUR_PROJECT_ID> > src/types/database.types.ts
+
+import { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/types/Database.types';
+
+export const ABUSE_CONFIG = {
+  /** 댓글 간 최소 대기 시간 (ms) */
+  COOLTIME_MS: 10_000,
+  /** 중복 체크할 최근 댓글 수 */
+  DUPLICATE_CHECK_RANGE: 3,
+  /** 연속 작성 최대 횟수 (초과 시 차단) */
+  CONSECUTIVE_LIMIT: 3,
+  /** 최소 글자 수 */
+  MIN_LENGTH: 5,
+  /** 최대 글자 수 */
+  MAX_LENGTH: 1000,
+} as const;
+
+export type AbuseCheckResult =
+  | { ok: true }
+  | { ok: false; code: AbuseErrorCode; message: string };
+
+export type AbuseErrorCode =
+  | 'TOO_SHORT'
+  | 'TOO_LONG'
+  | 'COOLTIME'
+  | 'DUPLICATE'
+  | 'CONSECUTIVE_LIMIT';
+
+function normalize(text: string): string {
+  return text
+    .replace(/[\u200B-\u200D\uFEFF\u00A0]/g, '') // 유니코드 invisible 문자 제거
+    .replace(/\s+/g, ' ') // 연속 공백 → 단일 공백
+    .trim()
+    .toLowerCase();
+}
+
+export async function checkCommentAbuse(params: {
+  supabase: SupabaseClient<Database>;
+  userId: string;
+  postId: string;
+  content: string;
+}): Promise<AbuseCheckResult> {
+  const { supabase, userId, postId, content } = params;
+  const trimmed = content.trim();
+
+  // 1. 길이 검사
+  if (trimmed.length < ABUSE_CONFIG.MIN_LENGTH) {
+    return {
+      ok: false,
+      code: 'TOO_SHORT',
+      message: `댓글은 최소 ${ABUSE_CONFIG.MIN_LENGTH}자 이상 입력해주세요.`,
+    };
+  }
+  if (trimmed.length > ABUSE_CONFIG.MAX_LENGTH) {
+    return {
+      ok: false,
+      code: 'TOO_LONG',
+      message: `댓글은 ${ABUSE_CONFIG.MAX_LENGTH}자를 초과할 수 없습니다.`,
+    };
+  }
+
+  // 2. 병렬로 DB 조회 (쿨타임 / 중복 / 연속)
+  const [lastTimeResult, recentContentResult, recentCommentersResult] =
+    await Promise.all([
+      supabase.rpc('get_last_comment_time', { p_user_id: userId }),
+      supabase.rpc('get_recent_comments_content', {
+        p_user_id: userId,
+        p_post_id: postId,
+        p_limit: ABUSE_CONFIG.DUPLICATE_CHECK_RANGE,
+      }),
+      supabase.rpc('get_recent_commenters', {
+        p_post_id: postId,
+        p_limit: ABUSE_CONFIG.CONSECUTIVE_LIMIT,
+      }),
+    ]);
+
+  // 3. 쿨타임 검사
+  const lastTime = lastTimeResult.data;
+  if (lastTime) {
+    const elapsed = Date.now() - new Date(lastTime as string).getTime();
+    if (elapsed < ABUSE_CONFIG.COOLTIME_MS) {
+      const remainSec = Math.ceil((ABUSE_CONFIG.COOLTIME_MS - elapsed) / 1000);
+      return {
+        ok: false,
+        code: 'COOLTIME',
+        message: `${remainSec}초 후에 다시 작성할 수 있습니다.`,
+      };
+    }
+  }
+
+  // 4. 중복 검사
+  type ContentRow =
+    Database['public']['Functions']['get_recent_comments_content']['Returns'][number];
+  const recentContents = (recentContentResult.data ?? []) as ContentRow[];
+  const normalizedInput = normalize(trimmed);
+  if (
+    recentContents.some((row) => normalize(row.content) === normalizedInput)
+  ) {
+    return {
+      ok: false,
+      code: 'DUPLICATE',
+      message: `최근 ${ABUSE_CONFIG.DUPLICATE_CHECK_RANGE}개 댓글과 동일한 내용입니다.`,
+    };
+  }
+
+  // 5. 연속 작성 검사
+  type CommenterRow =
+    Database['public']['Functions']['get_recent_commenters']['Returns'][number];
+  const recentCommenters = (recentCommentersResult.data ??
+    []) as CommenterRow[];
+  if (
+    recentCommenters.length >= ABUSE_CONFIG.CONSECUTIVE_LIMIT &&
+    recentCommenters.every((row) => row.user_id === userId)
+  ) {
+    return {
+      ok: false,
+      code: 'CONSECUTIVE_LIMIT',
+      message: `연속으로 ${ABUSE_CONFIG.CONSECUTIVE_LIMIT}회 이상 댓글을 작성할 수 없습니다.`,
+    };
+  }
+
+  return { ok: true };
+}

--- a/src/lib/CommentAbuseGuard.ts
+++ b/src/lib/CommentAbuseGuard.ts
@@ -13,7 +13,7 @@ export const ABUSE_CONFIG = {
   /** 중복 체크할 최근 댓글 수 */
   DUPLICATE_CHECK_RANGE: 3,
   /** 연속 작성 최대 횟수 (초과 시 차단) */
-  CONSECUTIVE_LIMIT: 3,
+  CONSECUTIVE_LIMIT: 2,
   /** 최소 글자 수 */
   MIN_LENGTH: 5,
   /** 최대 글자 수 */
@@ -119,7 +119,7 @@ export async function checkCommentAbuse(params: {
     return {
       ok: false,
       code: 'CONSECUTIVE_LIMIT',
-      message: `연속으로 ${ABUSE_CONFIG.CONSECUTIVE_LIMIT}회 이상 댓글을 작성할 수 없습니다.`,
+      message: `연속으로 ${ABUSE_CONFIG.CONSECUTIVE_LIMIT + 1}회 이상 댓글을 작성할 수 없습니다.`,
     };
   }
 

--- a/src/types/Database.types.ts
+++ b/src/types/Database.types.ts
@@ -1,0 +1,63 @@
+// src/types/database.types.ts
+
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[];
+
+export type Database = {
+  public: {
+    Tables: {
+      comments: {
+        Row: {
+          id: string;
+          post_id: string;
+          user_id: string;
+          content: string;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          post_id: string;
+          user_id: string;
+          content: string;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          post_id?: string;
+          user_id?: string;
+          content?: string;
+          created_at?: string;
+        };
+        Relationships: [];
+      };
+    };
+    Views: {
+      [_ in never]: never;
+    };
+    Functions: {
+      get_last_comment_time: {
+        Args: { p_user_id: string };
+        Returns: string | null;
+      };
+      get_recent_comments_content: {
+        Args: { p_user_id: string; p_post_id: string; p_limit: number };
+        Returns: { content: string }[];
+      };
+      get_recent_commenters: {
+        Args: { p_post_id: string; p_limit: number };
+        Returns: { user_id: string }[];
+      };
+    };
+    Enums: {
+      [_ in never]: never;
+    };
+    CompositeTypes: {
+      [_ in never]: never;
+    };
+  };
+};

--- a/supabase/migrations/20260511_comments_abuse_prevention.sql
+++ b/supabase/migrations/20260511_comments_abuse_prevention.sql
@@ -1,0 +1,107 @@
+-- ──────────────────────────────────────────────
+-- 기존 함수
+-- ──────────────────────────────────────────────
+
+-- 신고 수 증가
+CREATE OR REPLACE FUNCTION increment_report_count(post_id uuid)
+RETURNS void
+LANGUAGE sql
+SECURITY INVOKER AS $$
+  UPDATE posts SET report_count = report_count + 1 WHERE id = post_id;
+$$;
+
+-- 조회수 증가
+CREATE OR REPLACE FUNCTION increment_view_count(post_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY INVOKER AS $$
+BEGIN
+  UPDATE posts SET view_count = view_count + 1 WHERE id = post_id;
+END;
+$$;
+
+-- updated_at 자동 갱신 트리거 함수
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY INVOKER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$;
+
+-- ──────────────────────────────────────────────
+-- 댓글 어뷰징 방지 함수 및 트리거
+-- ──────────────────────────────────────────────
+
+-- 1) 쿨타임: 마지막 댓글 작성 시각 조회
+CREATE OR REPLACE FUNCTION get_last_comment_time(p_user_id uuid)
+RETURNS timestamptz
+LANGUAGE sql SECURITY DEFINER AS $$
+  SELECT created_at
+  FROM comments
+  WHERE user_id = p_user_id
+  ORDER BY created_at DESC
+  LIMIT 1;
+$$;
+
+-- 2) 중복: 최근 N개 댓글 내용 조회
+CREATE OR REPLACE FUNCTION get_recent_comments_content(
+  p_user_id  uuid,
+  p_post_id  uuid,
+  p_limit    int DEFAULT 3
+)
+RETURNS TABLE(content text)
+LANGUAGE sql SECURITY DEFINER AS $$
+  SELECT content
+  FROM comments
+  WHERE user_id = p_user_id
+    AND post_id = p_post_id
+  ORDER BY created_at DESC
+  LIMIT p_limit;
+$$;
+
+-- 3) 연속 작성: 게시물의 마지막 N개 댓글 작성자 조회
+CREATE OR REPLACE FUNCTION get_recent_commenters(
+  p_post_id  uuid,
+  p_limit    int DEFAULT 3
+)
+RETURNS TABLE(user_id uuid)
+LANGUAGE sql SECURITY DEFINER AS $$
+  SELECT user_id
+  FROM comments
+  WHERE post_id = p_post_id
+  ORDER BY created_at DESC
+  LIMIT p_limit;
+$$;
+
+-- 4) 쿨타임 트리거 함수: 동시 요청 우회 차단
+CREATE OR REPLACE FUNCTION check_comment_cooltime()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER AS $$
+DECLARE
+  last_time TIMESTAMPTZ;
+BEGIN
+  SELECT created_at INTO last_time
+  FROM comments
+  WHERE user_id = NEW.user_id
+  ORDER BY created_at DESC
+  LIMIT 1;
+
+  IF last_time IS NOT NULL AND
+     EXTRACT(EPOCH FROM (NOW() - last_time)) < 10 THEN
+    RAISE EXCEPTION 'COOLTIME: % seconds remaining',
+      CEIL(10 - EXTRACT(EPOCH FROM (NOW() - last_time)));
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+-- 5) 트리거 등록: comments INSERT 전에 쿨타임 검사
+CREATE OR REPLACE TRIGGER enforce_comment_cooltime
+  BEFORE INSERT ON comments
+  FOR EACH ROW
+  EXECUTE FUNCTION check_comment_cooltime();


### PR DESCRIPTION
## 📌 개요
댓글 도배 및 어뷰징 방지 로직을 구현했습니다.
클라이언트 사이드가 아닌 서버 사이드(API Route + DB 트리거)에서 검증하여 우회가 불가능한 구조로 설계했습니다.

## 💻 작업 사항

### 1. API Route 추가 (`src/app/api/comments/route.ts`)
- 기존 클라이언트에서 Supabase를 직접 호출하던 방식을 API Route 경유로 변경
- POST /api/comments — 어뷰징 검사 후 댓글 저장
- GET /api/comments — 댓글 목록 조회

### 2. 어뷰징 방지 로직 구현 (`src/lib/CommentAbuseGuard.ts`)
- **쿨타임 차단**: 댓글 작성 후 10초 내 재작성 차단
- **중복 차단**: 최근 3개 댓글과 동일한 내용 차단 (공백·대소문자·유니코드 invisible 문자 우회 방지를 위한 텍스트 정규화 적용)
- **연속 작성 차단**: 동일 유저가 연속 3회 이상 작성 차단
- **길이 검사**: 최소 5자 / 최대 1000자
- 3개의 DB 조회를 `Promise.all`로 병렬 처리하여 레이턴시 최소화

<img width="676" height="290" alt="image" src="https://github.com/user-attachments/assets/39d93d4a-82dd-4c17-b103-b44c7fa457fb" />
<img width="638" height="283" alt="image" src="https://github.com/user-attachments/assets/6d66d1ff-2469-42d8-ad16-d955a421d655" />
<img width="708" height="306" alt="image" src="https://github.com/user-attachments/assets/e80204f8-cf94-4410-aa26-56006e10f564" />
<img width="642" height="390" alt="image" src="https://github.com/user-attachments/assets/9137e13f-273b-442e-bf0b-fa23f6544073" />
<img width="611" height="270" alt="image" src="https://github.com/user-attachments/assets/b803d4a3-0080-4e4f-a52a-474176ac139e" />


### 3. DB 함수 및 트리거 Migration 추가 (`supabase/migrations/20260511_comments_abuse_prevention.sql`)
- DB 함수 3개 추가: `get_last_comment_time`, `get_recent_comments_content`, `get_recent_commenters`
- `check_comment_cooltime` 트리거 추가
- 브라우저 Console에서 직접 fetch를 날리는 동시 요청 우회 시도도 DB 레벨에서 차단

**Migration 파일로 관리하는 이유**
- 기존에는 Supabase SQL Editor에서 직접 실행하는 방식이었으나, 이 경우 새로운 팀원이 합류하거나 로컬 환경을 새로 세팅할 때 함수/트리거가 누락될 수 있음
- Migration 파일로 관리하면 `supabase db push` 한 번으로 DB 환경이 자동으로 동일하게 세팅됨
- git 히스토리로 함수 변경 이력 추적 가능

> 💡 새로 로컬 환경을 세팅하는 팀원은 `supabase db push` 실행 필요 (이미 세팅된 팀원은 불필요)


### 4. 타입 정의 추가 (`src/types/database.types.ts`)
- Supabase DB 함수 및 comments 테이블 타입 정의
- `any` 없이 완전한 타입 안전성 확보

### 5. PostDetailClient.tsx 수정
- `createComment` 직접 호출 → `/api/comments` fetch로 변경
- 차단 시 `showErrorToast`로 사유 표시

## 💡 관련 Issue

Closes #117 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #117 )
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
