### PR TITLE
[Feat] 관리자 페이지 URL 쿼리 상태 관리 적용

### DIFF
--- a/src/app/(admin)/admin/support/page.tsx
+++ b/src/app/(admin)/admin/support/page.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from 'next';
 
 import AdminSupportTableClient from '@/components/admin/support/AdminSupportTableClient';
 import type {
-  SupportSection,
   SupportDojangQueryRow,
   SupportPostQueryRow,
   SupportProfileQueryRow,
@@ -135,28 +134,13 @@ async function getAdminSupportData() {
   };
 }
 
-function getInitialSupportSection(
-  sectionParam: string | string[] | undefined,
-): SupportSection {
-  const section = Array.isArray(sectionParam) ? sectionParam[0] : sectionParam;
-
-  return section === 'reports' ? 'reports' : 'dojang';
-}
-
-export default async function AdminSupportPage({
-  searchParams,
-}: {
-  searchParams: Promise<{ section?: string | string[] | undefined }>;
-}) {
-  const resolvedSearchParams = await searchParams;
+export default async function AdminSupportPage() {
   const data = await getAdminSupportData();
-  const initialSection = getInitialSupportSection(resolvedSearchParams.section);
 
   return (
     <AdminSupportTableClient
       dojangVerifications={data.dojangVerifications}
       reports={data.reports}
-      initialSection={initialSection}
     />
   );
 }

--- a/src/components/admin/AdminDataTable.tsx
+++ b/src/components/admin/AdminDataTable.tsx
@@ -20,6 +20,9 @@ interface AdminDataTableProps<T> {
   emptyMessage?: string;
   initialPageSize?: number;
   pageSizeOptions?: readonly number[];
+  currentPage?: number;
+  // eslint-disable-next-line no-unused-vars
+  onPageChange?: (_page: number) => void;
   // eslint-disable-next-line no-unused-vars
   getRowKey?: (_row: T, _index: number) => React.Key;
 }
@@ -30,11 +33,13 @@ export default function AdminDataTable<T>({
   emptyMessage = '데이터가 없습니다.',
   initialPageSize,
   pageSizeOptions,
+  currentPage,
+  onPageChange,
   getRowKey,
 }: AdminDataTableProps<T>) {
   const {
     pageSize,
-    currentPage,
+    currentPage: safeCurrentPage,
     totalPages,
     paginatedData,
     pageSizeOptions: normalizedPageSizeOptions,
@@ -44,6 +49,8 @@ export default function AdminDataTable<T>({
     data,
     initialPageSize,
     pageSizeOptions,
+    currentPage,
+    onPageChange,
   });
 
   return (
@@ -79,7 +86,7 @@ export default function AdminDataTable<T>({
             </tr>
           ) : (
             paginatedData.map((row, rowIndex) => {
-              const originalIndex = (currentPage - 1) * pageSize + rowIndex;
+              const originalIndex = (safeCurrentPage - 1) * pageSize + rowIndex;
 
               return (
                 <tr
@@ -118,7 +125,7 @@ export default function AdminDataTable<T>({
       </table>
 
       <AdminTablePagination
-        currentPage={currentPage}
+        currentPage={safeCurrentPage}
         totalPages={totalPages}
         totalItems={data.length}
         pageSize={pageSize}

--- a/src/components/admin/AdminTableToolbar.tsx
+++ b/src/components/admin/AdminTableToolbar.tsx
@@ -14,6 +14,7 @@ interface AdminTableToolbarProps<TFilter extends string> {
   searchQuery: string;
   // eslint-disable-next-line no-unused-vars
   onSearchQueryChange: (_value: string) => void;
+  onSearch?: () => void;
   searchPlaceholder?: string;
 }
 
@@ -23,6 +24,7 @@ export default function AdminTableToolbar<TFilter extends string>({
   onFilterChange,
   searchQuery,
   onSearchQueryChange,
+  onSearch,
   searchPlaceholder,
 }: AdminTableToolbarProps<TFilter>) {
   return (
@@ -56,6 +58,7 @@ export default function AdminTableToolbar<TFilter extends string>({
         <SearchInput
           searchQuery={searchQuery}
           setSearchQuery={onSearchQueryChange}
+          onSearch={onSearch}
           placeholder={searchPlaceholder}
         />
       </div>

--- a/src/components/admin/competitions/AdminCompetitionsClient.tsx
+++ b/src/components/admin/competitions/AdminCompetitionsClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 import AdminBadge from '@/components/admin/AdminBadge';
 import AdminDataTable, {
@@ -17,6 +17,7 @@ import type {
   AdminCompetitionFilterValue,
   AdminCompetitionRow,
 } from '@/components/admin/competitions/types';
+import { useAdminTableQueryState } from '@/hooks/useAdminTableQueryState';
 import { filterAdminCompetitions } from '@/components/admin/competitions/utils';
 
 interface AdminCompetitionsClientProps {
@@ -81,9 +82,19 @@ const COMPETITION_COLUMNS: AdminTableColumn<AdminCompetitionRow>[] = [
 export default function AdminCompetitionsClient({
   data,
 }: AdminCompetitionsClientProps) {
-  const [activeFilter, setActiveFilter] =
-    useState<AdminCompetitionFilterValue>('all');
-  const [searchQuery, setSearchQuery] = useState('');
+  const {
+    activeFilter,
+    currentPage,
+    searchQuery,
+    setFilter,
+    setPage,
+    setSearchQuery,
+    commitSearch,
+  } = useAdminTableQueryState<AdminCompetitionFilterValue>({
+    filterParamName: 'status',
+    defaultFilter: 'all',
+    validFilters: ADMIN_COMPETITION_FILTERS.map((filter) => filter.value),
+  });
 
   const filteredData = useMemo(() => {
     return filterAdminCompetitions(data, activeFilter, searchQuery);
@@ -94,17 +105,20 @@ export default function AdminCompetitionsClient({
       <AdminTableToolbar
         filters={ADMIN_COMPETITION_FILTERS}
         activeFilter={activeFilter}
-        onFilterChange={setActiveFilter}
+        onFilterChange={setFilter}
         searchQuery={searchQuery}
         onSearchQueryChange={setSearchQuery}
+        onSearch={commitSearch}
         searchPlaceholder="대회 제목 검색..."
       />
 
       <AdminDataTable
         columns={COMPETITION_COLUMNS}
+        currentPage={currentPage}
         data={filteredData}
         emptyMessage="등록된 대회가 없습니다."
         getRowKey={(row) => row.id}
+        onPageChange={setPage}
       />
     </>
   );

--- a/src/components/admin/posts/AdminPostsTableClient.tsx
+++ b/src/components/admin/posts/AdminPostsTableClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import AdminBadge from '@/components/admin/AdminBadge';
 import AdminDataTable, {
   type AdminTableColumn,
@@ -15,6 +15,7 @@ import type {
   AdminPostFilterValue,
   AdminPostRow,
 } from '@/components/admin/posts/types';
+import { useAdminTableQueryState } from '@/hooks/useAdminTableQueryState';
 import {
   filterAdminPosts,
   getPostStatusBadge,
@@ -72,8 +73,19 @@ const POST_COLUMNS: AdminTableColumn<AdminPostRow>[] = [
 export default function AdminPostTableClient({
   data,
 }: AdminPostTableClientProps) {
-  const [activeFilter, setActiveFilter] = useState<AdminPostFilterValue>('all');
-  const [searchQuery, setSearchQuery] = useState('');
+  const {
+    activeFilter,
+    currentPage,
+    searchQuery,
+    setFilter,
+    setPage,
+    setSearchQuery,
+    commitSearch,
+  } = useAdminTableQueryState<AdminPostFilterValue>({
+    filterParamName: 'category',
+    defaultFilter: 'all',
+    validFilters: ADMIN_POST_FILTERS.map((filter) => filter.value),
+  });
 
   const filteredData = useMemo(() => {
     return filterAdminPosts(data, activeFilter, searchQuery);
@@ -84,15 +96,18 @@ export default function AdminPostTableClient({
       <AdminTableToolbar
         filters={ADMIN_POST_FILTERS}
         activeFilter={activeFilter}
-        onFilterChange={setActiveFilter}
+        onFilterChange={setFilter}
         searchQuery={searchQuery}
         onSearchQueryChange={setSearchQuery}
+        onSearch={commitSearch}
       />
 
       <AdminDataTable
         columns={POST_COLUMNS}
         data={filteredData}
+        currentPage={currentPage}
         getRowKey={(row) => row.id}
+        onPageChange={setPage}
       />
     </>
   );

--- a/src/components/admin/support/AdminSupportTableClient.tsx
+++ b/src/components/admin/support/AdminSupportTableClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 import AdminBadge from '@/components/admin/AdminBadge';
 import AdminDataTable, {
@@ -21,6 +21,7 @@ import type {
   AdminReportRow,
   SupportSection,
 } from '@/components/admin/support/types';
+import { useAdminTableQueryState } from '@/hooks/useAdminTableQueryState';
 import {
   filterDojangVerifications,
   filterReports,
@@ -29,7 +30,6 @@ import {
 interface AdminSupportTableClientProps {
   dojangVerifications: AdminDojangVerificationRow[];
   reports: AdminReportRow[];
-  initialSection: SupportSection;
 }
 
 const DOJANG_COLUMNS: AdminTableColumn<AdminDojangVerificationRow>[] = [
@@ -99,7 +99,7 @@ const REPORT_COLUMNS: AdminTableColumn<AdminReportRow>[] = [
     width: '11%',
     align: 'center',
     truncate: false,
-    render: (row) => (
+    render: (row) =>
       row.action_result === '-' ? (
         <span className="text-sm text-zinc-400">-</span>
       ) : (
@@ -107,8 +107,7 @@ const REPORT_COLUMNS: AdminTableColumn<AdminReportRow>[] = [
           label={row.action_result}
           variant={REPORT_ACTION_BADGE_VARIANT_MAP[row.action_result]}
         />
-      )
-    ),
+      ),
   },
   { key: 'handled_at', header: '처리 날짜', width: '11%', align: 'center' },
   {
@@ -124,11 +123,21 @@ const REPORT_COLUMNS: AdminTableColumn<AdminReportRow>[] = [
 export default function AdminSupportTableClient({
   dojangVerifications,
   reports,
-  initialSection,
 }: AdminSupportTableClientProps) {
-  const [activeSection, setActiveSection] =
-    useState<SupportSection>(initialSection);
-  const [searchQuery, setSearchQuery] = useState('');
+  const {
+    activeFilter: activeSection,
+    currentPage,
+    searchQuery,
+    setFilter,
+    setPage,
+    setSearchQuery,
+    commitSearch,
+  } = useAdminTableQueryState<SupportSection>({
+    filterParamName: 'section',
+    defaultFilter: 'dojang',
+    validFilters: SUPPORT_SECTION_FILTERS.map((filter) => filter.value),
+    resetSearchOnFilterChange: true,
+  });
 
   const filteredDojangVerifications = useMemo(() => {
     return filterDojangVerifications(dojangVerifications, searchQuery);
@@ -138,40 +147,40 @@ export default function AdminSupportTableClient({
     return filterReports(reports, searchQuery);
   }, [reports, searchQuery]);
 
-  const handleSectionChange = (nextSection: SupportSection) => {
-    setActiveSection(nextSection);
-    setSearchQuery('');
-  };
-
   const searchPlaceholder =
     activeSection === 'dojang'
       ? '도장명, 주소 검색...'
-      : '게시글 제목 검색...';
+      : '신고 게시글 제목 검색...';
 
   return (
     <>
       <AdminTableToolbar
         filters={SUPPORT_SECTION_FILTERS}
         activeFilter={activeSection}
-        onFilterChange={handleSectionChange}
+        onFilterChange={setFilter}
         searchQuery={searchQuery}
         onSearchQueryChange={setSearchQuery}
+        onSearch={commitSearch}
         searchPlaceholder={searchPlaceholder}
       />
 
       {activeSection === 'dojang' ? (
         <AdminDataTable
           columns={DOJANG_COLUMNS}
+          currentPage={currentPage}
           data={filteredDojangVerifications}
           emptyMessage="도장 인증 요청이 없습니다."
           getRowKey={(row) => row.id}
+          onPageChange={setPage}
         />
       ) : (
         <AdminDataTable
           columns={REPORT_COLUMNS}
+          currentPage={currentPage}
           data={filteredReports}
           emptyMessage="신고 내역이 없습니다."
           getRowKey={(row) => row.id}
+          onPageChange={setPage}
         />
       )}
     </>

--- a/src/components/admin/users/AdminUsersClient.tsx
+++ b/src/components/admin/users/AdminUsersClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 import AdminBadge from '@/components/admin/AdminBadge';
 import AdminDataTable, {
@@ -18,6 +18,7 @@ import type {
   AdminUserFilterValue,
   AdminUserRow,
 } from '@/components/admin/users/types';
+import { useAdminTableQueryState } from '@/hooks/useAdminTableQueryState';
 import { filterAdminUsers } from '@/components/admin/users/utils';
 
 interface AdminUsersClientProps {
@@ -150,8 +151,19 @@ const USER_COLUMNS: AdminTableColumn<AdminUserRow>[] = [
 ];
 
 export default function AdminUsersClient({ data }: AdminUsersClientProps) {
-  const [activeFilter, setActiveFilter] = useState<AdminUserFilterValue>('all');
-  const [searchQuery, setSearchQuery] = useState('');
+  const {
+    activeFilter,
+    currentPage,
+    searchQuery,
+    setFilter,
+    setPage,
+    setSearchQuery,
+    commitSearch,
+  } = useAdminTableQueryState<AdminUserFilterValue>({
+    filterParamName: 'status',
+    defaultFilter: 'all',
+    validFilters: ADMIN_USER_FILTERS.map((filter) => filter.value),
+  });
 
   const filteredData = useMemo(() => {
     return filterAdminUsers(data, activeFilter, searchQuery);
@@ -162,17 +174,20 @@ export default function AdminUsersClient({ data }: AdminUsersClientProps) {
       <AdminTableToolbar
         filters={ADMIN_USER_FILTERS}
         activeFilter={activeFilter}
-        onFilterChange={setActiveFilter}
+        onFilterChange={setFilter}
         searchQuery={searchQuery}
         onSearchQueryChange={setSearchQuery}
+        onSearch={commitSearch}
         searchPlaceholder="닉네임, 이름, 이메일 검색..."
       />
 
       <AdminDataTable
         columns={USER_COLUMNS}
+        currentPage={currentPage}
         data={filteredData}
         emptyMessage="등록된 사용자가 없습니다."
         getRowKey={(row) => row.id}
+        onPageChange={setPage}
       />
     </>
   );

--- a/src/components/common/SearchInput.tsx
+++ b/src/components/common/SearchInput.tsx
@@ -4,7 +4,8 @@ import { Input } from '../ui/input';
 
 interface SearchInputProps {
   searchQuery: string;
-  setSearchQuery: (query: string) => void;
+  // eslint-disable-next-line no-unused-vars
+  setSearchQuery: (_query: string) => void;
   onSearch?: () => void;
   placeholder?: string;
 }
@@ -17,7 +18,7 @@ export default function SearchInput({
 }: SearchInputProps) {
   return (
     <div className="flex-1 relative flex items-center">
-      <button className="absolute left-3 z-10" onClick={onSearch}>
+      <button type="button" className="absolute left-3 z-10" onClick={onSearch}>
         <Image src="/glasses.svg" alt="검색" width={18} height={18} />
       </button>
       <Input

--- a/src/hooks/useAdminTablePagination.ts
+++ b/src/hooks/useAdminTablePagination.ts
@@ -1,9 +1,12 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 interface UseTablePaginationParams<T> {
   data: T[];
   initialPageSize?: number;
   pageSizeOptions?: readonly number[];
+  currentPage?: number;
+  // eslint-disable-next-line no-unused-vars
+  onPageChange?: (_page: number) => void;
 }
 
 const DEFAULT_PAGE_SIZE = 10;
@@ -13,6 +16,8 @@ export function useAdminTablePagination<T>({
   data,
   initialPageSize = DEFAULT_PAGE_SIZE,
   pageSizeOptions = DEFAULT_PAGE_SIZE_OPTIONS,
+  currentPage,
+  onPageChange,
 }: UseTablePaginationParams<T>) {
   const normalizedPageSizeOptions = useMemo(() => {
     const mergedOptions = new Set<number>([
@@ -27,10 +32,19 @@ export function useAdminTablePagination<T>({
     initialPageSize > 0 ? initialPageSize : DEFAULT_PAGE_SIZE,
   );
 
-  const [currentPage, setCurrentPage] = useState(1);
+  const [internalCurrentPage, setInternalCurrentPage] = useState(1);
+  const resolvedCurrentPage = currentPage ?? internalCurrentPage;
 
   const totalPages = Math.max(1, Math.ceil(data.length / pageSize));
-  const safeCurrentPage = Math.min(currentPage, totalPages);
+  const safeCurrentPage = Math.min(resolvedCurrentPage, totalPages);
+
+  useEffect(() => {
+    if (!onPageChange || safeCurrentPage === resolvedCurrentPage) {
+      return;
+    }
+
+    onPageChange(safeCurrentPage);
+  }, [onPageChange, resolvedCurrentPage, safeCurrentPage]);
 
   const paginatedData = useMemo(() => {
     const startIndex = (safeCurrentPage - 1) * pageSize;
@@ -39,16 +53,27 @@ export function useAdminTablePagination<T>({
     return data.slice(startIndex, endIndex);
   }, [data, pageSize, safeCurrentPage]);
 
-  const handlePageChange = (page: number) => {
-    const clampedPage = Math.min(Math.max(page, 1), totalPages);
+  const handlePageChange = useCallback(
+    (page: number) => {
+      const clampedPage = Math.min(Math.max(page, 1), totalPages);
 
-    setCurrentPage(clampedPage);
-  };
+      if (onPageChange) {
+        onPageChange(clampedPage);
+        return;
+      }
 
-  const handlePageSizeChange = (nextPageSize: number) => {
-    setPageSize(nextPageSize);
-    setCurrentPage(1);
-  };
+      setInternalCurrentPage(clampedPage);
+    },
+    [onPageChange, totalPages],
+  );
+
+  const handlePageSizeChange = useCallback(
+    (nextPageSize: number) => {
+      setPageSize(nextPageSize);
+      handlePageChange(1);
+    },
+    [handlePageChange],
+  );
 
   return {
     pageSize,

--- a/src/hooks/useAdminTableQueryState.ts
+++ b/src/hooks/useAdminTableQueryState.ts
@@ -44,11 +44,12 @@ export function useAdminTableQueryState<TFilter extends string>({
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
-
-  const currentPage = useMemo(
+  const pageParamState = useMemo(
     () => parsePositiveIntParam(searchParams.get('page'), defaultPage),
     [defaultPage, searchParams],
   );
+
+  const currentPage = pageParamState.value;
 
   const activeFilter = useMemo(
     () =>
@@ -102,6 +103,19 @@ export function useAdminTableQueryState<TFilter extends string>({
     },
     [currentUrl, pathname, router, searchParams],
   );
+
+  useEffect(() => {
+    if (!pageParamState.shouldNormalize) {
+      return;
+    }
+
+    navigateWithSearchParams(
+      {
+        page: pageParamState.normalizedValue,
+      },
+      'replace',
+    );
+  }, [navigateWithSearchParams, pageParamState]);
 
   useEffect(() => {
     if (debouncedSearchInput !== searchInput) {

--- a/src/hooks/useAdminTableQueryState.ts
+++ b/src/hooks/useAdminTableQueryState.ts
@@ -1,0 +1,199 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+
+import {
+  parseEnumParam,
+  parsePositiveIntParam,
+  updateSearchParams,
+} from '@/lib/urlSearchParams';
+import { useDebounce } from '@/hooks/useDebounce';
+
+type NavigationMode = 'push' | 'replace';
+
+interface UseAdminTableQueryStateOptions<TFilter extends string> {
+  filterParamName: string;
+  defaultFilter: TFilter;
+  validFilters: readonly TFilter[];
+  defaultPage?: number;
+  defaultSearch?: string;
+  resetSearchOnFilterChange?: boolean;
+  searchDebounceMs?: number;
+  navigationMode?: {
+    page?: NavigationMode;
+    filter?: NavigationMode;
+    search?: NavigationMode;
+  };
+}
+
+interface SetFilterOptions {
+  resetPage?: boolean;
+}
+
+export function useAdminTableQueryState<TFilter extends string>({
+  filterParamName,
+  defaultFilter,
+  validFilters,
+  defaultPage = 1,
+  defaultSearch = '',
+  resetSearchOnFilterChange = false,
+  searchDebounceMs = 300,
+  navigationMode,
+}: UseAdminTableQueryStateOptions<TFilter>) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const currentPage = useMemo(
+    () => parsePositiveIntParam(searchParams.get('page'), defaultPage),
+    [defaultPage, searchParams],
+  );
+
+  const activeFilter = useMemo(
+    () =>
+      parseEnumParam(
+        searchParams.get(filterParamName),
+        validFilters,
+        defaultFilter,
+      ),
+    [defaultFilter, filterParamName, searchParams, validFilters],
+  );
+
+  const appliedSearchQuery = useMemo(
+    () => searchParams.get('search') ?? defaultSearch,
+    [defaultSearch, searchParams],
+  );
+
+  const [searchInput, setSearchInput] = useState(appliedSearchQuery);
+
+  useEffect(() => {
+    // URL change(back/forward, shared link)를 로컬 입력값에 동기화한다.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setSearchInput(appliedSearchQuery);
+  }, [appliedSearchQuery]);
+
+  const debouncedSearchInput = useDebounce(searchInput, searchDebounceMs);
+  const currentQueryString = searchParams.toString();
+  const currentUrl = currentQueryString ? `${pathname}?${currentQueryString}` : pathname;
+
+  const navigateWithSearchParams = useCallback(
+    (
+      updates: Record<string, string | null | undefined>,
+      mode: NavigationMode = 'replace',
+    ) => {
+      const nextSearchParams = updateSearchParams(searchParams, updates);
+      const nextQueryString = nextSearchParams.toString();
+      const nextUrl = nextQueryString ? `${pathname}?${nextQueryString}` : pathname;
+
+      if (nextUrl === currentUrl) {
+        return;
+      }
+
+      if (mode === 'push') {
+        router.push(nextUrl, { scroll: false });
+        return;
+      }
+
+      router.replace(nextUrl, { scroll: false });
+    },
+    [currentUrl, pathname, router, searchParams],
+  );
+
+  useEffect(() => {
+    if (debouncedSearchInput !== searchInput) {
+      return;
+    }
+
+    const normalizedSearch =
+      debouncedSearchInput.trim() === '' ? null : debouncedSearchInput.trim();
+
+    if ((normalizedSearch ?? '') === appliedSearchQuery) {
+      return;
+    }
+
+    navigateWithSearchParams(
+      {
+        search: normalizedSearch,
+        page: null,
+      },
+      navigationMode?.search ?? 'replace',
+    );
+  }, [
+    appliedSearchQuery,
+    debouncedSearchInput,
+    navigateWithSearchParams,
+    navigationMode?.search,
+    searchInput,
+  ]);
+
+  const setPage = useCallback(
+    (page: number) => {
+      const nextPage = Math.max(page, 1);
+
+      navigateWithSearchParams(
+        {
+          page: nextPage <= 1 ? null : String(nextPage),
+        },
+        navigationMode?.page ?? 'push',
+      );
+    },
+    [navigateWithSearchParams, navigationMode?.page],
+  );
+
+  const setFilter = useCallback(
+    (nextFilter: TFilter, options?: SetFilterOptions) => {
+      const shouldResetPage = options?.resetPage ?? true;
+      const nextSearch =
+        resetSearchOnFilterChange && searchInput.trim() !== ''
+          ? null
+          : undefined;
+
+      navigateWithSearchParams(
+        {
+          [filterParamName]:
+            nextFilter === defaultFilter ? null : String(nextFilter),
+          ...(shouldResetPage ? { page: null } : {}),
+          ...(resetSearchOnFilterChange ? { search: nextSearch } : {}),
+        },
+        navigationMode?.filter ?? 'push',
+      );
+
+      if (resetSearchOnFilterChange) {
+        setSearchInput('');
+      }
+    },
+    [
+      defaultFilter,
+      filterParamName,
+      navigateWithSearchParams,
+      navigationMode?.filter,
+      resetSearchOnFilterChange,
+      searchInput,
+    ],
+  );
+
+  const commitSearch = useCallback(() => {
+    const normalizedSearch =
+      searchInput.trim() === '' ? null : searchInput.trim();
+
+    navigateWithSearchParams(
+      {
+        search: normalizedSearch,
+        page: null,
+      },
+      navigationMode?.search ?? 'replace',
+    );
+  }, [navigateWithSearchParams, navigationMode?.search, searchInput]);
+
+  return {
+    currentPage,
+    activeFilter,
+    searchQuery: searchInput,
+    appliedSearchQuery,
+    setPage,
+    setFilter,
+    setSearchQuery: setSearchInput,
+    commitSearch,
+  };
+}

--- a/src/hooks/useAdminTableQueryState.ts
+++ b/src/hooks/useAdminTableQueryState.ts
@@ -68,14 +68,15 @@ export function useAdminTableQueryState<TFilter extends string>({
   const [searchInput, setSearchInput] = useState(appliedSearchQuery);
 
   useEffect(() => {
-    // URL change(back/forward, shared link)를 로컬 입력값에 동기화한다.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setSearchInput(appliedSearchQuery);
   }, [appliedSearchQuery]);
 
   const debouncedSearchInput = useDebounce(searchInput, searchDebounceMs);
   const currentQueryString = searchParams.toString();
-  const currentUrl = currentQueryString ? `${pathname}?${currentQueryString}` : pathname;
+  const currentUrl = currentQueryString
+    ? `${pathname}?${currentQueryString}`
+    : pathname;
 
   const navigateWithSearchParams = useCallback(
     (
@@ -84,7 +85,9 @@ export function useAdminTableQueryState<TFilter extends string>({
     ) => {
       const nextSearchParams = updateSearchParams(searchParams, updates);
       const nextQueryString = nextSearchParams.toString();
-      const nextUrl = nextQueryString ? `${pathname}?${nextQueryString}` : pathname;
+      const nextUrl = nextQueryString
+        ? `${pathname}?${nextQueryString}`
+        : pathname;
 
       if (nextUrl === currentUrl) {
         return;

--- a/src/lib/urlSearchParams.ts
+++ b/src/lib/urlSearchParams.ts
@@ -1,20 +1,48 @@
 import type { ReadonlyURLSearchParams } from 'next/navigation';
 
+interface NormalizedPositiveIntParam {
+  value: number;
+  shouldNormalize: boolean;
+  normalizedValue: string | null;
+}
+
 export function parsePositiveIntParam(
   value: string | null,
   fallback: number = 1,
-) {
+): NormalizedPositiveIntParam {
   if (!value) {
-    return fallback;
+    return {
+      value: fallback,
+      shouldNormalize: false,
+      normalizedValue: fallback <= 1 ? null : String(fallback),
+    };
   }
 
-  const parsedValue = Number.parseInt(value, 10);
+  if (!/^\d+$/.test(value)) {
+    return {
+      value: fallback,
+      shouldNormalize: true,
+      normalizedValue: fallback <= 1 ? null : String(fallback),
+    };
+  }
+
+  const parsedValue = Number(value);
 
   if (!Number.isFinite(parsedValue) || parsedValue < 1) {
-    return fallback;
+    return {
+      value: fallback,
+      shouldNormalize: true,
+      normalizedValue: fallback <= 1 ? null : String(fallback),
+    };
   }
 
-  return parsedValue;
+  const normalizedValue = parsedValue <= 1 ? null : String(parsedValue);
+
+  return {
+    value: parsedValue,
+    shouldNormalize: value !== normalizedValue,
+    normalizedValue,
+  };
 }
 
 export function parseEnumParam<TValue extends string>(

--- a/src/lib/urlSearchParams.ts
+++ b/src/lib/urlSearchParams.ts
@@ -1,0 +1,48 @@
+import type { ReadonlyURLSearchParams } from 'next/navigation';
+
+export function parsePositiveIntParam(
+  value: string | null,
+  fallback: number = 1,
+) {
+  if (!value) {
+    return fallback;
+  }
+
+  const parsedValue = Number.parseInt(value, 10);
+
+  if (!Number.isFinite(parsedValue) || parsedValue < 1) {
+    return fallback;
+  }
+
+  return parsedValue;
+}
+
+export function parseEnumParam<TValue extends string>(
+  value: string | null,
+  validValues: readonly TValue[],
+  fallback: TValue,
+) {
+  if (!value) {
+    return fallback;
+  }
+
+  return validValues.includes(value as TValue) ? (value as TValue) : fallback;
+}
+
+export function updateSearchParams(
+  currentSearchParams: ReadonlyURLSearchParams,
+  updates: Record<string, string | null | undefined>,
+) {
+  const nextSearchParams = new URLSearchParams(currentSearchParams.toString());
+
+  Object.entries(updates).forEach(([key, value]) => {
+    if (!value) {
+      nextSearchParams.delete(key);
+      return;
+    }
+
+    nextSearchParams.set(key, value);
+  });
+
+  return nextSearchParams;
+}


### PR DESCRIPTION
<!--
  PR 작성 가이드
  - 리뷰어를 존중하는 표현을 사용해주세요.
  - 변경 의도와 주요 내용을 명확하게 작성해주세요.
 -->

## 📌 개요

- 관리자 페이지 URL 쿼리 상태 관리 적용

## 💻 작업 사항
- 관리자 테이블의 page/search/status/category 상태를 URL 쿼리 기반으로 관리하도록 개선
- 새로고침, URL 공유, 브라우저 뒤로가기/앞으로가기 시 필터 상태가 유지되도록 처리 
- URL 파라미터 파싱/갱신 로직을 공통 유틸로 분리 (`urlSearchParams.ts`)
- 관리자 테이블 쿼리 상태 관리를 위한 공통 hook 추가 (`useAdminTableQueryState.ts`)
- AdminDataTable 페이지네이션을 controlled 방식으로도 사용할 수 있도록 확장 
- 검색어 입력은 로컬 draft state로 관리하고, debounce 후 URL에 반영되도록 개선
<img width="453" height="41" alt="스크린샷 2026-05-15 오후 1 13 52" src="https://github.com/user-attachments/assets/a599b5dd-2d38-4a99-af80-4f3ae34354f2" />

### 체크 사항
- 필터링 버튼 클릭시 category URL쿼리 정상 작동 하는지 체크
- 검색 입력값 search URL 쿼리 정상 작동 하는지 체크
- 새로고침 혹은 뒤로가기 앞으로가기 작동시, 정보 남아있는지 체크


## 💡 관련 Issue

Closes #182

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #)
- [x] 불필요한 console.log를 제거했습니다.
- [x] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
