### PR TITLE
[feat] 홈 페이지 메타데이터 추가 및 로그인/로그아웃 분기 구현

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,9 @@
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
-import { Metadata } from 'next';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import LogoutButton from '@/components/layout/LogoutButton';
+import { LogIn } from 'lucide-react';
 
 export const metadata: Metadata = {
   title: '블랙벨트 | 주짓수 올인원 네트워크',
@@ -15,17 +18,33 @@ export const metadata: Metadata = {
   },
 };
 
-export default function Home() {
-  // throw Error('test');
+const NAV_LINKS = [
+  { href: '/community', icon: '/whitebelt.svg', label: '커뮤니티' },
+  { href: '/dojangs', icon: '/brownbelt.svg', label: '도장 찾기' },
+  {
+    href: '/competitions',
+    icon: '/blackbeltcompetiton.svg',
+    label: '대회 일정',
+  },
+] as const;
+
+const NAV_LINK_CLASS =
+  'flex items-center gap-2 px-6 py-3 border-2 border-btn-focus text-black text-sm font-medium rounded-xl hover:bg-btn-focus hover:text-white transition-colors duration-200';
+
+export default async function Home() {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
   return (
     <main
       aria-label="블랙벨트 홈"
       className="min-h-screen bg-white flex flex-col items-center justify-center px-6 py-16 relative overflow-hidden"
     >
-      {/* 로고 */}
+      {/* 로고 & 타이틀 */}
       <div className="flex flex-col items-center mb-6 animate-fade-in">
-        <div className="mb-4 relative">
+        <div className="mb-4">
           <Image
             src="/blackbelt.svg"
             alt="블랙벨트 로고"
@@ -34,7 +53,6 @@ export default function Home() {
           />
         </div>
 
-        {/* 타이틀 */}
         <h1
           className="text-4xl font-black tracking-tight text-black text-center leading-tight"
           style={{ fontFamily: "Georgia, 'Times New Roman', serif" }}
@@ -47,10 +65,8 @@ export default function Home() {
         >
           (Black-Belt)
         </p>
-        <br />
 
-        {/* 설명 텍스트 */}
-        <p className="text-sm text-gray-600 text-center max-w-xl leading-relaxed">
+        <p className="text-sm text-gray-600 text-center max-w-xl leading-relaxed mt-4">
           주짓수인들을 위한 올인원 네트워크, 블랙벨트
           <br />
           <br />
@@ -65,57 +81,31 @@ export default function Home() {
         </p>
       </div>
 
-      {/* 네비게이션 버튼 */}
+      {/* 네비게이션 */}
       <nav aria-label="주요 메뉴">
         <div className="flex flex-wrap justify-center gap-3 mt-2">
-          <Link
-            href="/community"
-            className="flex items-center gap-2 px-5 py-2.5 border-2 border-btn-focus text-black text-sm font-medium rounded-xl hover:bg-btn-focus hover:text-white transition-colors duration-200"
-          >
-            <Image
-              src="/whitebelt.svg"
-              alt=""
-              width={35}
-              height={35}
-              aria-hidden="true"
-            />
-            <span>커뮤니티</span>
-          </Link>
+          {NAV_LINKS.map(({ href, icon, label }) => (
+            <Link key={href} href={href} className={NAV_LINK_CLASS}>
+              <Image
+                src={icon}
+                alt=""
+                width={35}
+                height={35}
+                aria-hidden="true"
+              />
+              <span>{label}</span>
+            </Link>
+          ))}
 
-          <Link
-            href="/dojangs"
-            className="flex items-center gap-2 px-5 py-2.5 border-2 border-btn-focus text-black text-sm font-medium rounded-xl hover:bg-btn-focus hover:text-white transition-colors duration-200"
-          >
-            <Image
-              src="/brownbelt.svg"
-              alt=""
-              width={35}
-              height={35}
-              aria-hidden="true"
-            />
-            <span>도장 찾기</span>
-          </Link>
-
-          <Link
-            href="/competitions"
-            className="flex items-center gap-2 px-5 py-2.5 border-2 border-btn-focus text-black text-sm font-medium rounded-xl hover:bg-btn-focus hover:text-white transition-colors duration-200"
-          >
-            <Image
-              src="/blackbeltcompetiton.svg"
-              alt=""
-              width={35}
-              height={35}
-              aria-hidden="true"
-            />
-            <span>대회 일정</span>
-          </Link>
-
-          <Link
-            href="/login"
-            className="flex items-center gap-2 px-5 py-2.5 border-2 border-btn-focus text-black text-sm font-medium rounded-xl hover:bg-btn-focus hover:text-white transition-colors duration-200"
-          >
-            <span>로그인</span>
-          </Link>
+          {/* 로그인 상태 분기 */}
+          {user ? (
+            <LogoutButton />
+          ) : (
+            <Link href="/login" className={NAV_LINK_CLASS}>
+              <LogIn size={20} aria-hidden="true" />
+              <span>로그인</span>
+            </Link>
+          )}
         </div>
       </nav>
     </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,19 @@
 import Link from 'next/link';
 import Image from 'next/image';
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: '블랙벨트 | 주짓수 올인원 네트워크',
+  description:
+    '주짓수 수련자와 도장을 하나의 공간에서 연결하는 커뮤니티 플랫폼.',
+  keywords: ['주짓수', '블랙벨트', '도장', '커뮤니티', 'BJJ'],
+  openGraph: {
+    title: '블랙벨트 | 주짓수 올인원 네트워크',
+    description: '주짓수인들을 위한 올인원 네트워크, 블랙벨트',
+    locale: 'ko_KR',
+    type: 'website',
+  },
+};
 
 export default function Home() {
   // throw Error('test');

--- a/src/components/layout/LogoutButton.tsx
+++ b/src/components/layout/LogoutButton.tsx
@@ -1,15 +1,17 @@
 'use client';
 
+import { LogOut } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
 
 const NAV_LINK_CLASS =
-  'flex items-center gap-2 px-5 py-2.5 border-2 border-btn-focus text-black text-sm font-medium rounded-xl hover:bg-btn-focus hover:text-white transition-colors duration-200';
+  'flex items-center gap-2 px-6 py-3 border-2 border-btn-focus text-black text-sm font-medium rounded-xl hover:bg-btn-focus hover:text-white transition-colors duration-200';
 
 export default function LogoutButton() {
   const { logout } = useAuth();
 
   return (
     <button type="button" className={NAV_LINK_CLASS} onClick={() => logout()}>
+      <LogOut size={20} aria-hidden="true" />
       <span>로그아웃</span>
     </button>
   );

--- a/src/components/layout/LogoutButton.tsx
+++ b/src/components/layout/LogoutButton.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useAuth } from '@/hooks/useAuth';
+
+const NAV_LINK_CLASS =
+  'flex items-center gap-2 px-5 py-2.5 border-2 border-btn-focus text-black text-sm font-medium rounded-xl hover:bg-btn-focus hover:text-white transition-colors duration-200';
+
+export default function LogoutButton() {
+  const { logout } = useAuth();
+
+  return (
+    <button type="button" className={NAV_LINK_CLASS} onClick={() => logout()}>
+      <span>로그아웃</span>
+    </button>
+  );
+}

--- a/src/components/layout/LogoutButton.tsx
+++ b/src/components/layout/LogoutButton.tsx
@@ -4,7 +4,7 @@ import { LogOut } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
 
 const NAV_LINK_CLASS =
-  'flex items-center gap-2 px-6 py-3 border-2 border-btn-focus text-black text-sm font-medium rounded-xl hover:bg-btn-focus hover:text-white transition-colors duration-200';
+  'flex items-center gap-2 px-6 py-3 border-2 border-btn-focus text-black text-sm font-medium rounded-xl hover:bg-btn-focus hover:text-white transition-colors duration-200 cursor-pointer';
 
 export default function LogoutButton() {
   const { logout } = useAuth();

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,4 +1,3 @@
-// supabase/server.ts
 import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
 

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,0 +1,24 @@
+// supabase/server.ts
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+
+export async function createSupabaseServerClient() {
+  const cookieStore = await cookies();
+
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value, options }) =>
+            cookieStore.set(name, value, options),
+          );
+        },
+      },
+    },
+  );
+}


