### PR TITLE
[feat] 게시글 관련 메타데이터추가, 캐싱 전략 추가

### DIFF
--- a/src/app/(main)/community/[id]/edit/page.tsx
+++ b/src/app/(main)/community/[id]/edit/page.tsx
@@ -1,8 +1,29 @@
+// community/[id]/edit/page.tsx
+export const dynamic = 'force-dynamic';
+
+import type { Metadata } from 'next';
 import EditClient from '@/components/community/EditClient';
 import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
 import { getPost } from '@/services/communityService';
 import { notFound, redirect } from 'next/navigation';
+
+type Props = { params: Promise<{ id: string }> };
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params;
+  const post = await getPost(id);
+
+  if (!post) {
+    return { title: '게시글을 찾을 수 없습니다' };
+  }
+
+  return {
+    title: `${post.title} — 수정`,
+    description: `"${post.title}" 게시글을 수정합니다.`,
+    robots: { index: false }, // 수정 페이지는 검색엔진 색인 제외
+  };
+}
 
 async function getInitialData(id: string) {
   const cookieStore = await cookies();
@@ -21,18 +42,12 @@ async function getInitialData(id: string) {
 
   if (!user) redirect('/login');
   if (!post) notFound();
-
-  // 본인 게시글만 수정 가능
   if (post.user_id !== user.id) redirect(`/community/${id}`);
 
   return { post };
 }
 
-export default async function EditPage({
-  params,
-}: {
-  params: Promise<{ id: string }>;
-}) {
+export default async function EditPage({ params }: Props) {
   const { id } = await params;
   const { post } = await getInitialData(id);
 

--- a/src/app/(main)/community/[id]/edit/page.tsx
+++ b/src/app/(main)/community/[id]/edit/page.tsx
@@ -15,11 +15,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const post = await getPost(id);
 
   if (!post) {
-    return { title: '게시글을 찾을 수 없습니다' };
+    return { title: '게시글을 찾을 수 없습니다 | Black Belt BJJ' };
   }
 
   return {
-    title: `${post.title} — 수정`,
+    title: `${post.title} 수정 | Black Belt BJJ`,
     description: `"${post.title}" 게시글을 수정합니다.`,
     robots: { index: false }, // 수정 페이지는 검색엔진 색인 제외
   };

--- a/src/app/(main)/community/[id]/page.tsx
+++ b/src/app/(main)/community/[id]/page.tsx
@@ -1,4 +1,7 @@
-// 서버 컴포넌트
+// community/[id]/page.tsx
+export const dynamic = 'force-dynamic';
+
+import type { Metadata } from 'next';
 import PostDetailClient from '@/components/community/PostDetailClient';
 import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
@@ -8,6 +11,33 @@ import {
   incrementViewCount,
 } from '@/services/communityService';
 import { notFound } from 'next/navigation';
+
+type Props = { params: Promise<{ id: string }> };
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params;
+  const post = await getPost(id);
+
+  if (!post) {
+    return {
+      title: '게시글을 찾을 수 없습니다',
+      description: '존재하지 않거나 삭제된 게시글입니다.',
+    };
+  }
+
+  const description = post.content.slice(0, 120).replace(/\n/g, ' ');
+
+  return {
+    title: post.title,
+    description,
+    openGraph: {
+      title: post.title,
+      description,
+      ...(post.image_url && { images: [{ url: post.image_url }] }),
+      type: 'article',
+    },
+  };
+}
 
 async function getInitialData(id: string) {
   const cookieStore = await cookies();
@@ -36,11 +66,7 @@ async function getInitialData(id: string) {
   return { post, comments, userId: user?.id ?? null };
 }
 
-export default async function PostDetailPage({
-  params,
-}: {
-  params: Promise<{ id: string }>;
-}) {
+export default async function PostDetailPage({ params }: Props) {
   const { id } = await params;
   const { post, comments, userId } = await getInitialData(id);
 

--- a/src/app/(main)/community/[id]/page.tsx
+++ b/src/app/(main)/community/[id]/page.tsx
@@ -28,11 +28,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const description = post.content.slice(0, 120).replace(/\n/g, ' ');
 
   return {
-    title: post.title,
-    description,
+    title: `${post.title} | Black Belt BJJ`,
+    description: description ?? '주짓수 커뮤니티 게시글 상세 정보',
     openGraph: {
-      title: post.title,
-      description,
+      title: `${post.title} | Black Belt BJJ`,
+      description: description ?? '주짓수 커뮤니티 게시글 상세 정보',
       ...(post.image_url && { images: [{ url: post.image_url }] }),
       type: 'article',
     },

--- a/src/app/(main)/community/[id]/page.tsx
+++ b/src/app/(main)/community/[id]/page.tsx
@@ -20,7 +20,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   if (!post) {
     return {
-      title: '게시글을 찾을 수 없습니다',
+      title: '게시글을 찾을 수 없습니다 | Black Belt BJJ',
       description: '존재하지 않거나 삭제된 게시글입니다.',
     };
   }

--- a/src/app/(main)/community/write/page.tsx
+++ b/src/app/(main)/community/write/page.tsx
@@ -1,21 +1,24 @@
-// 서버 컴포넌트
+// community/write/page.tsx
+export const dynamic = 'force-dynamic';
+
+import type { Metadata } from 'next';
 import WriteClient from '@/components/community/WriteClient';
 import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
+
+export const metadata: Metadata = {
+  title: '게시글 작성',
+  description: '블랙벨트 커뮤니티에 새 게시글을 작성합니다.',
+  robots: { index: false }, // 작성 페이지는 검색엔진 색인 제외
+};
 
 async function getUser() {
   const cookieStore = await cookies();
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        getAll() {
-          return cookieStore.getAll();
-        },
-      },
-    },
+    { cookies: { getAll: () => cookieStore.getAll() } },
   );
 
   const {
@@ -26,8 +29,6 @@ async function getUser() {
 
 export default async function WritePage() {
   const user = await getUser();
-
-  // 서버에서 미인증 차단 — 클라이언트 useEffect 불필요
   if (!user) redirect('/login');
 
   return <WriteClient />;

--- a/src/app/(main)/community/write/page.tsx
+++ b/src/app/(main)/community/write/page.tsx
@@ -8,7 +8,7 @@ import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 
 export const metadata: Metadata = {
-  title: '게시글 작성',
+  title: '게시글 작성 | Black Belt BJJ',
   description: '블랙벨트 커뮤니티에 새 게시글을 작성합니다.',
   robots: { index: false }, // 작성 페이지는 검색엔진 색인 제외
 };


### PR DESCRIPTION
## 📌 개요

커뮤니티 게시글 관련 페이지에 캐싱 전략과 메타데이터를 추가했습니다.
SEO 개선 및 링크 공유 시 미리보기 카드 노출을 위한 작업입니다.

## 💻 작업 사항

### 캐싱 전략 — `force-dynamic` 적용

| 페이지 | 이유 |
|---|---|
| `community/[id]/page.tsx` | `supabase.auth.getUser()`로 유저 확인, 실시간 댓글/좋아요 데이터 필요 |
| `community/[id]/edit/page.tsx` | 인증 및 게시글 소유자 검증 필요 |
| `community/write/page.tsx` | 비로그인 시 redirect 처리 필요 |

### 메타데이터 추가

**동적 메타데이터 (`generateMetadata`)**
- `community/[id]/page.tsx` — 게시글 제목 / 내용 앞 120자 / 이미지로 생성
- `community/[id]/edit/page.tsx` — 게시글 제목 기반으로 생성

**정적 메타데이터**
- `community/write/page.tsx` — 고정 제목/설명 적용

**write / edit 페이지 `robots: { index: false }` 추가**
- 작성·수정 페이지는 검색엔진 색인 불필요
- 비로그인 접근 시 어차피 `/login` redirect로 크롤러가 읽을 내용 없음

### 기대 효과
- 게시글 링크 카카오톡/슬랙 공유 시 제목·설명·이미지 미리보기 카드 노출-> 배포후 확인 필요
- 검색엔진이 게시글 내용 파악 가능 → SEO 개선
- 불필요한 페이지(작성/수정)의 검색 노출 차단

## 💡 관련 Issue

Closes #131 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #131)
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
