### PR TITLE
[Feat] 관리자 알림 모달 및 토스트 기능 추가

### DIFF
--- a/src/components/admin/competitions/AdminCompetitionPostAction.tsx
+++ b/src/components/admin/competitions/AdminCompetitionPostAction.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { RotateCcw, FileText } from 'lucide-react';
-import { useTransition } from 'react';
+import { useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 
 import { restoreAdminCompetition } from '@/actions/admin/competitions';
+import ConfirmModal from '@/components/common/ConfirmModal';
 import type { AdminCompetitionPublishStatus } from '@/components/admin/competitions/types';
 import { ROUTES } from '@/constants/routes';
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
@@ -25,6 +26,7 @@ export default function AdminCompetitionPostAction({
 }: AdminCompetitionPostActionProps) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
 
   if (publishStatus === '게시중') {
     return (
@@ -42,10 +44,6 @@ export default function AdminCompetitionPostAction({
   }
 
   const handleRestore = () => {
-    const confirmed = window.confirm(`${name} 대회 게시글을 복구하시겠습니까?`);
-
-    if (!confirmed) return;
-
     startTransition(async () => {
       const result = await restoreAdminCompetition(id);
 
@@ -60,15 +58,28 @@ export default function AdminCompetitionPostAction({
   };
 
   return (
-    <button
-      type="button"
-      onClick={handleRestore}
-      aria-label={`${name} 복구`}
-      title="복구"
-      className={actionButtonClass}
-      disabled={isPending}
-    >
-      <RotateCcw size={18} className="text-blue-500" />
-    </button>
+    <>
+      <button
+        type="button"
+        onClick={() => setIsConfirmOpen(true)}
+        aria-label={`${name} 복구`}
+        title="복구"
+        className={actionButtonClass}
+        disabled={isPending}
+      >
+        <RotateCcw size={18} className="text-blue-500" />
+      </button>
+
+      <ConfirmModal
+        isOpen={isConfirmOpen}
+        onClose={() => setIsConfirmOpen(false)}
+        onConfirm={handleRestore}
+        title="대회 게시글 복구 확인"
+        description={`${name} 대회 게시글을 복구하시겠습니까?`}
+        confirmLabel="복구"
+        confirmVariant="success"
+        disabled={isPending}
+      />
+    </>
   );
 }

--- a/src/components/admin/posts/AdminPostsActions.tsx
+++ b/src/components/admin/posts/AdminPostsActions.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useTransition } from 'react';
+import { useState, useTransition } from 'react';
 import { Eye, EyeOff, Trash2, RotateCcw, FileText } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 
@@ -9,6 +9,7 @@ import {
   restoreAdminPost,
   toggleAdminPostVisibility,
 } from '@/actions/admin/posts';
+import ConfirmModal from '@/components/common/ConfirmModal';
 import type { AdminPostStatus } from '@/components/admin/posts/types';
 import { ROUTES } from '@/constants/routes';
 import { showErrorToast, showSuccessToast } from '@/lib/toast';
@@ -20,6 +21,8 @@ interface AdminPostActionsProps {
   deleted_at: string | null;
 }
 
+type ConfirmAction = 'toggleHidden' | 'delete' | 'restore' | null;
+
 export default function AdminPostActions({
   id,
   title,
@@ -28,6 +31,7 @@ export default function AdminPostActions({
 }: AdminPostActionsProps) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
+  const [confirmAction, setConfirmAction] = useState<ConfirmAction>(null);
 
   const isDeleted = Boolean(deleted_at);
   const canViewDetail = status !== 'hidden';
@@ -40,15 +44,7 @@ export default function AdminPostActions({
     window.open(ROUTES.COMMUNITY_DETAIL(id), '_blank', 'noopener,noreferrer');
   };
 
-  const handleToggleHidden = () => {
-    const confirmed = window.confirm(
-      status === 'hidden'
-        ? `${title} 게시글 숨김을 해제하시겠습니까?`
-        : `${title} 게시글을 숨김 처리하시겠습니까?`,
-    );
-
-    if (!confirmed) return;
-
+  const executeToggleHidden = () => {
     startTransition(async () => {
       const result = await toggleAdminPostVisibility({
         postId: id,
@@ -65,11 +61,7 @@ export default function AdminPostActions({
     });
   };
 
-  const handleDelete = () => {
-    const confirmed = window.confirm(`${title} 게시글을 삭제하시겠습니까?`);
-
-    if (!confirmed) return;
-
+  const executeDelete = () => {
     startTransition(async () => {
       const result = await deleteAdminPost(id);
 
@@ -83,11 +75,7 @@ export default function AdminPostActions({
     });
   };
 
-  const handleRestore = () => {
-    const confirmed = window.confirm(`${title} 게시글을 복구하시겠습니까?`);
-
-    if (!confirmed) return;
-
+  const executeRestore = () => {
     startTransition(async () => {
       const result = await restoreAdminPost(id);
 
@@ -101,59 +89,104 @@ export default function AdminPostActions({
     });
   };
 
+  const confirmModalContent =
+    confirmAction === 'toggleHidden'
+      ? {
+          title: status === 'hidden' ? '숨김 해제 확인' : '숨김 처리 확인',
+          description:
+            status === 'hidden'
+              ? `${title} 게시글의 숨김을 해제하시겠습니까?`
+              : `${title} 게시글을 숨김 처리하시겠습니까?`,
+          confirmLabel: status === 'hidden' ? '숨김 해제' : '숨김 처리',
+          confirmVariant: 'default' as const,
+          onConfirm: executeToggleHidden,
+        }
+      : confirmAction === 'delete'
+        ? {
+            title: '게시글 삭제 확인',
+            description: `${title} 게시글을 삭제하시겠습니까?`,
+            confirmLabel: '삭제',
+            confirmVariant: 'danger' as const,
+            onConfirm: executeDelete,
+          }
+        : confirmAction === 'restore'
+          ? {
+              title: '게시글 복구 확인',
+              description: `${title} 게시글을 복구하시겠습니까?`,
+              confirmLabel: '복구',
+              confirmVariant: 'success' as const,
+              onConfirm: executeRestore,
+            }
+          : null;
+
   return (
-    <div className="flex justify-center gap-2">
-      {isDeleted ? (
-        <button
-          type="button"
-          aria-label={`${title} 복구`}
-          onClick={handleRestore}
-          title="복구"
-          className={actionButtonClass}
-          disabled={isPending}
-        >
-          <RotateCcw size={18} className="text-blue-500" />
-        </button>
-      ) : (
-        <>
-          {canViewDetail ? (
+    <>
+      <div className="flex justify-center gap-2">
+        {isDeleted ? (
+          <button
+            type="button"
+            aria-label={`${title} 복구`}
+            onClick={() => setConfirmAction('restore')}
+            title="복구"
+            className={actionButtonClass}
+            disabled={isPending}
+          >
+            <RotateCcw size={18} className="text-blue-500" />
+          </button>
+        ) : (
+          <>
+            {canViewDetail ? (
+              <button
+                type="button"
+                aria-label={`${title} 상세보기`}
+                onClick={handleView}
+                title="상세보기"
+                className={actionButtonClass}
+                disabled={isPending}
+              >
+                <FileText size={18} />
+              </button>
+            ) : (
+              <span className={actionPlaceholderClass}>-</span>
+            )}
+
             <button
               type="button"
-              aria-label={`${title} 상세보기`}
-              onClick={handleView}
-              title="상세보기"
+              aria-label={`${title} 숨김 토글`}
+              onClick={() => setConfirmAction('toggleHidden')}
+              title={status === 'hidden' ? '숨김 해제' : '숨김'}
               className={actionButtonClass}
               disabled={isPending}
             >
-              <FileText size={18} />
+              {status === 'hidden' ? <Eye size={18} /> : <EyeOff size={18} />}
             </button>
-          ) : (
-            <span className={actionPlaceholderClass}>-</span>
-          )}
 
-          <button
-            type="button"
-            aria-label={`${title} 숨김 토글`}
-            onClick={handleToggleHidden}
-            title={status === 'hidden' ? '숨김 해제' : '숨김'}
-            className={actionButtonClass}
-            disabled={isPending}
-          >
-            {status === 'hidden' ? <Eye size={18} /> : <EyeOff size={18} />}
-          </button>
+            <button
+              type="button"
+              aria-label={`${title} 삭제`}
+              onClick={() => setConfirmAction('delete')}
+              title="삭제"
+              className={actionButtonClass}
+              disabled={isPending}
+            >
+              <Trash2 size={18} className="text-red-500" />
+            </button>
+          </>
+        )}
+      </div>
 
-          <button
-            type="button"
-            aria-label={`${title} 삭제`}
-            onClick={handleDelete}
-            title="삭제"
-            className={actionButtonClass}
-            disabled={isPending}
-          >
-            <Trash2 size={18} className="text-red-500" />
-          </button>
-        </>
-      )}
-    </div>
+      {confirmModalContent ? (
+        <ConfirmModal
+          isOpen={Boolean(confirmModalContent)}
+          onClose={() => setConfirmAction(null)}
+          onConfirm={confirmModalContent.onConfirm}
+          title={confirmModalContent.title}
+          description={confirmModalContent.description}
+          confirmLabel={confirmModalContent.confirmLabel}
+          confirmVariant={confirmModalContent.confirmVariant}
+          disabled={isPending}
+        />
+      ) : null}
+    </>
   );
 }

--- a/src/components/admin/support/AdminSupportDojangActions.tsx
+++ b/src/components/admin/support/AdminSupportDojangActions.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { ExternalLink, FileText } from 'lucide-react';
-import { useState } from 'react';
+import { useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 
 import AdminBadge from '@/components/admin/AdminBadge';
+import ConfirmModal from '@/components/common/ConfirmModal';
 import { DOJANG_STATUS_BADGE_VARIANT_MAP } from '@/components/admin/support/constants';
 import type { AdminDojangVerificationRow } from '@/components/admin/support/types';
 import { formatOptionalText } from '@/components/admin/support/utils';
@@ -17,6 +18,7 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog';
 import { supabase } from '@/lib/supabase';
+import { showErrorToast, showSuccessToast } from '@/lib/toast';
 
 interface AdminSupportDojangActionsProps {
   row: AdminDojangVerificationRow;
@@ -26,6 +28,19 @@ interface DetailItemProps {
   label: string;
   value: React.ReactNode;
 }
+
+type ConfirmDojangAction =
+  | {
+      nextStatus: 'pending' | 'approved' | 'rejected';
+      title: string;
+      description: string;
+      confirmLabel: string;
+      confirmVariant: 'default' | 'danger' | 'success' | 'warning';
+      failureMessage: string;
+      successMessage: string;
+      successIcon: string;
+    }
+  | null;
 
 const actionButtonClass =
   'inline-flex items-center justify-center rounded-md p-2 text-zinc-500 transition-colors duration-200 hover:bg-gray-100 cursor-pointer';
@@ -44,30 +59,30 @@ export default function AdminSupportDojangActions({
 }: AdminSupportDojangActionsProps) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  const [confirmAction, setConfirmAction] = useState<ConfirmDojangAction>(null);
 
   const updateDojangStatus = async (
     nextStatus: 'pending' | 'approved' | 'rejected',
-    confirmationMessage: string,
     failureMessage: string,
+    successMessage: string,
+    successIcon: string,
   ) => {
-    const confirmed = window.confirm(confirmationMessage);
+    startTransition(async () => {
+      const { error } = await supabase
+        .from('dojang')
+        .update({ dojang_status: nextStatus })
+        .eq('id', row.id);
 
-    if (!confirmed) {
-      return;
-    }
+      if (error) {
+        showErrorToast(failureMessage);
+        return;
+      }
 
-    const { error } = await supabase
-      .from('dojang')
-      .update({ dojang_status: nextStatus })
-      .eq('id', row.id);
-
-    if (error) {
-      alert(failureMessage);
-      return;
-    }
-
-    setOpen(false);
-    router.refresh();
+      showSuccessToast(successMessage, successIcon);
+      setOpen(false);
+      router.refresh();
+    });
   };
 
   return (
@@ -79,6 +94,7 @@ export default function AdminSupportDojangActions({
             aria-label={`${row.dojang_name} 상세보기`}
             title="상세보기"
             className={actionButtonClass}
+            disabled={isPending}
           >
             <FileText size={18} />
           </button>
@@ -137,12 +153,18 @@ export default function AdminSupportDojangActions({
               <button
                 type="button"
                 onClick={() =>
-                  updateDojangStatus(
-                    'approved',
-                    `${row.dojang_name} 인증 요청을 승인하시겠습니까?`,
-                    '도장 승인에 실패했습니다.',
-                  )
+                  setConfirmAction({
+                    nextStatus: 'approved',
+                    title: '도장 승인 확인',
+                    description: `${row.dojang_name} 인증 요청을 승인하시겠습니까?`,
+                    confirmLabel: '승인',
+                    confirmVariant: 'success',
+                    failureMessage: '도장 승인에 실패했습니다.',
+                    successMessage: '도장 인증 요청을 승인했습니다.',
+                    successIcon: '✅',
+                  })
                 }
+                disabled={isPending}
                 className={`${actionButtonClass} h-9 border-green-200 bg-green-50 px-3 text-green-700 hover:bg-green-100`}
               >
                 승인
@@ -150,12 +172,18 @@ export default function AdminSupportDojangActions({
               <button
                 type="button"
                 onClick={() =>
-                  updateDojangStatus(
-                    'rejected',
-                    `${row.dojang_name} 인증 요청을 거부하시겠습니까?`,
-                    '도장 거부 처리에 실패했습니다.',
-                  )
+                  setConfirmAction({
+                    nextStatus: 'rejected',
+                    title: '도장 거부 확인',
+                    description: `${row.dojang_name} 인증 요청을 거부하시겠습니까?`,
+                    confirmLabel: '거부',
+                    confirmVariant: 'danger',
+                    failureMessage: '도장 거부 처리에 실패했습니다.',
+                    successMessage: '도장 인증 요청을 거부했습니다.',
+                    successIcon: '🚫',
+                  })
                 }
+                disabled={isPending}
                 className={`${actionButtonClass} h-9 border-red-200 bg-red-50 px-3 text-red-600 hover:bg-red-100`}
               >
                 거부
@@ -168,12 +196,18 @@ export default function AdminSupportDojangActions({
               <button
                 type="button"
                 onClick={() =>
-                  updateDojangStatus(
-                    'pending',
-                    `${row.dojang_name} 인증 상태를 검토중으로 변경하시겠습니까?`,
-                    '승인 취소에 실패했습니다.',
-                  )
+                  setConfirmAction({
+                    nextStatus: 'pending',
+                    title: '승인 취소 확인',
+                    description: `${row.dojang_name} 인증 상태를 검토중으로 변경하시겠습니까?`,
+                    confirmLabel: '승인 취소',
+                    confirmVariant: 'warning',
+                    failureMessage: '승인 취소에 실패했습니다.',
+                    successMessage: '도장 인증 상태를 검토중으로 변경했습니다.',
+                    successIcon: '↩️',
+                  })
                 }
+                disabled={isPending}
                 className={`${actionButtonClass} h-9 border-amber-200 bg-amber-50 px-3 text-amber-700 hover:bg-amber-100`}
               >
                 승인 취소
@@ -181,12 +215,18 @@ export default function AdminSupportDojangActions({
               <button
                 type="button"
                 onClick={() =>
-                  updateDojangStatus(
-                    'rejected',
-                    `${row.dojang_name} 인증 상태를 거부로 변경하시겠습니까?`,
-                    '도장 거부 처리에 실패했습니다.',
-                  )
+                  setConfirmAction({
+                    nextStatus: 'rejected',
+                    title: '도장 거부 확인',
+                    description: `${row.dojang_name} 인증 상태를 거부로 변경하시겠습니까?`,
+                    confirmLabel: '거부',
+                    confirmVariant: 'danger',
+                    failureMessage: '도장 거부 처리에 실패했습니다.',
+                    successMessage: '도장 인증 상태를 거부로 변경했습니다.',
+                    successIcon: '🚫',
+                  })
                 }
+                disabled={isPending}
                 className={`${actionButtonClass} h-9 border-red-200 bg-red-50 px-3 text-red-600 hover:bg-red-100`}
               >
                 거부
@@ -199,12 +239,18 @@ export default function AdminSupportDojangActions({
               <button
                 type="button"
                 onClick={() =>
-                  updateDojangStatus(
-                    'pending',
-                    `${row.dojang_name} 인증 상태를 다시 검토중으로 변경하시겠습니까?`,
-                    '재검토 처리에 실패했습니다.',
-                  )
+                  setConfirmAction({
+                    nextStatus: 'pending',
+                    title: '재검토 확인',
+                    description: `${row.dojang_name} 인증 상태를 다시 검토중으로 변경하시겠습니까?`,
+                    confirmLabel: '재검토',
+                    confirmVariant: 'default',
+                    failureMessage: '재검토 처리에 실패했습니다.',
+                    successMessage: '도장 인증 상태를 재검토로 변경했습니다.',
+                    successIcon: '🔄',
+                  })
                 }
+                disabled={isPending}
                 className={`${actionButtonClass} h-9 border-blue-200 bg-blue-50 px-3 text-blue-700 hover:bg-blue-100`}
               >
                 재검토
@@ -212,12 +258,18 @@ export default function AdminSupportDojangActions({
               <button
                 type="button"
                 onClick={() =>
-                  updateDojangStatus(
-                    'approved',
-                    `${row.dojang_name} 인증 요청을 승인하시겠습니까?`,
-                    '도장 승인에 실패했습니다.',
-                  )
+                  setConfirmAction({
+                    nextStatus: 'approved',
+                    title: '도장 승인 확인',
+                    description: `${row.dojang_name} 인증 요청을 승인하시겠습니까?`,
+                    confirmLabel: '승인',
+                    confirmVariant: 'success',
+                    failureMessage: '도장 승인에 실패했습니다.',
+                    successMessage: '도장 인증 요청을 승인했습니다.',
+                    successIcon: '✅',
+                  })
                 }
+                disabled={isPending}
                 className={`${actionButtonClass} h-9 border-green-200 bg-green-50 px-3 text-green-700 hover:bg-green-100`}
               >
                 승인
@@ -226,6 +278,26 @@ export default function AdminSupportDojangActions({
           ) : null}
         </DialogContent>
       </Dialog>
+
+      {confirmAction ? (
+        <ConfirmModal
+          isOpen={Boolean(confirmAction)}
+          onClose={() => setConfirmAction(null)}
+          onConfirm={() =>
+            updateDojangStatus(
+              confirmAction.nextStatus,
+              confirmAction.failureMessage,
+              confirmAction.successMessage,
+              confirmAction.successIcon,
+            )
+          }
+          title={confirmAction.title}
+          description={confirmAction.description}
+          confirmLabel={confirmAction.confirmLabel}
+          confirmVariant={confirmAction.confirmVariant}
+          disabled={isPending}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/components/admin/support/AdminSupportReportActions.tsx
+++ b/src/components/admin/support/AdminSupportReportActions.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { FileText, ShieldAlert } from 'lucide-react';
-import { useState } from 'react';
+import { useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 
 import AdminBadge from '@/components/admin/AdminBadge';
+import ConfirmModal from '@/components/common/ConfirmModal';
 import {
   REPORT_ACTION_BADGE_VARIANT_MAP,
   REPORT_STATUS_BADGE_VARIANT_MAP,
@@ -20,6 +21,7 @@ import {
 } from '@/components/ui/dialog';
 import { ROUTES } from '@/constants/routes';
 import { supabase } from '@/lib/supabase';
+import { showErrorToast, showSuccessToast } from '@/lib/toast';
 
 interface AdminSupportReportActionsProps {
   row: AdminReportRow;
@@ -29,6 +31,16 @@ interface DetailItemProps {
   label: string;
   value: React.ReactNode;
 }
+
+type ConfirmReportAction =
+  | {
+      actionType: 'hide_post' | 'delete_post' | 'none';
+      title: string;
+      description: string;
+      confirmLabel: string;
+      confirmVariant: 'default' | 'danger' | 'success' | 'warning';
+    }
+  | null;
 
 const actionButtonClass =
   'inline-flex items-center justify-center rounded-md p-2 text-zinc-500 transition-colors duration-200 hover:bg-gray-100 cursor-pointer';
@@ -49,14 +61,17 @@ export default function AdminSupportReportActions({
 }: AdminSupportReportActionsProps) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
+  const [isSubmitting, startTransition] = useTransition();
+  const [confirmAction, setConfirmAction] = useState<ConfirmReportAction>(null);
 
-  const isPending = row.raw_status === 'pending' || row.raw_status === null;
+  const isProcessPending =
+    row.raw_status === 'pending' || row.raw_status === null;
   const canViewDetail =
     Boolean(row.post_id) && row.post_status_label === '게시중';
 
   const handleViewDetail = () => {
     if (!canViewDetail || !row.post_id) {
-      alert('연결된 게시글 정보를 찾을 수 없습니다.');
+      showErrorToast('연결된 게시글 정보를 찾을 수 없습니다.');
       return;
     }
 
@@ -71,78 +86,83 @@ export default function AdminSupportReportActions({
     actionType: 'hide_post' | 'delete_post' | 'none',
   ) => {
     if ((actionType === 'hide_post' || actionType === 'delete_post') && !row.post_id) {
-      alert('연결된 게시글 정보를 찾을 수 없습니다.');
+      showErrorToast('연결된 게시글 정보를 찾을 수 없습니다.');
       return;
     }
 
-    const confirmationMessage =
-      actionType === 'hide_post'
-        ? `${row.post_title} 게시글을 숨김 처리하시겠습니까?`
-        : actionType === 'delete_post'
-          ? `${row.post_title} 게시글을 삭제 처리하시겠습니까?`
-          : `${row.post_title} 신고를 문제없음으로 처리하시겠습니까?`;
+    startTransition(async () => {
+      if (actionType === 'hide_post' && row.post_id) {
+        const { error } = await supabase
+          .from('posts')
+          .update({ status: 'hidden' })
+          .eq('id', row.post_id);
 
-    const confirmed = window.confirm(confirmationMessage);
+        if (error) {
+          showErrorToast('게시글 숨김 처리에 실패했습니다.');
+          return;
+        }
+      }
 
-    if (!confirmed) {
-      return;
-    }
+      if (actionType === 'delete_post' && row.post_id) {
+        const { error } = await supabase
+          .from('posts')
+          .update({ deleted_at: new Date().toISOString() })
+          .eq('id', row.post_id);
 
-    if (actionType === 'hide_post' && row.post_id) {
+        if (error) {
+          showErrorToast('게시글 삭제 처리에 실패했습니다.');
+          return;
+        }
+      }
+
+      const nextReportStatus = actionType === 'none' ? 'ignored' : 'resolved';
       const { error } = await supabase
-        .from('posts')
-        .update({ status: 'hidden' })
-        .eq('id', row.post_id);
+        .from('reports')
+        .update({
+          reports_status: nextReportStatus,
+          action_type: actionType,
+          handled_at: new Date().toISOString(),
+        })
+        .eq('id', row.id);
 
       if (error) {
-        alert('게시글 숨김 처리에 실패했습니다.');
+        showErrorToast('신고 처리 상태 저장에 실패했습니다.');
         return;
       }
-    }
 
-    if (actionType === 'delete_post' && row.post_id) {
-      const { error } = await supabase
-        .from('posts')
-        .update({ deleted_at: new Date().toISOString() })
-        .eq('id', row.post_id);
+      const successMessage =
+        actionType === 'hide_post'
+          ? '신고 내역을 게시글 숨김으로 처리했습니다.'
+          : actionType === 'delete_post'
+            ? '신고 내역을 게시글 삭제로 처리했습니다.'
+            : '신고 내역을 문제없음으로 처리했습니다.';
 
-      if (error) {
-        alert('게시글 삭제 처리에 실패했습니다.');
-        return;
-      }
-    }
+      const successIcon =
+        actionType === 'hide_post'
+          ? '🙈'
+          : actionType === 'delete_post'
+            ? '🗑️'
+            : '✅';
 
-    const nextReportStatus = actionType === 'none' ? 'ignored' : 'resolved';
-    const { error } = await supabase
-      .from('reports')
-      .update({
-        reports_status: nextReportStatus,
-        action_type: actionType,
-        handled_at: new Date().toISOString(),
-      })
-      .eq('id', row.id);
-
-    if (error) {
-      alert('신고 처리 상태 저장에 실패했습니다.');
-      return;
-    }
-
-    setOpen(false);
-    router.refresh();
+      showSuccessToast(successMessage, successIcon);
+      setOpen(false);
+      router.refresh();
+    });
   };
 
   return (
     <div className="flex items-center justify-center gap-2">
       {canViewDetail ? (
-        <button
-          type="button"
-          onClick={handleViewDetail}
-          aria-label={`${row.post_title} 상세보기`}
-          title="상세보기"
-          className={actionButtonClass}
-        >
-          <FileText size={18} />
-        </button>
+          <button
+            type="button"
+            onClick={handleViewDetail}
+            aria-label={`${row.post_title} 상세보기`}
+            title="상세보기"
+            className={actionButtonClass}
+            disabled={isSubmitting}
+          >
+            <FileText size={18} />
+          </button>
       ) : (
         <span className={actionPlaceholderClass}>-</span>
       )}
@@ -151,13 +171,14 @@ export default function AdminSupportReportActions({
         <DialogTrigger asChild>
           <button
             type="button"
-            aria-label={`${row.post_title} ${isPending ? '처리하기' : '처리내역'}`}
-            title={isPending ? '처리하기' : '처리내역'}
+            aria-label={`${row.post_title} ${isProcessPending ? '처리하기' : '처리내역'}`}
+            title={isProcessPending ? '처리하기' : '처리내역'}
             className={actionButtonClass}
+            disabled={isSubmitting}
           >
             <ShieldAlert
               size={18}
-              className={isPending ? 'text-red-500' : 'text-blue-500'}
+              className={isProcessPending ? 'text-red-500' : 'text-blue-500'}
             />
           </button>
         </DialogTrigger>
@@ -204,25 +225,52 @@ export default function AdminSupportReportActions({
             </dl>
           </section>
 
-          {isPending ? (
+          {isProcessPending ? (
             <div className="flex flex-wrap justify-end gap-2 border-t pt-4">
               <button
                 type="button"
-                onClick={() => handleProcessReport('none')}
+                onClick={() =>
+                  setConfirmAction({
+                    actionType: 'none',
+                    title: '문제없음 처리 확인',
+                    description: `${row.post_title} 신고를 문제없음으로 처리하시겠습니까?`,
+                    confirmLabel: '문제 없음 처리',
+                    confirmVariant: 'default',
+                  })
+                }
+                disabled={isSubmitting}
                 className={`${actionButtonClass} h-9 border-zinc-200 bg-zinc-50 px-3 text-zinc-700 hover:bg-zinc-100`}
               >
                 문제 없음 처리
               </button>
               <button
                 type="button"
-                onClick={() => handleProcessReport('hide_post')}
+                onClick={() =>
+                  setConfirmAction({
+                    actionType: 'hide_post',
+                    title: '게시글 숨김 처리 확인',
+                    description: `${row.post_title} 게시글을 숨김 처리하시겠습니까?`,
+                    confirmLabel: '게시글 숨김',
+                    confirmVariant: 'warning',
+                  })
+                }
+                disabled={isSubmitting}
                 className={`${actionButtonClass} h-9 border-blue-200 bg-blue-50 px-3 text-blue-700 hover:bg-blue-100`}
               >
                 게시글 숨김 처리
               </button>
               <button
                 type="button"
-                onClick={() => handleProcessReport('delete_post')}
+                onClick={() =>
+                  setConfirmAction({
+                    actionType: 'delete_post',
+                    title: '게시글 삭제 처리 확인',
+                    description: `${row.post_title} 게시글을 삭제 처리하시겠습니까?`,
+                    confirmLabel: '게시글 삭제',
+                    confirmVariant: 'danger',
+                  })
+                }
+                disabled={isSubmitting}
                 className={`${actionButtonClass} h-9 border-red-200 bg-red-50 px-3 text-red-600 hover:bg-red-100`}
               >
                 게시글 삭제 처리
@@ -231,6 +279,19 @@ export default function AdminSupportReportActions({
           ) : null}
         </DialogContent>
       </Dialog>
+
+      {confirmAction ? (
+        <ConfirmModal
+          isOpen={Boolean(confirmAction)}
+          onClose={() => setConfirmAction(null)}
+          onConfirm={() => handleProcessReport(confirmAction.actionType)}
+          title={confirmAction.title}
+          description={confirmAction.description}
+          confirmLabel={confirmAction.confirmLabel}
+          confirmVariant={confirmAction.confirmVariant}
+          disabled={isSubmitting}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/components/admin/users/AdminUserActions.tsx
+++ b/src/components/admin/users/AdminUserActions.tsx
@@ -2,8 +2,10 @@
 
 import { ExternalLink, FileText, Power, PowerOff } from 'lucide-react';
 import { useRouter } from 'next/navigation';
+import { useState, useTransition } from 'react';
 
 import AdminBadge from '@/components/admin/AdminBadge';
+import ConfirmModal from '@/components/common/ConfirmModal';
 import {
   ACCOUNT_STATUS_BADGE_VARIANT_MAP,
   DOJANG_APPROVAL_BADGE_VARIANT_MAP,
@@ -23,6 +25,7 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog';
 import { supabase } from '@/lib/supabase';
+import { showErrorToast, showSuccessToast } from '@/lib/toast';
 
 interface AdminUserActionsProps {
   user: AdminUserRow;
@@ -34,7 +37,7 @@ interface DetailItemProps {
 }
 
 const actionButtonClass =
-  'rounded-md p-2 text-zinc-500 transition-colors duration-200 hover:bg-gray-100 cursor-pointer';
+  'inline-flex items-center justify-center rounded-md p-2 text-zinc-500 transition-colors duration-200 hover:bg-gray-100 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50';
 
 function DetailItem({ label, value }: DetailItemProps) {
   return (
@@ -77,30 +80,32 @@ function UserAvatar({
 
 export default function AdminUserActions({ user }: AdminUserActionsProps) {
   const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
 
   const isActive = user.account_status === '활성';
   const nextAccountLabel = isActive ? '비활성' : '활성';
 
-  const handleToggleAccountStatus = async () => {
-    const confirmed = window.confirm(
-      `${user.nickname} 계정을 ${nextAccountLabel} 상태로 변경하시겠습니까?`,
-    );
+  const handleToggleAccountStatus = () => {
+    startTransition(async () => {
+      const { error } = await supabase
+        .from('profiles')
+        .update({
+          account_status: getNextAccountStatus(user.raw_account_status),
+        })
+        .eq('id', user.id);
 
-    if (!confirmed) {
-      return;
-    }
+      if (error) {
+        showErrorToast('계정 상태 변경에 실패했습니다.');
+        return;
+      }
 
-    const { error } = await supabase
-      .from('profiles')
-      .update({ account_status: getNextAccountStatus(user.raw_account_status) })
-      .eq('id', user.id);
-
-    if (error) {
-      alert('계정 상태 변경에 실패했습니다.');
-      return;
-    }
-
-    router.refresh();
+      showSuccessToast(
+        `${user.nickname} 계정을 ${nextAccountLabel} 상태로 변경했습니다.`,
+        isActive ? '🔒' : '🔓',
+      );
+      router.refresh();
+    });
   };
 
   return (
@@ -112,6 +117,7 @@ export default function AdminUserActions({ user }: AdminUserActionsProps) {
             aria-label={`${user.nickname} 상세 정보 보기`}
             title="상세보기"
             className={actionButtonClass}
+            disabled={isPending}
           >
             <FileText size={18} />
           </button>
@@ -240,10 +246,11 @@ export default function AdminUserActions({ user }: AdminUserActionsProps) {
 
       <button
         type="button"
-        onClick={handleToggleAccountStatus}
+        onClick={() => setIsConfirmOpen(true)}
         aria-label={`${user.nickname} 계정 ${isActive ? '비활성화' : '활성화'}`}
         title={isActive ? '비활성화' : '활성화'}
         className={actionButtonClass}
+        disabled={isPending}
       >
         {isActive ? (
           <PowerOff size={18} className="text-red-500" />
@@ -251,6 +258,17 @@ export default function AdminUserActions({ user }: AdminUserActionsProps) {
           <Power size={18} className="text-green-600" />
         )}
       </button>
+
+      <ConfirmModal
+        isOpen={isConfirmOpen}
+        onClose={() => setIsConfirmOpen(false)}
+        onConfirm={handleToggleAccountStatus}
+        title="계정 상태 변경 확인"
+        description={`${user.nickname} 계정을 ${nextAccountLabel} 상태로 변경하시겠습니까?`}
+        confirmLabel={nextAccountLabel}
+        confirmVariant={isActive ? 'warning' : 'success'}
+        disabled={isPending}
+      />
     </div>
   );
 }

--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -16,7 +16,20 @@ interface ConfirmModalProps {
   title: string;
   description: string;
   confirmLabel?: string;
+  cancelLabel?: string;
+  disabled?: boolean;
+  confirmVariant?: 'default' | 'danger' | 'success' | 'warning';
 }
+
+const confirmButtonVariantClassMap: Record<
+  NonNullable<ConfirmModalProps['confirmVariant']>,
+  string
+> = {
+  default: 'bg-black text-white hover:bg-gray-700',
+  danger: 'bg-red-600 text-white hover:bg-red-700',
+  success: 'bg-green-600 text-white hover:bg-green-700',
+  warning: 'bg-amber-500 text-white hover:bg-amber-600',
+};
 
 export default function ConfirmModal({
   isOpen,
@@ -25,6 +38,9 @@ export default function ConfirmModal({
   title,
   description,
   confirmLabel = '삭제',
+  cancelLabel = '취소',
+  disabled = false,
+  confirmVariant = 'default',
 }: ConfirmModalProps) {
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
@@ -35,17 +51,21 @@ export default function ConfirmModal({
         </DialogHeader>
         <DialogFooter>
           <button
+            type="button"
             onClick={onClose}
-            className="flex-1 py-2 rounded-lg text-sm font-medium bg-gray-100 text-gray-600 cursor-pointer hover:bg-gray-200 transition-colors"
+            disabled={disabled}
+            className="flex-1 rounded-lg bg-gray-100 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-50"
           >
-            취소
+            {cancelLabel}
           </button>
           <button
+            type="button"
             onClick={() => {
               onConfirm();
               onClose();
             }}
-            className="flex-1 py-2 rounded-lg text-sm font-medium bg-black text-white cursor-pointer hover:bg-gray-700 transition-colors"
+            disabled={disabled}
+            className={`flex-1 rounded-lg py-2 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${confirmButtonVariantClassMap[confirmVariant]}`}
           >
             {confirmLabel}
           </button>


### PR DESCRIPTION
<!--
  PR 작성 가이드
  - 리뷰어를 존중하는 표현을 사용해주세요.
  - 변경 의도와 주요 내용을 명확하게 작성해주세요.
 -->

## 📌 개요

- 관리자 알림 모달 및 토스트 기능 추가

## 💻 작업 사항
- 관리자 페이지 액션 확인창을 공통 `ConfirmModal` 컴포넌트로 통일했습니다.
<br />

- 게시글 관리의 숨김, 삭제, 복구 액션에 공통 확인 모달을 적용했습니다.
- 대회일정 관리의 복구 액션에 공통 확인 모달을 적용했습니다.
- 유저 관리의 활성화/비활성화 액션에 공통 확인 모달을 적용했습니다.
- 고객지원의 도장 인증 및 신고 내역 처리 액션도 공통 확인 모달 기반으로 정리했습니다.
<br />
 
- 관리자 액션 처리 결과를 `toast.ts`의 성공/실패 토스트로 안내하도록 개선했습니다.
- 중복 클릭 방지를 위해 액션 처리 중 버튼 비활성화 흐름을 함께 적용했습니다.

https://github.com/user-attachments/assets/add86714-a241-4a91-a1a2-c4e7a887630a




## 💡 관련 Issue

Closes #172

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #)
- [x] 불필요한 console.log를 제거했습니다.
- [x] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