### PR DESCRIPTION
## 개요
홈 페이지 메타데이터 추가, 로그인/로그아웃 버튼 분기 구현, 코드 리팩토링을 진행했습니다.

## 변경 사항

### 1. 홈 메타데이터 추가
- `title`, `description`, `keywords`, `openGraph` 설정 추가
<img width="268" height="81" alt="image" src="https://github.com/user-attachments/assets/ac788fd4-8577-4da6-b5cd-94fa24f935e7" />

### 2. 로그인/로그아웃 버튼 분기
- Supabase 서버 클라이언트(`lib/supabase/server.ts`)를 신규 추가
- 서버에서 `getUser()`로 로그인 여부 판단
- 비로그인 시 로그인 버튼, 로그인 시 로그아웃 버튼으로 교체
- `LogoutButton` 컴포넌트는 Sidebar와 동일하게 `useAuth().logout()` 사용

<img width="1048" height="854" alt="20260512-0508-02 0225579" src="https://github.com/user-attachments/assets/849b515f-90d1-453f-8816-18e9890c30ae" />

### 3. 코드 리팩토링
- 네비게이션 버튼을 `NAV_LINKS` 배열로 추출해 중복 제거
- 공통 버튼 스타일을 `NAV_LINK_CLASS` 상수로 분리
- 로그인/로그아웃 버튼에 `lucide-react` 아이콘(`LogIn`, `LogOut`) 추가
- 버튼 패딩 조정(`px-6 py-3`)으로 시각적 통일감 개선

## 추가된 파일
- `src/lib/supabase/server.ts` — Supabase 서버 클라이언트 헬퍼
  - 기존 `lib/supabase.ts`는 `createBrowserClient`로 브라우저 전용이라
    Server Component에서 세션을 읽을 수 없음
  - 서버에서 `cookies()`를 통해 로그인 상태를 안전하게 확인하기 위해
    `createServerClient` 기반의 서버 전용 헬퍼를 별도 추가

- `src/components/layout/LogoutButton.tsx` — 로그아웃 버튼 클라이언트 컴포넌트

## 💡 관련 Issue

Closes #144 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #144 )
- [x] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
