### PR TITLE
[Feat] SERVICE_ROLE_KEY 활용 비밀번호 재설정 및 회원탈퇴 구현

### DIFF
--- a/src/app/(auth)/find-id/page.tsx
+++ b/src/app/(auth)/find-id/page.tsx
@@ -1,3 +1,0 @@
-export default function FindIdPage() {
-  return <div>아이디 찾기</div>;
-}

--- a/src/app/(auth)/find-password/page.tsx
+++ b/src/app/(auth)/find-password/page.tsx
@@ -3,7 +3,6 @@
 import React, { useState } from 'react';
 import { Mail, Lock, User } from 'lucide-react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 import { z } from 'zod';
 
 const step1Schema = z.object({
@@ -22,7 +21,7 @@ const step2Schema = z
   });
 
 export default function FindPasswordPage() {
-  const [step, setStep] = useState<1 | 2>(1);
+  const [step, setStep] = useState<1 | 2 | 3>(1);
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -34,15 +33,12 @@ export default function FindPasswordPage() {
     confirmPassword?: string;
     server?: string;
   }>({});
-  const router = useRouter();
+
   const handleStep1 = async () => {
     const result = step1Schema.safeParse({ name, email });
     if (!result.success) {
       const fieldErrors = result.error.flatten().fieldErrors;
-      setErrors({
-        name: fieldErrors.name?.[0],
-        email: fieldErrors.email?.[0],
-      });
+      setErrors({ name: fieldErrors.name?.[0], email: fieldErrors.email?.[0] });
       return;
     }
     setErrors({});
@@ -57,9 +53,9 @@ export default function FindPasswordPage() {
       setErrors({ server: '이름 또는 이메일이 올바르지 않습니다.' });
       return;
     }
-
     setStep(2);
   };
+
   const handleStep2 = async () => {
     const result = step2Schema.safeParse({ password, confirmPassword });
     if (!result.success) {
@@ -84,9 +80,9 @@ export default function FindPasswordPage() {
       });
       return;
     }
-
-    router.push('/login');
+    setStep(3);
   };
