### PR TITLE
[feat] 게시글,대회일정 작성/수정페이지에서 새로고침시 경고 팝업 추가

### DIFF
--- a/src/components/community/EditClient.tsx
+++ b/src/components/community/EditClient.tsx
@@ -29,7 +29,6 @@ export default function EditClient({ id, initialPost }: Props) {
   );
   const [imageFile, setImageFile] = useState<File | null>(null);
 
-  // 초기값과 달라졌는지 체크
   const isDirty =
     title !== initialPost.title ||
     content !== initialPost.content ||

--- a/src/components/community/EditClient.tsx
+++ b/src/components/community/EditClient.tsx
@@ -10,6 +10,7 @@ import ImageUpload from '@/components/community/ImageUpload';
 import PostFormActions from '@/components/community/PostFormActions';
 import { LimitedInput } from '../common/LimitedInput';
 import { LimitedTextarea } from '../common/LimitedTextarea';
+import { useBeforeUnload } from '@/hooks/useBeforeUnload';
 
 interface Props {
   id: string;
@@ -27,6 +28,14 @@ export default function EditClient({ id, initialPost }: Props) {
     initialPost.image_url ?? null,
   );
   const [imageFile, setImageFile] = useState<File | null>(null);
+
+  // 초기값과 달라졌는지 체크
+  const isDirty =
+    title !== initialPost.title ||
+    content !== initialPost.content ||
+    imageFile !== null;
+
+  useBeforeUnload(isDirty);
 
   const handleSubmit = async () => {
     if (!title.trim() || !content.trim()) {

--- a/src/components/community/WriteClient.tsx
+++ b/src/components/community/WriteClient.tsx
@@ -27,7 +27,6 @@ export default function WriteClient() {
   const [category, setCategory] = useState<PostCategory>('personal');
   const queryClient = useQueryClient();
 
-  // 하나라도 입력됐으면 dirty
   const isDirty =
     title.trim() !== '' || content.trim() !== '' || imageFile !== null;
 

--- a/src/components/community/WriteClient.tsx
+++ b/src/components/community/WriteClient.tsx
@@ -13,6 +13,7 @@ import PostFormActions from '@/components/community/PostFormActions';
 import PostDetailCard from '@/components/community/PostDetailCard';
 import { LimitedInput } from '../common/LimitedInput';
 import { LimitedTextarea } from '../common/LimitedTextarea';
+import { useBeforeUnload } from '@/hooks/useBeforeUnload';
 
 export default function WriteClient() {
   const router = useRouter();
@@ -25,6 +26,12 @@ export default function WriteClient() {
   const { user } = useAuth();
   const [category, setCategory] = useState<PostCategory>('personal');
   const queryClient = useQueryClient();
+
+  // 하나라도 입력됐으면 dirty
+  const isDirty =
+    title.trim() !== '' || content.trim() !== '' || imageFile !== null;
+
+  useBeforeUnload(isDirty);
 
   const handleSubmit = async () => {
     if (!title.trim() || !content.trim()) {

--- a/src/components/competition/CompetitionEditClient.tsx
+++ b/src/components/competition/CompetitionEditClient.tsx
@@ -14,6 +14,7 @@ import CompetitionForm, {
   CompetitionFormValues,
 } from '@/components/competition/CompetitionForm';
 import type { Competition } from '@/types/competition';
+import { useBeforeUnload } from '@/hooks/useBeforeUnload';
 
 interface CompetitionEditClientProps {
   competition: Competition;
@@ -38,6 +39,19 @@ export default function CompetitionEditClient({
     preview: competition.image_url ?? null,
     imageFile: null,
   });
+
+  const isDirty =
+    values.name !== (competition.name ?? '') ||
+    values.location !== (competition.location ?? '') ||
+    values.eventDate !== (competition.event_data ?? '') ||
+    values.applyDeadline !== (competition.apply_deadline ?? '') ||
+    values.applyUrl !== (competition.apply_url ?? '') ||
+    values.description !== (competition.description ?? '') ||
+    values.participants !==
+      (competition.participants ? String(competition.participants) : '') ||
+    values.imageFile !== null;
+
+  useBeforeUnload(isDirty);
 
   const handleSubmit = async () => {
     if (

--- a/src/components/competition/CompetitionWriteClient.tsx
+++ b/src/components/competition/CompetitionWriteClient.tsx
@@ -15,6 +15,7 @@ import CompetitionForm, {
   CompetitionFormValues,
 } from '@/components/competition/CompetitionForm';
 import CompetitionDetailCard from '@/components/competition/CompetitionDetailCard';
+import { useBeforeUnload } from '@/hooks/useBeforeUnload';
 
 const defaultValues: CompetitionFormValues = {
   name: '',
@@ -34,6 +35,18 @@ export default function CompetitionWriteClient({ userId }: { userId: string }) {
   const [tab, setTab] = useState<'write' | 'preview'>('write');
   const [values, setValues] = useState<CompetitionFormValues>(defaultValues);
   const [isLoading, setIsLoading] = useState(false);
+
+  const isDirty =
+    values.name.trim() !== '' ||
+    values.location.trim() !== '' ||
+    values.eventDate !== '' ||
+    values.applyDeadline !== '' ||
+    values.applyUrl !== '' ||
+    values.description.trim() !== '' ||
+    values.participants !== '' ||
+    values.imageFile !== null;
+
+  useBeforeUnload(isDirty);
 
   const handleSubmit = async () => {
     if (

--- a/src/hooks/useBeforeUnload.ts
+++ b/src/hooks/useBeforeUnload.ts
@@ -1,0 +1,19 @@
+import { useEffect, useRef } from 'react';
+
+export function useBeforeUnload(isDirty: boolean) {
+  const isDirtyRef = useRef(isDirty);
+
+  useEffect(() => {
+    isDirtyRef.current = isDirty;
+  }, [isDirty]);
+
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (!isDirtyRef.current) return;
+      e.preventDefault();
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, []);
+}


### PR DESCRIPTION
## 📌 개요

게시글 및 대회일정 작성/수정 페이지에서 새로고침 또는 탭 종료 시 작성 중인 내용이 사라지는 것을 방지하기 위해 브라우저 이탈 경고 팝업을 추가했습니다.

## 💻 작업 사항

**`useBeforeUnload` 커스텀 훅 추가** (`hooks/useBeforeUnload.ts`)
- `isDirty` 상태를 받아 변경사항이 있을 때만 `beforeunload` 이벤트 리스너를 등록
- 컴포넌트 언마운트 시 리스너 자동 제거

**커뮤니티 게시글 적용**
- `WriteClient` — 제목, 내용, 이미지 중 하나라도 입력된 경우 경고 활성화
- `EditClient` — 제목, 내용, 이미지가 초기값과 하나라도 달라진 경우 경고 활성화

**대회일정 적용**
- `CompetitionWriteClient` — 이름, 장소, 날짜, URL, 설명, 이미지 등 필드 중 하나라도 입력된 경우 경고 활성화
- `CompetitionEditClient` — 전체 필드를 초기 대회 데이터와 비교해 하나라도 달라진 경우 경고 활성화

> 브라우저 보안 정책상 경고 문구 커스터마이징은 불가하며, 팝업 노출 여부만 제어합니다. 제출 완료 후 페이지 이동 시에는 경고가 뜨지 않습니다.

## 💡 관련 Issue

Closes #156 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #156 )
- [x] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
