### PR TITLE
[fix] Supabase 세션 갱신 누락 및 쿠키 set 에러 수정

### DIFF
--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -13,9 +13,13 @@ export async function createSupabaseServerClient() {
           return cookieStore.getAll();
         },
         setAll(cookiesToSet) {
-          cookiesToSet.forEach(({ name, value, options }) =>
-            cookieStore.set(name, value, options),
-          );
+          try {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options),
+            );
+          } catch {
+            // proxy.ts에서 세션 갱신을 처리하므로 무시
+          }
         },
       },
     },

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,34 @@
+import { createServerClient } from '@supabase/ssr';
+import { NextResponse, type NextRequest } from 'next/server';
+
+export async function proxy(request: NextRequest) {
+  const supabaseResponse = NextResponse.next({ request });
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value, options }) =>
+            supabaseResponse.cookies.set(name, value, options),
+          );
+        },
+      },
+    },
+  );
+
+  // 세션 갱신 (getSession() 쓰면 안 됨!)
+  await supabase.auth.getUser();
+
+  return supabaseResponse;
+}
+
+export const config = {
+  matcher: [
+    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+  ],
+};


### PR DESCRIPTION
## 📌 개요
Supabase 세션 갱신 시 Server Component에서 쿠키 set을 시도해 발생하던 에러를 수정했습니다.

## 💻 작업 사항

**`src/proxy.ts` 추가**
- 모든 요청 전 Supabase 세션을 갱신하고 쿠키를 업데이트하는 proxy 추가
- Next.js 16 컨벤션에 맞게 `proxy.ts`로 작성

**`src/lib/supabase/server.ts` 수정**
- `setAll`에 try-catch 추가
- Server Component에서 호출될 경우 에러 없이 무시하도록 처리
- 실제 세션 갱신은 proxy.ts에서 담당

## 💡 관련 Issue

Closes #159 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #159 )
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 기능이 정상 동작하는지 확인했습니다.