+
   return (
     <>
       <p className="text-text-secondary text-sm font-medium text-center mb-6">
@@ -95,10 +91,14 @@ export default function FindPasswordPage() {
 
       <div className="max-w-150 w-full bg-bg-white rounded-[32px] p-8 shadow-sm border-none">
         <h2 className="text-2xl font-bold text-center text-text-primary mb-8">
-          {step === 1 ? '비밀번호 찾기' : '비밀번호 재설정'}
+          {step === 1
+            ? '비밀번호 찾기'
+            : step === 2
+              ? '비밀번호 재설정'
+              : '재설정 완료'}
         </h2>
 
-        {step === 1 ? (
+        {step === 1 && (
           <form
             className="space-y-5"
             onSubmit={(e) => {
@@ -106,7 +106,6 @@ export default function FindPasswordPage() {
               handleStep1();
             }}
           >
-            {/* 이름 */}
             <div>
               <label className="block text-sm font-medium text-text-primary mb-2">
                 이름
@@ -126,7 +125,6 @@ export default function FindPasswordPage() {
               </p>
             </div>
 
-            {/* 이메일 */}
             <div>
               <label className="block text-sm font-medium text-text-primary mb-2">
                 이메일
@@ -168,7 +166,9 @@ export default function FindPasswordPage() {
               </Link>
             </p>
           </form>
-        ) : (
+        )}
+
+        {step === 2 && (
           <form
             className="space-y-5"
             onSubmit={(e) => {
@@ -176,7 +176,6 @@ export default function FindPasswordPage() {
               handleStep2();
             }}
           >
-            {/* 새 비밀번호 */}
             <div>
               <label className="block text-sm font-medium text-text-primary mb-2">
                 새 비밀번호
@@ -196,7 +195,6 @@ export default function FindPasswordPage() {
               </p>
             </div>
 
-            {/* 비밀번호 확인 */}
             <div>
               <label className="block text-sm font-medium text-text-primary mb-2">
                 비밀번호 확인
@@ -238,6 +236,40 @@ export default function FindPasswordPage() {
               </Link>
             </p>
           </form>
+        )}
+
+        {step === 3 && (
+          <div className="flex flex-col items-center gap-6 py-4">
+            <div className="w-16 h-16 rounded-full bg-green-100 flex items-center justify-center">
+              <svg
+                className="w-8 h-8 text-green-500"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+            </div>
+            <div className="text-center flex flex-col gap-2">
+              <p className="text-lg font-bold text-text-primary">
+                비밀번호가 재설정되었습니다.
+              </p>
+              <p className="text-sm text-text-secondary">
+                새 비밀번호로 다시 로그인해주세요.
+              </p>
+            </div>
+            <Link
+              href="/login"
+              className="w-full bg-btn-focus text-btn-focus-text py-4 rounded-2xl font-bold text-lg hover:opacity-90 transition-all text-center"
+            >
+              로그인하러 가기
+            </Link>
+          </div>
         )}
       </div>
     </>

--- a/src/app/(auth)/find-password/page.tsx
+++ b/src/app/(auth)/find-password/page.tsx
@@ -5,7 +5,6 @@ import { Mail, Lock, User } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { z } from 'zod';
-import { supabase } from '@/lib/supabase';
 
 const step1Schema = z.object({
   name: z.string().min(1, '이름을 입력해주세요.'),
@@ -48,17 +47,14 @@ export default function FindPasswordPage() {
     }
     setErrors({});
 
-    const { data, error } = await supabase
-      .from('profiles')
-      .select('id')
-      .eq('email_value', email)
-      .eq('name', name)
-      .single();
+    const res = await fetch('/api/reset-password', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, email, checkOnly: true }),
+    });
 
-    if (error || !data) {
-      setErrors({
-        server: '이름 또는 이메일이 올바르지 않습니다.',
-      });
+    if (!res.ok) {
+      setErrors({ server: '이름 또는 이메일이 올바르지 않습니다.' });
       return;
     }
 
@@ -76,8 +72,13 @@ export default function FindPasswordPage() {
     }
     setErrors({});
 
-    const { error } = await supabase.auth.updateUser({ password });
-    if (error) {
+    const res = await fetch('/api/reset-password', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, email, password }),
+    });
+
+    if (!res.ok) {
       setErrors({
         server: '비밀번호 재설정에 실패했습니다. 다시 시도해주세요.',
       });

--- a/src/app/api/delete-account/route.ts
+++ b/src/app/api/delete-account/route.ts
@@ -3,7 +3,6 @@ import { NextRequest, NextResponse } from 'next/server';
 
 export async function DELETE(req: NextRequest) {
   const { userId } = await req.json();
-  console.log('userId:', userId);
 
   const supabaseAdmin = createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -16,7 +15,6 @@ export async function DELETE(req: NextRequest) {
     .eq('id', userId);
 
   if (profileError) {
-    console.log('profileError:', profileError);
     return NextResponse.json(
       { error: '회원탈퇴에 실패했습니다.' },
       { status: 500 },
@@ -24,7 +22,6 @@ export async function DELETE(req: NextRequest) {
   }
 
   const { error } = await supabaseAdmin.auth.admin.deleteUser(userId);
-  console.log('error:', error);
 
   if (error) {
     return NextResponse.json(

--- a/src/app/api/delete-account/route.ts
+++ b/src/app/api/delete-account/route.ts
@@ -3,13 +3,28 @@ import { NextRequest, NextResponse } from 'next/server';
 
 export async function DELETE(req: NextRequest) {
   const { userId } = await req.json();
+  console.log('userId:', userId);
 
   const supabaseAdmin = createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.SUPABASE_SERVICE_ROLE_KEY!,
   );
 
+  const { error: profileError } = await supabaseAdmin
+    .from('profiles')
+    .delete()
+    .eq('id', userId);
+
+  if (profileError) {
+    console.log('profileError:', profileError);
+    return NextResponse.json(
+      { error: '회원탈퇴에 실패했습니다.' },
+      { status: 500 },
+    );
+  }
+
   const { error } = await supabaseAdmin.auth.admin.deleteUser(userId);
+  console.log('error:', error);
 
   if (error) {
     return NextResponse.json(

--- a/src/app/api/delete-acoount/route.ts
+++ b/src/app/api/delete-acoount/route.ts
@@ -1,0 +1,22 @@
+import { createClient } from '@supabase/supabase-js';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function DELETE(req: NextRequest) {
+  const { userId } = await req.json();
+
+  const supabaseAdmin = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+
+  const { error } = await supabaseAdmin.auth.admin.deleteUser(userId);
+
+  if (error) {
+    return NextResponse.json(
+      { error: '회원탈퇴에 실패했습니다.' },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/register-dojang/route.ts
+++ b/src/app/api/register-dojang/route.ts
@@ -1,0 +1,68 @@
+import { createClient } from '@supabase/supabase-js';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const {
+    email,
+    password,
+    name,
+    nickname,
+    belt,
+    licenseNumber,
+    ownerName,
+    phone,
+    address,
+    businessFileUrl,
+  } = await req.json();
+
+  const supabaseAdmin = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+
+  // 1. auth 유저 생성
+  const { data, error } = await supabaseAdmin.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true,
+  });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  // 2. profiles insert
+  const { error: profileError } = await supabaseAdmin.from('profiles').upsert({
+    id: data.user.id,
+    name,
+    nickname,
+    belt_level: belt,
+    email_value: email,
+    role: 'manager',
+  });
+
+  // 3. profiles 실패 시 auth 유저 롤백
+  if (profileError) {
+    await supabaseAdmin.auth.admin.deleteUser(data.user.id);
+    return NextResponse.json({ error: profileError.message }, { status: 500 });
+  }
+
+  // 4. dojang insert
+  const { error: dojangError } = await supabaseAdmin.from('dojang').insert({
+    profile_id: data.user.id,
+    business_number: licenseNumber,
+    representative: ownerName,
+    phone_value: phone,
+    address,
+    business_file_url: businessFileUrl,
+  });
+
+  // 5. dojang 실패 시 auth 유저 + profiles 롤백
+  if (dojangError) {
+    await supabaseAdmin.from('profiles').delete().eq('id', data.user.id);
+    await supabaseAdmin.auth.admin.deleteUser(data.user.id);
+    return NextResponse.json({ error: dojangError.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -1,0 +1,42 @@
+import { createClient } from '@supabase/supabase-js';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const { email, password, name, nickname, belt } = await req.json();
+
+  const supabaseAdmin = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+
+  // 1. auth 유저 생성
+  const { data, error } = await supabaseAdmin.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true,
+  });
+
+  console.log('error:', error); // ← 추가
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  // 2. profiles insert
+  const { error: profileError } = await supabaseAdmin.from('profiles').upsert({
+    id: data.user.id,
+    name,
+    nickname,
+    belt_level: belt,
+    email_value: email,
+    role: 'user',
+  });
+
+  // 3. profiles 실패 시 auth 유저 롤백
+  if (profileError) {
+    await supabaseAdmin.auth.admin.deleteUser(data.user.id);
+    return NextResponse.json({ error: profileError.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/reset-password/route.ts
+++ b/src/app/api/reset-password/route.ts
@@ -1,0 +1,42 @@
+import { createClient } from '@supabase/supabase-js';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const { name, email, password, checkOnly } = await req.json();
+
+  const supabaseAdmin = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+
+  const { data: profile } = await supabaseAdmin
+    .from('profiles')
+    .select('id')
+    .eq('email_value', email)
+    .eq('name', name)
+    .single();
+
+  if (!profile) {
+    return NextResponse.json(
+      { error: '이름 또는 이메일이 올바르지 않습니다.' },
+      { status: 404 },
+    );
+  }
+
+  if (checkOnly) {
+    return NextResponse.json({ success: true });
+  }
+
+  const { error } = await supabaseAdmin.auth.admin.updateUserById(profile.id, {
+    password,
+  });
+
+  if (error) {
+    return NextResponse.json(
+      { error: '비밀번호 재설정에 실패했습니다.' },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/components/mypage/SettingsTab.tsx
+++ b/src/components/mypage/SettingsTab.tsx
@@ -44,6 +44,7 @@ export default function SettingsTab({ profile }: SettingsTabProps) {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [showSaveConfirm, setShowSaveConfirm] = useState(false);
   const [showCancelConfirm, setShowCancelConfirm] = useState(false);
+  const [showDeleteSuccess, setShowDeleteSuccess] = useState(false);
 
   const router = useRouter();
   const { mutate: updateProfile, isPending: isUpdating } = useUpdateMyProfile();
@@ -295,7 +296,13 @@ export default function SettingsTab({ profile }: SettingsTabProps) {
                 onClick={() =>
                   deleteAccount(undefined, {
                     onSuccess: () => {
-                      router.push('/login');
+                      setShowDeleteConfirm(false);
+                      setShowDeleteSuccess(true);
+                    },
+                    onError: () => {
+                      showErrorToast(
+                        '회원탈퇴에 실패했습니다. 다시 시도해주세요.',
+                      );
                     },
                   })
                 }
@@ -311,6 +318,25 @@ export default function SettingsTab({ profile }: SettingsTabProps) {
                 )}
               </button>
             </div>
+          </DialogContent>
+        </Dialog>
+        {/* 탈퇴 완료 모달 */}
+        <Dialog open={showDeleteSuccess} onOpenChange={setShowDeleteSuccess}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle className="text-center">
+                탈퇴 완료되었습니다.
+              </DialogTitle>
+              <DialogDescription className="text-center">
+                이용해주셔서 감사합니다.
+              </DialogDescription>
+            </DialogHeader>
+            <button
+              onClick={() => router.push('/login')}
+              className="w-full mt-4 px-6 py-3 bg-btn-focus text-btn-focus-text rounded-xl text-sm font-bold hover:opacity-90 transition-all cursor-pointer"
+            >
+              확인
+            </button>
           </DialogContent>
         </Dialog>
       </div>

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -14,19 +14,16 @@ export async function registerGeneral({
   nickname: string;
   belt: string;
 }) {
-  const { data, error } = await supabase.auth.signUp({ email, password });
-  if (error) throw error;
-  if (!data.user) throw new Error('회원가입에 실패했습니다.');
-
-  const { error: profileError } = await supabase.from('profiles').upsert({
-    id: data.user.id,
-    name,
-    nickname,
-    belt_level: belt,
-    email_value: email,
-    role: 'user',
+  const res = await fetch('/api/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password, name, nickname, belt }),
   });
-  if (profileError) throw profileError;
+
+  if (!res.ok) {
+    const data = await res.json();
+    throw new Error(data.error);
+  }
 }
 
 // 도장 회원 가입
@@ -53,29 +50,27 @@ export async function registerDojang({
   address: string;
   businessFileUrl?: string;
 }) {
-  const { data, error } = await supabase.auth.signUp({ email, password });
-  if (error) throw error;
-  if (!data.user) throw new Error('회원가입에 실패했습니다.');
-
-  const { error: profileError } = await supabase.from('profiles').upsert({
-    id: data.user.id,
-    name,
-    nickname,
-    belt_level: belt,
-    email_value: email,
-    role: 'manager',
+  const res = await fetch('/api/register-dojang', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      email,
+      password,
+      name,
+      nickname,
+      belt,
+      licenseNumber,
+      ownerName,
+      phone,
+      address,
+      businessFileUrl,
+    }),
   });
-  if (profileError) throw profileError;
 
-  const { error: dojangError } = await supabase.from('dojang').insert({
-    profile_id: data.user.id,
-    business_number: licenseNumber,
-    representative: ownerName,
-    phone_value: phone,
-    address,
-    business_file_url: businessFileUrl,
-  });
-  if (dojangError) throw dojangError;
+  if (!res.ok) {
+    const data = await res.json();
+    throw new Error(data.error);
+  }
 }
 
 // 사업자등록증 파일 업로드

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -84,9 +84,22 @@ export async function fetchMyPosts(page: number): Promise<MyPost[]> {
 
 // 회원 탈퇴
 export async function deleteMyAccount(): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, 2000));
-  const { error } = await supabase.auth.signOut();
-  if (error) throw error;
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error('로그인이 필요합니다.');
+
+  const res = await fetch('/api/delete-account', {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userId: user.id }),
+  });
+
+  if (!res.ok) {
+    throw new Error('회원탈퇴에 실패했습니다.');
+  }
+
+  await supabase.auth.signOut();
 }
 
 // 내 게시글 수 조회


### PR DESCRIPTION
## 📌 개요

- SERVICE_ROLE_KEY를 활용한 API Route로 비밀번호 재설정과 회원탈퇴 기능 구현

## 💻 작업 사항

- reset-password API Route 생성
- delete-account API Route 생성
- 비밀번호 찾기 페이지에서 reset-password API Route 연동
- 비밀번호 재설정 완료 화면 추가
- delete-account API Route 연동으로 회원 완전 삭제 처리
- 회원탈퇴 완료 모달 추가
- find-id 페이지 삭제

회원탈퇴 
<img width="399" height="162" alt="스크린샷 2026-05-12 14 56 57" src="https://github.com/user-attachments/assets/5396a229-3385-4e72-8bde-54f3891f117f" />

https://github.com/user-attachments/assets/9831c00e-49ac-4fb0-aed4-a6f29a144a98


비밀번호 찾기
<img width="687" height="597" alt="스크린샷 2026-05-12 15 04 09" src="https://github.com/user-attachments/assets/0bc6c953-eed8-4c41-b939-47984f6c75a0" />

https://github.com/user-attachments/assets/24d5f6ca-4850-4b04-8d25-31fbe06da64d


## 💡 관련 Issue

Closes #143 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #)
- [x] 불필요한 console.log를 제거했습니다.
- [x] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
