### PR TITLE
[refactor] 게시글 관련 페이지 리팩토링

### DIFF
--- a/src/app/(main)/community/[id]/edit/page.tsx
+++ b/src/app/(main)/community/[id]/edit/page.tsx
@@ -2,8 +2,7 @@ export const dynamic = 'force-dynamic';
 
 import type { Metadata } from 'next';
 import EditClient from '@/components/community/EditClient';
-import { createServerClient } from '@supabase/ssr';
-import { cookies } from 'next/headers';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { getPost } from '@/services/communityService';
 import { notFound, redirect } from 'next/navigation';
 
@@ -25,12 +24,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 }
 
 async function getInitialData(id: string) {
-  const cookieStore = await cookies();
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    { cookies: { getAll: () => cookieStore.getAll() } },
-  );
+  const supabase = await createSupabaseServerClient();
 
   const [
     post,

--- a/src/app/(main)/community/[id]/edit/page.tsx
+++ b/src/app/(main)/community/[id]/edit/page.tsx
@@ -1,4 +1,3 @@
-// community/[id]/edit/page.tsx
 export const dynamic = 'force-dynamic';
 
 import type { Metadata } from 'next';
@@ -21,7 +20,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return {
     title: `${post.title} 수정 | Black Belt BJJ`,
     description: `"${post.title}" 게시글을 수정합니다.`,
-    robots: { index: false }, // 수정 페이지는 검색엔진 색인 제외
+    robots: { index: false },
   };
 }
 

--- a/src/app/(main)/community/[id]/page.tsx
+++ b/src/app/(main)/community/[id]/page.tsx
@@ -1,4 +1,3 @@
-// community/[id]/page.tsx
 export const dynamic = 'force-dynamic';
 
 import type { Metadata } from 'next';

--- a/src/app/(main)/community/[id]/page.tsx
+++ b/src/app/(main)/community/[id]/page.tsx
@@ -2,8 +2,7 @@ export const dynamic = 'force-dynamic';
 
 import type { Metadata } from 'next';
 import PostDetailClient from '@/components/community/PostDetailClient';
