### PR TITLE
[Feat] 관리자 페이지 meta data 추가

### DIFF
--- a/src/app/(admin)/admin/competitions/page.tsx
+++ b/src/app/(admin)/admin/competitions/page.tsx
@@ -1,7 +1,12 @@
+import type { Metadata } from 'next';
+
 import AdminCompetitionsClient from '@/components/admin/competitions/AdminCompetitionsClient';
 import type { CompetitionQueryRow } from '@/components/admin/competitions/types';
 import { mapCompetitionQueryRowsToAdminCompetitionRows } from '@/components/admin/competitions/utils';
+import { getAdminPageMetadata } from '@/constants/adminMeta';
 import { createServerSupabaseClient } from '@/lib/createServerSupabaseClient';
+
+export const metadata: Metadata = getAdminPageMetadata('competitions');
 
 async function getAdminCompetitions() {
   const supabase = await createServerSupabaseClient();

--- a/src/app/(admin)/admin/layout.tsx
+++ b/src/app/(admin)/admin/layout.tsx
@@ -1,9 +1,13 @@
+import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
 import AdminHeader from '@/components/admin/AdminHeader';
 import ScrollToTop from '@/components/common/ScrollToTop';
 import Sidebar from '@/components/layout/Sidebar';
+import { ADMIN_LAYOUT_METADATA } from '@/constants/adminMeta';
 import { createServerSupabaseClient } from '@/lib/createServerSupabaseClient';
+
+export const metadata: Metadata = ADMIN_LAYOUT_METADATA;
 
 async function requireAdminAccess() {
   const supabase = await createServerSupabaseClient();

--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -1,5 +1,10 @@
+import type { Metadata } from 'next';
+
 import AdminDashboardCards from '@/components/admin/dashboard/AdminDashboardCards';
+import { getAdminPageMetadata } from '@/constants/adminMeta';
 import { getAdminDashboardData } from '@/lib/getAdminDashboardData';
+
+export const metadata: Metadata = getAdminPageMetadata('dashboard');
 
 export default async function AdminDashboardPage() {
   const dashboardData = await getAdminDashboardData();

--- a/src/app/(admin)/admin/posts/page.tsx
+++ b/src/app/(admin)/admin/posts/page.tsx
@@ -1,7 +1,12 @@
+import type { Metadata } from 'next';
+
 import AdminPostTableClient from '@/components/admin/posts/AdminPostsTableClient';
 import type { PostQueryRow } from '@/components/admin/posts/types';
 import { mapPostQueryRowsToAdminPostRows } from '@/components/admin/posts/utils';
+import { getAdminPageMetadata } from '@/constants/adminMeta';
 import { createServerSupabaseClient } from '@/lib/createServerSupabaseClient';
+
+export const metadata: Metadata = getAdminPageMetadata('posts');
 
 async function getAdminPosts() {
   const supabase = await createServerSupabaseClient();

--- a/src/app/(admin)/admin/support/page.tsx
+++ b/src/app/(admin)/admin/support/page.tsx
@@ -1,3 +1,5 @@
+import type { Metadata } from 'next';
+
 import AdminSupportTableClient from '@/components/admin/support/AdminSupportTableClient';
 import type {
   SupportSection,
@@ -11,7 +13,10 @@ import {
   mapReportQueryRowsToAdminReportRows,
   sortSupportReportQueryRows,
 } from '@/components/admin/support/utils';
+import { getAdminPageMetadata } from '@/constants/adminMeta';
 import { createServerSupabaseClient } from '@/lib/createServerSupabaseClient';
+
+export const metadata: Metadata = getAdminPageMetadata('support');
 
 async function getAdminSupportData() {
   const supabase = await createServerSupabaseClient();

--- a/src/app/(admin)/admin/users/page.tsx
+++ b/src/app/(admin)/admin/users/page.tsx
@@ -1,10 +1,15 @@
+import type { Metadata } from 'next';
+
 import AdminUsersClient from '@/components/admin/users/AdminUsersClient';
 import type {
   DojangQueryRow,
   ProfileQueryRow,
 } from '@/components/admin/users/types';
 import { mapProfilesToAdminUserRows } from '@/components/admin/users/utils';
+import { getAdminPageMetadata } from '@/constants/adminMeta';
 import { createServerSupabaseClient } from '@/lib/createServerSupabaseClient';
+
+export const metadata: Metadata = getAdminPageMetadata('users');
 
 async function getAdminUsers() {
   const supabase = await createServerSupabaseClient();

--- a/src/constants/adminMeta.ts
+++ b/src/constants/adminMeta.ts
@@ -1,3 +1,5 @@
+import type { Metadata } from 'next';
+
 export type AdminPageKey =
   | 'dashboard'
   | 'posts'
@@ -8,12 +10,14 @@ export type AdminPageKey =
 interface AdminMeta {
   title: string;
   description: string;
+  metadataTitle?: string;
 }
 
 export const ADMIN_META: Record<AdminPageKey, AdminMeta> = {
   dashboard: {
     title: '대시보드',
     description: '관리자 현황을 한눈에 확인하세요',
+    metadataTitle: '대시 보드',
   },
   posts: {
     title: '게시글 관리',
@@ -26,9 +30,28 @@ export const ADMIN_META: Record<AdminPageKey, AdminMeta> = {
   support: {
     title: '고객지원',
     description: '도장 인증, 신고 내역, 문의 내역을 관리합니다',
+    metadataTitle: '고객 지원',
   },
   competitions: {
     title: '대회일정 관리',
     description: '대회일정을 관리합니다.',
   },
 };
+
+export const ADMIN_LAYOUT_METADATA: Metadata = {
+  title: 'Black Belt BJJ',
+  description: 'Black Belt BJJ 관리자 페이지입니다.',
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export function getAdminPageMetadata(page: AdminPageKey): Metadata {
+  const { title, description, metadataTitle } = ADMIN_META[page];
+
+  return {
+    title: `${metadataTitle ?? title} | Black Belt BJJ`,
+    description,
+  };
+}


### PR DESCRIPTION
<!--
  PR 작성 가이드
  - 리뷰어를 존중하는 표현을 사용해주세요.
  - 변경 의도와 주요 내용을 명확하게 작성해주세요.
 -->

## 📌 개요

- 관리자 페이지 meta data 추가

## 💻 작업 사항
관리자 관련 페이지에 모두 관리자 페이지 meta data를 추가했습니다!
- 관리자 페이지 공통 메타데이터 구조를 정리했습니다.
- 관리자 전용 layout에 `noindex`, `nofollow` 메타를 적용해 검색엔진 색인을 방지했습니다.
- 대시보드, 게시글 관리, 대회일정 관리, 유저 관리, 고객지원 페이지에 각각 메타데이터를 연결했습니다.
- 각 관리자 페이지의 브라우저 탭 제목이 `페이지명 | Black Belt BJJ` 형식으로 표시되도록 설정했습니다.
- 관리자 헤더 문구와 메타 제목을 분리할 수 있도록 `adminMeta` 상수 구조를 확장했습니다.

<img width="236" height="45" alt="스크린샷 2026-05-13 오후 5 58 10" src="https://github.com/user-attachments/assets/46ebd7d6-57b5-442d-9e46-844c1bbe752c" />


## 💡 관련 Issue

Closes #153

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #)
- [x] 불필요한 console.log를 제거했습니다.
- [x] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
