### PR TITLE
[fix & feat]: soft delete 적용

### DIFF
--- a/src/components/community/PostDetailClient.tsx
+++ b/src/components/community/PostDetailClient.tsx
@@ -90,9 +90,10 @@ export default function PostDetailClient({
     if (!confirm('게시글을 삭제하시겠습니까?')) return;
     try {
       await deletePost(id);
-      queryClient.invalidateQueries({ queryKey: ['posts'] });
+      await queryClient.invalidateQueries({ queryKey: ['posts'] }); // await 추가
       showSuccessToast('게시글이 삭제되었습니다.', '🗑️');
       router.push('/community');
+      router.refresh(); // 추가
     } catch {
       showErrorToast('게시글 삭제에 실패했습니다.');
     }

--- a/src/components/community/Postcard.tsx
+++ b/src/components/community/Postcard.tsx
@@ -47,7 +47,6 @@ export default function PostCard({ post, userId }: PostCardProps) {
     <Link
       href={`/community/${post.id}`}
       className="block w-full"
-      target="_blank"
       rel="noopener noreferrer"
       aria-label={`${post.title} 게시글 상세보기`}
     >

--- a/src/components/competition/CompetitionDetailClient.tsx
+++ b/src/components/competition/CompetitionDetailClient.tsx
@@ -9,6 +9,7 @@ import { handleShare } from '@/utils/share';
 import type { Competition } from '@/types/competition';
 import CompetitionDetailCard from '@/components/competition/CompetitionDetailCard';
 import Image from 'next/image';
+import { deleteCompetition } from '@/services/competitionService';
 
 interface CompetitionDetailClientProps {
   competition: Competition;
@@ -29,15 +30,15 @@ export default function CompetitionDetailClient({
   const handleDeletePost = async () => {
     if (!confirm('대회 게시글을 삭제하시겠습니까?')) return;
     try {
-      await supabase.from('competition').delete().eq('id', id);
+      await deleteCompetition(id);
       showSuccessToast('삭제되었습니다.', '🗑️');
       await queryClient.invalidateQueries({ queryKey: ['competition'] });
       router.push('/competitions');
+      router.refresh();
     } catch (e) {
       console.error(e);
     }
   };
-
   return (
     <main
       className="max-w-2xl mx-auto p-4 space-y-4"

--- a/src/lib/getCompetitions.ts
+++ b/src/lib/getCompetitions.ts
@@ -6,7 +6,8 @@ export async function getCompetitions(page = 0, pageSize = 10) {
 
   const { error, data } = await supabase
     .from('competition')
-    .select('*') // comments(count) 제거
+    .select('*')
+    .is('deleted_at', null) // soft delete 필터
     .order('event_data', { ascending: true })
     .range(from, to);
 
@@ -14,7 +15,6 @@ export async function getCompetitions(page = 0, pageSize = 10) {
 
   return data.map((competition) => ({
     ...competition,
-    comment_count: 0, // 일단 0으로
-    comments: undefined,
+    comment_count: 0,
   }));
 }

--- a/src/services/communityService.ts
+++ b/src/services/communityService.ts
@@ -19,6 +19,8 @@ export async function getPosts(page = 0, pageSize = 10) {
   const { data, error } = await supabase
     .from('posts')
     .select('*, comments(count), profiles(nickname, avatar_url)')
+    .is('deleted_at', null) // soft delete 필터
+    .eq('status', 'published') // 발행된 게시글만
     .order('created_at', { ascending: false })
     .range(from, to);
 
@@ -32,11 +34,13 @@ export async function getPosts(page = 0, pageSize = 10) {
     profiles: undefined,
   }));
 }
+
 export const getPost = cache(async (id: string) => {
   const { data, error } = await supabase
     .from('posts')
     .select('*, profiles(nickname, avatar_url, belt_level, role)')
     .eq('id', id)
+    .is('deleted_at', null) // soft delete 필터
     .single();
   if (error) throw error;
 
@@ -80,8 +84,12 @@ export async function updatePost(
   if (error) throw error;
 }
 
+// soft delete
 export async function deletePost(id: string) {
-  const { error } = await supabase.from('posts').delete().eq('id', id);
+  const { error } = await supabase
+    .from('posts')
+    .update({ deleted_at: new Date().toISOString() })
+    .eq('id', id);
   if (error) throw error;
 }
 
@@ -101,6 +109,7 @@ export async function getComments(postId: string) {
     .from('comments')
     .select('*, profiles(nickname, avatar_url, belt_level, role)')
     .eq('post_id', postId)
+    .is('deleted_at', null) // soft delete 필터
     .order('created_at', { ascending: true });
 
   if (error) throw error;
@@ -149,8 +158,12 @@ export async function updateComment(id: string, content: string) {
   if (error) throw error;
 }
 
+// soft delete
 export async function deleteComment(id: string) {
-  const { error } = await supabase.from('comments').delete().eq('id', id);
+  const { error } = await supabase
+    .from('comments')
+    .update({ deleted_at: new Date().toISOString() })
+    .eq('id', id);
   if (error) throw error;
 }
 

--- a/src/services/competitionService.ts
+++ b/src/services/competitionService.ts
@@ -10,6 +10,7 @@ export async function createCompetition({
   description,
   image_url,
   user_id,
+  participants,
 }: {
   name: string;
   location: string;
@@ -31,7 +32,8 @@ export async function createCompetition({
       apply_url,
       description,
       image_url,
-      user_id, // 추가
+      user_id,
+      participants,
     })
     .select()
     .single();
@@ -57,6 +59,7 @@ export async function getCompetition(id: string): Promise<Competition> {
     .from('competition')
     .select('*, profiles(nickname, avatar_url, role)')
     .eq('id', id)
+    .is('deleted_at', null) // soft delete 필터
     .single();
   if (error) throw error;
 
@@ -68,6 +71,7 @@ export async function getCompetition(id: string): Promise<Competition> {
     profiles: undefined,
   } as Competition;
 }
+
 export async function updateCompetition(
   id: string,
   fields: {
@@ -84,6 +88,15 @@ export async function updateCompetition(
   const { error } = await supabase
     .from('competition')
     .update(fields)
+    .eq('id', id);
+  if (error) throw error;
+}
+
+// soft delete
+export async function deleteCompetition(id: string) {
+  const { error } = await supabase
+    .from('competition')
+    .update({ deleted_at: new Date().toISOString() })
     .eq('id', id);
   if (error) throw error;
 }


### PR DESCRIPTION

## 📌 개요
- posts, comments, competition 테이블에 deleted_at 컬럼 추가
- deletePost, deleteComment, deleteCompetition soft delete로 변경
- getPosts, getPost, getComments, getCompetition 조회 시 deleted_at IS NULL 필터 추가
- handleDeletePost await invalidateQueries + router.refresh() 추가


## 💻 작업 사항
- posts, comments, competition 테이블에 deleted_at 컬럼 추가
- deletePost, deleteComment, deleteCompetition soft delete로 변경
- getPosts, getPost, getComments, getCompetition 조회 시 deleted_at IS NULL 필터 추가
- handleDeletePost await invalidateQueries + router.refresh() 추가
<img width="962" height="36" alt="스크린샷 2026-05-13 시간: 15 17 24" src="https://github.com/user-attachments/assets/feb2e83d-8964-443d-b47f-3ec330009158" />
<img width="1096" height="705" alt="스크린샷 2026-05-13 시간: 15 17 14" src="https://github.com/user-attachments/assets/4bc396e1-f2e5-4425-9780-19b41c50bf8b" />
<img width="964" height="40" alt="스크린샷 2026-05-13 시간: 15 17 07" src="https://github.com/user-attachments/assets/4524fd7d-18b8-4fab-99b2-67ca4a9130b2" />
<img width="1070" height="408" alt="스크린샷 2026-05-13 시간: 15 16 52" src="https://github.com/user-attachments/assets/ed97de40-cc1a-4615-8190-12dea107866c" />
<img width="518" height="188" alt="스크린샷 2026-05-13 시간: 15 19 43" src="https://github.com/user-attachments/assets/5295d0d5-98a0-4d5a-952d-8e43c94a279b" />

## 💡 관련 Issue

Closes #162 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #162 )
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