-import { createServerClient } from '@supabase/ssr';
-import { cookies } from 'next/headers';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
 import {
   getPost,
   getComments,
@@ -39,12 +38,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 }
 
 async function getInitialData(id: string) {
-  const cookieStore = await cookies();
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    { cookies: { getAll: () => cookieStore.getAll() } },
-  );
+  const supabase = await createSupabaseServerClient();
 
   const [
     post,

--- a/src/app/(main)/community/write/page.tsx
+++ b/src/app/(main)/community/write/page.tsx
@@ -2,8 +2,7 @@ export const dynamic = 'force-dynamic';
 
 import type { Metadata } from 'next';
 import WriteClient from '@/components/community/WriteClient';
-import { createServerClient } from '@supabase/ssr';
-import { cookies } from 'next/headers';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { redirect } from 'next/navigation';
 
 export const metadata: Metadata = {
@@ -12,22 +11,12 @@ export const metadata: Metadata = {
   robots: { index: false },
 };
 
-async function getUser() {
-  const cookieStore = await cookies();
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    { cookies: { getAll: () => cookieStore.getAll() } },
-  );
-
+export default async function WritePage() {
+  const supabase = await createSupabaseServerClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();
-  return user;
-}
 
-export default async function WritePage() {
-  const user = await getUser();
   if (!user) redirect('/login');
 
   return <WriteClient />;

--- a/src/app/(main)/community/write/page.tsx
+++ b/src/app/(main)/community/write/page.tsx
@@ -1,4 +1,3 @@
-// community/write/page.tsx
 export const dynamic = 'force-dynamic';
 
 import type { Metadata } from 'next';
@@ -10,7 +9,7 @@ import { redirect } from 'next/navigation';
 export const metadata: Metadata = {
   title: '게시글 작성 | Black Belt BJJ',
   description: '블랙벨트 커뮤니티에 새 게시글을 작성합니다.',
-  robots: { index: false }, // 작성 페이지는 검색엔진 색인 제외
+  robots: { index: false },
 };
 
 async function getUser() {

--- a/src/components/community/PostDetailClient.tsx
+++ b/src/components/community/PostDetailClient.tsx
@@ -3,9 +3,12 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { deletePost, deleteComment } from '@/services/communityService';
+import {
+  deletePost,
+  deleteComment,
+  updateComment,
+} from '@/services/communityService';
 import { reportPost, ReportReason } from '@/services/reportService';
-import { supabase } from '@/lib/supabase';
 import type { Post, Comment } from '@/types/community';
 import Image from 'next/image';
 import { useAuth } from '@/hooks/useAuth';
@@ -69,7 +72,6 @@ export default function PostDetailClient({
         return;
       }
 
-      // 현재 유저 프로필 정보를 합쳐서 바로 표시 (프로필 이미지 즉시 반영)
       setComments((prev) => [
         ...prev,
         {
@@ -79,8 +81,7 @@ export default function PostDetailClient({
         },
       ]);
       setComment('');
-    } catch (e) {
-      console.error(e);
+    } catch {
       showErrorToast('네트워크 오류가 발생했습니다.');
     }
   };
@@ -92,18 +93,15 @@ export default function PostDetailClient({
       queryClient.invalidateQueries({ queryKey: ['posts'] });
       showSuccessToast('게시글이 삭제되었습니다.', '🗑️');
       router.push('/community');
-    } catch (e) {
-      console.error(e);
+    } catch {
+      showErrorToast('게시글 삭제에 실패했습니다.');
     }
   };
 
   const handleEditComment = async (commentId: string) => {
     if (!editingContent.trim()) return;
     try {
-      await supabase
-        .from('comments')
-        .update({ content: editingContent })
-        .eq('id', commentId);
+      await updateComment(commentId, editingContent);
       setComments((prev) =>
         prev.map((c) =>
           c.id === commentId ? { ...c, content: editingContent } : c,
@@ -112,8 +110,8 @@ export default function PostDetailClient({
       setEditingCommentId(null);
       setEditingContent('');
       showSuccessToast('댓글이 수정되었습니다.', '✅');
-    } catch (e) {
-      console.error(e);
+    } catch {
+      showErrorToast('댓글 수정에 실패했습니다.');
     }
   };
 
@@ -123,8 +121,8 @@ export default function PostDetailClient({
       await deleteComment(commentId);
       setComments((prev) => prev.filter((c) => c.id !== commentId));
       showSuccessToast('댓글이 삭제되었습니다.', '🗑️');
-    } catch (e) {
-      console.error(e);
+    } catch {
+      showErrorToast('댓글 삭제에 실패했습니다.');
     }
   };
 
@@ -179,7 +177,6 @@ export default function PostDetailClient({
 
   return (
     <div className="max-w-2xl mx-auto p-4 space-y-4">
-      {/* 뒤로가기 */}
       <button
         onClick={() => router.push('/community')}
         aria-label="커뮤니티 목록으로 이동"
@@ -203,7 +200,6 @@ export default function PostDetailClient({
         목록으로
       </button>
 
-      {/* 게시글 카드 */}
       <PostDetailCard
         post={postDetailCardData}
         isLiked={isLiked}
@@ -255,7 +251,6 @@ export default function PostDetailClient({
         }
       />
 
-      {/* 댓글 카드 */}
       <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden">
         <div className="px-5 pt-5 pb-3 flex items-center gap-2 border-b border-gray-100">
           <Image
@@ -269,7 +264,6 @@ export default function PostDetailClient({
           <h2 className="text-sm font-semibold text-gray-800">댓글</h2>
         </div>
 
-        {/* 댓글 입력 */}
         <div className="px-5 py-4">
           <div className="flex items-center gap-2">
             <label htmlFor="comment-input" className="sr-only">
@@ -302,7 +296,6 @@ export default function PostDetailClient({
           </div>
         </div>
 
-        {/* 댓글 목록 */}
         <div className="px-5 pb-5 space-y-4">
           {comments.map((c, index) => (
             <div key={c.id}>
@@ -348,7 +341,7 @@ export default function PostDetailClient({
                         className="flex-1"
                         onKeyDown={(e) =>
                           e.key === 'Enter' && handleEditComment(c.id)
-                        } // 추가
+                        }
                       />
                       <button
                         onClick={() => handleEditComment(c.id)}
@@ -416,7 +409,6 @@ export default function PostDetailClient({
         </div>
       </div>
 
-      {/* 신고 모달 */}
       <ReportModal
         isOpen={reportModalOpen}
         onClose={() => setReportModalOpen(false)}

--- a/src/components/community/WriteClient.tsx
+++ b/src/components/community/WriteClient.tsx
@@ -64,7 +64,6 @@ export default function WriteClient() {
         <h1 className="text-lg font-semibold mx-auto">게시글 작성</h1>
       </div>
 
-      {/* ✅ 탭 버튼 */}
       <div role="tablist" className="flex bg-gray-100 rounded-xl p-1 mb-6">
         <button
           role="tab"
@@ -90,7 +89,6 @@ export default function WriteClient() {
         </button>
       </div>
 
-      {/* ✅ 작성 탭 */}
       {tab === 'write' && (
         <>
           <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
@@ -165,7 +163,6 @@ export default function WriteClient() {
         </>
       )}
 
-      {/* ✅ 미리보기 탭 */}
       {tab === 'preview' &&
         (!title && !content ? (
           <div className="flex flex-col items-center justify-center py-16 text-gray-400 mb-6">
@@ -191,7 +188,6 @@ export default function WriteClient() {
           </div>
         ))}
 
-      {/* 하단 버튼 */}
       <PostFormActions
         onCancel={() => router.back()}
         onSubmit={handleSubmit}

--- a/src/services/communityService.ts
+++ b/src/services/communityService.ts
@@ -1,5 +1,16 @@
+import { cache } from 'react';
 import { supabase } from '@/lib/supabase';
 import type { Post, Comment, PostCategory } from '@/types/community';
+
+interface ProfileBase {
+  nickname: string;
+  avatar_url: string;
+}
+
+interface PostProfile extends ProfileBase {
+  belt_level: string;
+  role: string;
+}
 
 export async function getPosts() {
   const { data, error } = await supabase
@@ -12,16 +23,13 @@ export async function getPosts() {
   return data.map((post) => ({
     ...post,
     comment_count: (post.comments as { count: number }[])[0]?.count ?? 0,
-    nickname: (post.profiles as { nickname: string; avatar_url: string } | null)
-      ?.nickname,
-    avatar_url: (
-      post.profiles as { nickname: string; avatar_url: string } | null
-    )?.avatar_url,
+    nickname: (post.profiles as ProfileBase | null)?.nickname,
+    avatar_url: (post.profiles as ProfileBase | null)?.avatar_url,
     profiles: undefined,
   }));
 }
 
-export async function getPost(id: string) {
+export const getPost = cache(async (id: string) => {
   const { data, error } = await supabase
     .from('posts')
     .select('*, profiles(nickname, avatar_url, belt_level, role)')
@@ -37,7 +45,7 @@ export async function getPost(id: string) {
     role: data.profiles?.role,
     profiles: undefined,
   } as Post;
-}
+});
 
 export async function createPost({
   category,
@@ -76,20 +84,13 @@ export async function deletePost(id: string) {
 
 export async function uploadPostImage(file: File): Promise<string> {
   const ext = file.name.split('.').pop();
-  const fileName = `${Date.now()}.${ext}`; // 한글 파일명 제거
+  const fileName = `${Date.now()}.${ext}`;
   const { error } = await supabase.storage
     .from('post-images')
     .upload(fileName, file);
   if (error) throw error;
   const { data } = supabase.storage.from('post-images').getPublicUrl(fileName);
   return data.publicUrl;
-}
-
-interface CommentProfile {
-  nickname: string;
-  avatar_url: string;
-  belt_level: string;
-  role: string;
 }
 
 export async function getComments(postId: string) {
@@ -103,10 +104,10 @@ export async function getComments(postId: string) {
 
   return data.map((comment) => ({
     ...comment,
-    nickname: (comment.profiles as CommentProfile | null)?.nickname,
-    avatar_url: (comment.profiles as CommentProfile | null)?.avatar_url,
-    belt_level: (comment.profiles as CommentProfile | null)?.belt_level,
-    role: (comment.profiles as CommentProfile | null)?.role,
+    nickname: (comment.profiles as PostProfile | null)?.nickname,
+    avatar_url: (comment.profiles as PostProfile | null)?.avatar_url,
+    belt_level: (comment.profiles as PostProfile | null)?.belt_level,
+    role: (comment.profiles as PostProfile | null)?.role,
     profiles: undefined,
   })) as Comment[];
 }
@@ -137,10 +138,19 @@ export async function createComment({
   } as Comment;
 }
 
+export async function updateComment(id: string, content: string) {
+  const { error } = await supabase
+    .from('comments')
+    .update({ content })
+    .eq('id', id);
+  if (error) throw error;
+}
+
 export async function deleteComment(id: string) {
   const { error } = await supabase.from('comments').delete().eq('id', id);
   if (error) throw error;
 }
+
 export async function incrementViewCount(id: string) {
   await supabase.rpc('increment_view_count', { post_id: id });
 }


### PR DESCRIPTION
## 📌 개요
게시글 관련 페이지의 중복 코드 제거 및 성능 개선을 위한 리팩토링입니다.

## 💻 작업 사항

**communityService.ts**
- `getPost`에 React `cache()` 적용 → `generateMetadata`, `getInitialData`에서 같은 `id`로 호출 시 DB 쿼리 1회로 감소
- `updateComment` 함수 추가
- 중복 타입 정리 (`CommentProfile` → `ProfileBase` / `PostProfile`)

**page 파일 (write, edit, [id])**
- Supabase 클라이언트 생성 보일러플레이트 → `createSupabaseServerClient()` 헬퍼로 교체
- `write/page.tsx` 불필요한 `getUser()` 래퍼 함수 제거

**PostDetailClient.tsx**
- `supabase` 직접 import 제거 → `updateComment` 서비스 함수 사용
- `console.error` 전부 제거 → `showErrorToast`로 통일 (삭제 실패 시 무음 처리되던 버그 수정 포함)

**WriteClient.tsx**
- 불필요한 주석 제거

## 💡 관련 Issue

Closes #129 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #129 )
- [x] 불필요한 console.log를 제거했습니다.
- [x] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
