### PR TITLE
[Feat] 서비스 전체 페이지 및 공통 컴포넌트 다크모드 지원 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
+        "@types/navermaps": "^3.9.1",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -3937,6 +3938,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "dev": true,
@@ -3962,6 +3970,16 @@
     "node_modules/@types/mdurl": {
       "version": "2.0.0",
       "license": "MIT"
+    },
+    "node_modules/@types/navermaps": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@types/navermaps/-/navermaps-3.9.1.tgz",
+      "integrity": "sha512-XCYtuJ0mYaXx5lBeB0iahk+sPG7Q9tLHQGR6AkGCOGwrRG8qowdG5/FIYlI7am59j/Hm4vaiR+eRZ31kTgMWjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "20.19.39",
@@ -8308,6 +8326,8 @@
     },
     "node_modules/next-themes": {
       "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",

--- a/src/app/(auth)/find-password/FindPasswordClient.tsx
+++ b/src/app/(auth)/find-password/FindPasswordClient.tsx
@@ -249,7 +249,6 @@ export default function FindPasswordPage() {
               >
                 <path
                   strokeLinecap="round"
-                  ㅋㅋㅋ
                   strokeLinejoin="round"
                   strokeWidth={2}
                   d="M5 13l4 4L19 7"

--- a/src/app/(auth)/find-password/FindPasswordClient.tsx
+++ b/src/app/(auth)/find-password/FindPasswordClient.tsx
@@ -240,15 +240,16 @@ export default function FindPasswordPage() {
 
         {step === 3 && (
           <div className="flex flex-col items-center gap-6 py-4">
-            <div className="w-16 h-16 rounded-full bg-green-100 flex items-center justify-center">
+            <div className="w-16 h-16 rounded-full bg-state-green-bg flex items-center justify-center">
               <svg
-                className="w-8 h-8 text-green-500"
+                className="w-8 h-8 text-state-green-text"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
               >
                 <path
                   strokeLinecap="round"
+                  ㅋㅋㅋ
                   strokeLinejoin="round"
                   strokeWidth={2}
                   d="M5 13l4 4L19 7"

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import Image from 'next/image';
+import ThemeToggle from '@/components/layout/ThemeToggle';
 
 export default function AuthLayout({
   children,
@@ -7,7 +8,10 @@ export default function AuthLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="relative min-h-screen flex flex-col items-center justify-center bg-bg-page px-10 py-6">
+    <div className="relative min-h-screen flex flex-col items-center justify-center bg-bg-white px-10 py-6">
+      <div className="fixed top-4 right-4 z-50">
+        <ThemeToggle />
+      </div>
       <Link href="/" className="flex flex-col items-center mb-2">
         <div className="relative w-40 h-20 mb-3">
           <Image

--- a/src/app/(auth)/login/LoginClient.tsx
+++ b/src/app/(auth)/login/LoginClient.tsx
@@ -145,7 +145,7 @@ export default function LoginPage() {
           <div className="flex justify-end -mt-5 -mb-5">
             <Link
               href="/find-password"
-              className="text-sm font-bold hover:underline text-[#4f74e8]"
+              className="text-sm font-bold hover:underline text-(--color-auth-find-password)"
             >
               비밀번호 찾기
             </Link>

--- a/src/app/(auth)/register/RegisterClient.tsx
+++ b/src/app/(auth)/register/RegisterClient.tsx
@@ -59,11 +59,27 @@ const dojangSchema = z
 
 // 벨트 종류
 const BELTS = [
-  { value: 'white', label: 'White  (입문자)', color: '#e8e8e8' },
-  { value: 'blue', label: 'Blue   (파란띠)', color: '#2e6fdb' },
-  { value: 'purple', label: 'Purple (보라띠)', color: '#7c4ddb' },
-  { value: 'brown', label: 'Brown  (갈색띠)', color: '#8b5a2b' },
-  { value: 'black', label: 'Black  (검은띠)', color: '#1a1a1a' },
+  {
+    value: 'white',
+    label: 'White  (입문자)',
+    color: 'var(--color-belt-white)',
+  },
+  { value: 'blue', label: 'Blue   (파란띠)', color: 'var(--color-belt-blue)' },
+  {
+    value: 'purple',
+    label: 'Purple (보라띠)',
+    color: 'var(--color-belt-purple)',
+  },
+  {
+    value: 'brown',
+    label: 'Brown  (갈색띠)',
+    color: 'var(--color-belt-brown)',
+  },
+  {
+    value: 'black',
+    label: 'Black  (검은띠)',
+    color: 'var(--color-belt-black)',
+  },
 ];
 
 const BeltSelect = forwardRef<
@@ -701,7 +717,7 @@ export default function RegisterPage() {
   return (
     <>
       {/* 탭 */}
-      <div className="flex border-b border-gray-200 mb-6">
+      <div className="flex border-b border-border mb-6">
         <button
           onClick={() => setTab('general')}
           className={`flex-1 pb-3 text-sm font-bold transition-all cursor-pointer ${

--- a/src/app/(main)/mypage/MyPageClient.tsx
+++ b/src/app/(main)/mypage/MyPageClient.tsx
@@ -40,9 +40,9 @@ export default function MyPageClient() {
   if (!profile) return null;
 
   return (
-    <main className="w-full min-h-screen">
+    <main className="w-full min-h-screen bg-bg-page">
       {/* 헤더 */}
-      <div className="fixed top-0 left-50 right-0 z-10 bg-white shadow-sm flex justify-center">
+      <div className="fixed top-0 left-50 right-0 z-10 bg-bg-white shadow-sm flex justify-center">
         <div className="w-full max-w-7xl px-6 py-6">
           <h1 className="text-4xl font-bold text-text-primary">마이페이지</h1>
           <p className="text-sm text-text-secondary mt-2">
@@ -71,7 +71,7 @@ export default function MyPageClient() {
               className={`px-4 py-2.5 rounded-lg text-sm font-bold transition-all shadow-sm border cursor-pointer ${
                 tab === 'posts'
                   ? 'bg-btn-focus text-btn-focus-text border-btn-focus'
-                  : 'bg-bg-white text-text-secondary border-gray-100 hover:text-text-primary'
+                  : 'bg-bg-white text-text-secondary border-border-custom hover:text-text-primary'
               }`}
             >
               게시글
@@ -81,7 +81,7 @@ export default function MyPageClient() {
               className={`px-4 py-2.5 rounded-lg text-sm font-bold transition-all shadow-sm border cursor-pointer ${
                 tab === 'settings'
                   ? 'bg-btn-focus text-btn-focus-text border-btn-focus'
-                  : 'bg-bg-white text-text-secondary border-gray-100 hover:text-text-primary'
+                  : 'bg-bg-white text-text-secondary border-border-custom hover:text-text-primary'
               }`}
             >
               설정

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -190,14 +190,14 @@
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);
   --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
+  --popover: #e5e7eb;
+  --popover-foreground: #0f0f0f;
   --primary: oklch(0.922 0 0);
   --primary-foreground: oklch(0.205 0 0);
   --secondary: oklch(0.269 0 0);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
+  --muted-foreground: #4a4a4a;
   --accent: oklch(0.269 0 0);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -89,6 +89,23 @@
   /* 에러 페이지 */
   --color-error-not-found: #2c56e7; /* not-found color */
   --color-error-runtime: #e7000b; /* error color */
+
+  /* 커뮤니티 카테고리 뱃지 */
+  --color-category-promo-bg: var(--category-promo-bg);
+  --color-category-notice-bg: var(--category-notice-bg);
+  --color-category-personal-bg: var(--category-personal-bg);
+  --color-category-text: var(--category-text);
+
+  /* 대회 모집 상태 뱃지 */
+  --color-state-recruiting-bg: var(--state-recruiting-bg);
+  --color-state-recruiting-text: var(--state-recruiting-text);
+  --color-state-deadline-bg: var(--state-deadline-bg);
+  --color-state-deadline-text: var(--state-deadline-text);
+  --color-state-closed-bg: var(--state-closed-bg);
+  --color-state-closed-text: var(--state-closed-text);
+
+  /* 대회 D-day */
+  --color-dday-imminent: var(--dday-imminent);
 }
 
 :root {
@@ -140,6 +157,20 @@
   --state-manager-bg: #dbeafe;
   --state-basic-bg: #f3f4f6;
   --border-custom: #e5e7eb;
+
+  --category-promo-bg: #155dfc;
+  --category-notice-bg: #e7000b;
+  --category-personal-bg: #364153;
+  --category-text: #ffffff;
+
+  --state-recruiting-bg: #22c55e;
+  --state-recruiting-text: #ffffff;
+  --state-deadline-bg: #f97316;
+  --state-deadline-text: #ffffff;
+  --state-closed-bg: #9ca3af;
+  --state-closed-text: #ffffff;
+
+  --dday-imminent: #3b82f6;
 }
 
 .dark {
@@ -191,6 +222,20 @@
   --state-manager-bg: #1e3a5f;
   --state-basic-bg: #2a2a2a;
   --border-custom: #3f3f3f;
+
+  --category-promo-bg: #1d4ed8;
+  --category-notice-bg: #dc2626;
+  --category-personal-bg: #4b5563;
+  --category-text: #ffffff;
+
+  --state-recruiting-bg: #16a34a;
+  --state-recruiting-text: #ffffff;
+  --state-deadline-bg: #ea580c;
+  --state-deadline-text: #ffffff;
+  --state-closed-bg: #6b7280;
+  --state-closed-text: #ffffff;
+
+  --dday-imminent: #60a5fa;
 }
 
 .dark input,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -106,6 +106,12 @@
 
   /* 대회 D-day */
   --color-dday-imminent: var(--dday-imminent);
+
+  --color-belt-white: var(--belt-white);
+  --color-belt-blue: var(--belt-blue);
+  --color-belt-purple: var(--belt-purple);
+  --color-belt-brown: var(--belt-brown);
+  --color-belt-black: var(--belt-black);
 }
 
 :root {
@@ -171,6 +177,12 @@
   --state-closed-text: #ffffff;
 
   --dday-imminent: #3b82f6;
+
+  --belt-white: #e8e8e8;
+  --belt-blue: #2e6fdb;
+  --belt-purple: #7c4ddb;
+  --belt-brown: #8b5a2b;
+  --belt-black: #1a1a1a;
 }
 
 .dark {
@@ -236,6 +248,12 @@
   --state-closed-text: #ffffff;
 
   --dday-imminent: #60a5fa;
+
+  --belt-white: #e8e8e8;
+  --belt-blue: #2e6fdb;
+  --belt-purple: #7c4ddb;
+  --belt-brown: #8b5a2b;
+  --belt-black: #3a3a3a;
 }
 
 .dark input,
@@ -265,4 +283,14 @@
   outline: 2px solid var(--color-btn-focus);
   outline-offset: 2px;
   border-radius: 0.5rem;
+}
+
+.dark select {
+  color: #f9fafb;
+  background-color: var(--input-bg);
+}
+
+.dark select option {
+  background-color: var(--input-bg);
+  color: #f9fafb;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -48,36 +48,36 @@
   --radius-4xl: calc(var(--radius) * 2.6);
 
   /* 텍스트 */
-  --color-state-manager-text: #1447e6; /* 도장 회원 텍스트*/
-  --color-state-basic-text: #4a5565; /* 일반 회원 텍스트 */
-  --color-btn-focus-text: #ffffff; /* 버튼 클릭 시 텍스트 색상 */
-  --color-btn-text: #4a5565; /* 버튼 기본 텍스트 및 기본 텍스트 색상 */
-  --color-input-text: #101828; /* 버튼 클릭 시 배경 */
-  --color-text-primary: #101828; /* 제목 텍스트, 주요 텍스트 */
-  --color-text-secondary: #6a7282; /* 부제목 텍스트*/
+  --color-state-manager-text: #1447e6;
+  --color-state-basic-text: #4a5565;
+  --color-btn-focus-text: var(--btn-focus-text);
+  --color-btn-text: var(--btn-text);
+  --color-input-text: var(--input-text);
+  --color-text-primary: var(--text-primary);
+  --color-text-secondary: var(--text-secondary);
 
   /* 배경 */
-  --color-bg-page: #f8f9fa; /* 전체 페이지 배경 */
-  --color-bg-white: #ffffff; /* 카드, 사이드바 배경 */
-  --color-table-top: #f3f4f6; /* 마이페이지 표 상단 배경 */
+  --color-bg-page: var(--bg-page);
+  --color-bg-white: var(--bg-white);
+  --color-table-top: var(--table-top);
 
   /* 버튼 */
-  --color-btn-basic: #f3f4f6; /* 버튼 기본 상태 */
-  --color-btn-focus: #2c2c2c; /* 버튼 클릭 시 배경 */
+  --color-btn-basic: var(--btn-basic);
+  --color-btn-focus: var(--btn-focus);
   --color-state-green-btn-fucus: #00a63e; /* 모집중 버튼 클릭 시*/
   --color-state-yellow-btn-focus: #d08700; /* 마감임박 버튼 클릭 시 */
   --color-state-red-btn-focus: #e7000b; /* 모집완료 버튼 클릭 시 */
 
   /* 입력 */
-  --color-input-bg: #f3f4f6; /* 인풋 배경 */
-  --color-border: #2c2c2c; /* 카드, 인풋 테두리 */
+  --color-input-bg: var(--input-bg);
+  --color-border: var(--border-custom);
 
   /* 상태 */
-  --color-state-green-bg: #dcfce7; /* 모집중 상태 배경*/
-  --color-state-green-text: #008236; /* 모집중 상태 텍스트*/
+  --color-state-green-bg: var(--state-green-bg);
+  --color-state-green-text: var(--state-green-text);
   --color-state-yellow: #d08700; /* 마감임박 상태 */
-  --color-state-manager-bg: #dbeafe; /* 도장 회원 */
-  --color-state-basic-bg: #f3f4f6; /* 일반 회원 */
+  --color-state-manager-bg: var(--state-manager-bg);
+  --color-state-basic-bg: var(--state-basic-bg);
 
   /* 위험 */
   --color-danger: #e7000b; /* 회원 탈퇴 버튼 */
@@ -124,6 +124,22 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+  --btn-focus-text: #ffffff;
+  --btn-text: #4a5565;
+  --input-text: #101828;
+  --text-primary: #101828;
+  --text-secondary: #6a7282;
+  --bg-page: #f8f9fa;
+  --bg-white: #ffffff;
+  --table-top: #f3f4f6;
+  --btn-basic: #f3f4f6;
+  --btn-focus: #2c2c2c;
+  --input-bg: #f3f4f6;
+  --state-green-bg: #dcfce7;
+  --state-green-text: #008236;
+  --state-manager-bg: #dbeafe;
+  --state-basic-bg: #f3f4f6;
+  --border-custom: #e5e7eb;
 }
 
 .dark {
@@ -158,6 +174,28 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
+
+  --btn-focus-text: #0f0f0f;
+  --btn-text: #d1d5db;
+  --input-text: #f9fafb;
+  --text-primary: #e5e7eb;
+  --text-secondary: #9ca3af;
+  --bg-page: #0f0f0f;
+  --bg-white: #1a1a1a;
+  --table-top: #262626;
+  --btn-basic: #2a2a2a;
+  --btn-focus: #e5e7eb;
+  --input-bg: #262626;
+  --state-green-bg: #052e16;
+  --state-green-text: #4ade80;
+  --state-manager-bg: #1e3a5f;
+  --state-basic-bg: #2a2a2a;
+  --border-custom: #3f3f3f;
+}
+
+.dark input,
+.dark textarea {
+  color: #f9fafb;
 }
 
 @layer base {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@
 
 import { QueryClientProvider } from '@tanstack/react-query';
 import { Toaster } from 'react-hot-toast';
+import { ThemeProvider } from 'next-themes';
 import { queryClient } from '@/lib/queryClient';
 import './globals.css';
 
@@ -11,12 +12,14 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="ko">
-      <body className="bg-bg-page min-w-5xl">
-        <QueryClientProvider client={queryClient}>
-          {children}
-          <Toaster position="top-center" />
-        </QueryClientProvider>
+    <html lang="ko" suppressHydrationWarning>
+      <body className="bg-background min-w-5xl">
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          <QueryClientProvider client={queryClient}>
+            {children}
+            <Toaster position="top-center" />
+          </QueryClientProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { Suspense } from 'react';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import LogoutButton from '@/components/layout/LogoutButton';
 import { LogIn } from 'lucide-react';
+import ThemeToggle from '@/components/layout/ThemeToggle';
 
 export const metadata: Metadata = {
   title: '블랙벨트 | 주짓수 올인원 네트워크',
@@ -30,7 +31,7 @@ const NAV_LINKS = [
 ] as const;
 
 const NAV_LINK_CLASS =
-  'flex items-center gap-2 px-6 py-3 border-2 border-btn-focus text-black text-sm font-medium rounded-xl hover:bg-btn-focus hover:text-white transition-colors duration-200';
+  'flex items-center gap-2 px-6 py-3 border-2 border-btn-focus text-text-primary text-sm font-medium rounded-xl hover:bg-btn-focus hover:text-btn-focus-text transition-colors duration-200';
 
 async function AuthButton() {
   const supabase = await createSupabaseServerClient();
@@ -52,8 +53,11 @@ export default function Home() {
   return (
     <main
       aria-label="블랙벨트 홈"
-      className="min-h-screen bg-white flex flex-col items-center justify-center px-6 py-16 relative overflow-hidden"
+      className="min-h-screen bg-bg-white flex flex-col items-center justify-center px-6 py-16 relative overflow-hidden"
     >
+      <div className="fixed top-4 right-4 z-50">
+        <ThemeToggle />
+      </div>
       <div className="flex flex-col items-center mb-6 animate-fade-in">
         <div className="mb-4">
           <Image
@@ -64,18 +68,18 @@ export default function Home() {
           />
         </div>
         <h1
-          className="text-4xl font-black tracking-tight text-black text-center leading-tight"
+          className="text-4xl font-black tracking-tight text-text-primary text-center leading-tight"
           style={{ fontFamily: "Georgia, 'Times New Roman', serif" }}
         >
           블랙벨트
         </h1>
         <p
-          className="text-lg font-light tracking-[0.3em] text-gray-500 mt-1"
+          className="text-lg font-light tracking-[0.3em] text-text-secondary mt-1"
           style={{ fontFamily: "Georgia, 'Times New Roman', serif" }}
         >
           (Black-Belt)
         </p>
-        <p className="text-sm text-gray-600 text-center max-w-xl leading-relaxed mt-4">
+        <p className="text-sm text-text-secondary text-center max-w-xl leading-relaxed mt-4">
           주짓수인들을 위한 올인원 네트워크, 블랙벨트
           <br />
           <br />

--- a/src/components/admin/AdminBadge.tsx
+++ b/src/components/admin/AdminBadge.tsx
@@ -9,7 +9,7 @@ const baseStyle =
   'inline-flex items-center rounded-full px-2 py-1 text-xs font-medium';
 
 const variantStyleMap: Record<AdminBadgeVariant, string> = {
-  gray: 'bg-gray-100 text-gray-800',
+  gray: 'bg-btn-basic text-text-primary',
   blue: 'bg-blue-100 text-blue-700',
   red: 'bg-red-100 text-red-700',
   green: 'bg-green-100 text-green-700',

--- a/src/components/admin/AdminBadge.tsx
+++ b/src/components/admin/AdminBadge.tsx
@@ -9,7 +9,7 @@ const baseStyle =
   'inline-flex items-center rounded-full px-2 py-1 text-xs font-medium';
 
 const variantStyleMap: Record<AdminBadgeVariant, string> = {
-  gray: 'bg-btn-basic text-text-primary',
+  gray: 'bg-gray-100 text-gray-800',
   blue: 'bg-blue-100 text-blue-700',
   red: 'bg-red-100 text-red-700',
   green: 'bg-green-100 text-green-700',

--- a/src/components/admin/AdminDataTable.tsx
+++ b/src/components/admin/AdminDataTable.tsx
@@ -47,8 +47,8 @@ export default function AdminDataTable<T>({
   });
 
   return (
-    <section className="w-full max-w-7xl rounded-md border bg-white px-6 py-4 mb-8">
-      <table className="w-full table-fixed border-collapse bg-white">
+    <section className="w-full max-w-7xl rounded-md border bg-bg-white px-6 py-4 mb-8">
+      <table className="w-full table-fixed border-collapse bg-bg-white">
         <thead>
           <tr>
             {columns.map((column) => (
@@ -72,7 +72,7 @@ export default function AdminDataTable<T>({
             <tr>
               <td
                 colSpan={columns.length}
-                className="px-4 py-10 text-center text-sm text-zinc-500"
+                className="px-4 py-10 text-center text-sm text-text-secondary"
               >
                 {emptyMessage}
               </td>
@@ -86,13 +86,13 @@ export default function AdminDataTable<T>({
                   key={
                     getRowKey ? getRowKey(row, originalIndex) : originalIndex
                   }
-                  className="group transition-colors duration-200 hover:bg-[var(--color-table-top)]"
+                  className="group transition-colors duration-200 hover:bg-table-top"
                 >
                   {columns.map((column) => (
                     <td
                       key={String(column.key)}
                       className={cn(
-                        'border-b px-4 py-3 text-sm text-zinc-700',
+                        'border-b px-4 py-3 text-sm text-text-primary',
                         column.align === 'center' && 'text-center',
                         column.align === 'left' && 'text-left',
                       )}

--- a/src/components/admin/AdminHeader.tsx
+++ b/src/components/admin/AdminHeader.tsx
@@ -10,15 +10,14 @@ function isAdminPageKey(value: string): value is AdminPageKey {
 
 export default function AdminHeader() {
   const segment = useSelectedLayoutSegment();
-  const page =
-    segment && isAdminPageKey(segment) ? segment : 'dashboard';
+  const page = segment && isAdminPageKey(segment) ? segment : 'dashboard';
   const { title, description } = ADMIN_META[page];
 
   return (
-    <header className="fixed top-0 left-50 right-0 z-50 flex justify-center bg-white shadow-md">
+    <header className="fixed top-0 left-50 right-0 z-50 flex justify-center bg-bg-white shadow-md">
       <div className="w-full max-w-7xl px-6 py-6 space-y-2">
-        <h1 className="text-2xl font-bold text-zinc-950">{title}</h1>
-        <p className="text-sm text-zinc-500">{description}</p>
+        <h1 className="text-2xl font-bold text-text-primary">{title}</h1>
+        <p className="text-sm text-text-secondary">{description}</p>
       </div>
     </header>
   );

--- a/src/components/admin/AdminTablePagination.tsx
+++ b/src/components/admin/AdminTablePagination.tsx
@@ -68,7 +68,7 @@ export default function AdminTablePagination({
   const endItem = Math.min(currentPage * pageSize, totalItems);
 
   return (
-    <footer className="flex flex-col gap-4 border-t border-zinc-200 px-4 py-4 md:flex-row md:items-center md:justify-between">
+    <footer className="flex flex-col gap-4 border-t border-border px-4 py-4 md:flex-row md:items-center md:justify-between">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
         <p className="text-sm text-text-secondary">
           총 {totalItems}개 중 {startItem}-{endItem}개 표시
@@ -77,7 +77,7 @@ export default function AdminTablePagination({
         <label className="flex items-center gap-2 text-sm text-text-secondary">
           페이지당
           <select
-            className="h-9 cursor-pointer rounded-md border border-zinc-200 bg-bg-white px-3 text-sm text-text-primary outline-none transition-colors duration-200 focus:border-btn-focus"
+            className="h-9 cursor-pointer rounded-md border border-border bg-bg-white px-3 text-sm text-text-primary outline-none transition-colors duration-200 focus:border-btn-focus"
             value={pageSize}
             onChange={(event) => onPageSizeChange(Number(event.target.value))}
           >
@@ -100,7 +100,7 @@ export default function AdminTablePagination({
             aria-label="이전 페이지"
             className={cn(
               navigationButtonClass,
-              'cursor-pointer border-zinc-200 bg-bg-white text-btn-text hover:bg-btn-basic',
+              'cursor-pointer border-border bg-bg-white text-btn-text hover:bg-btn-basic',
             )}
             disabled={currentPage === 1}
             onClick={() => onPageChange(currentPage - 1)}
@@ -114,7 +114,7 @@ export default function AdminTablePagination({
                 return (
                   <span
                     key={item}
-                    className="inline-flex h-9 min-w-9 items-center justify-center text-zinc-400"
+                    className="inline-flex h-9 min-w-9 items-center justify-center text-text-secondary"
                   >
                     <MoreHorizontal className="size-4" />
                   </span>
@@ -133,7 +133,7 @@ export default function AdminTablePagination({
                     'cursor-pointer',
                     isActive
                       ? 'border-btn-focus bg-btn-focus text-btn-focus-text'
-                      : 'border-zinc-200 bg-bg-white text-btn-text hover:bg-btn-basic',
+                      : 'border-border bg-bg-white text-btn-text hover:bg-btn-basic',
                   )}
                   onClick={() => onPageChange(item)}
                 >
@@ -148,7 +148,7 @@ export default function AdminTablePagination({
             aria-label="다음 페이지"
             className={cn(
               navigationButtonClass,
-              'cursor-pointer border-zinc-200 bg-bg-white text-btn-text hover:bg-btn-basic',
+              'cursor-pointer border-border bg-bg-white text-btn-text hover:bg-btn-basic',
             )}
             disabled={currentPage === totalPages}
             onClick={() => onPageChange(currentPage + 1)}

--- a/src/components/admin/AdminTableToolbar.tsx
+++ b/src/components/admin/AdminTableToolbar.tsx
@@ -41,7 +41,7 @@ export default function AdminTableToolbar<TFilter extends string>({
                 type="button"
                 onClick={() => onFilterChange(filter.value)}
                 className={cn(
-                  'h-12 min-w-[84px] cursor-pointer rounded-md border px-4 py-2 text-sm font-medium transition-colors duration-200',
+                  'h-12 min-w-21 cursor-pointer rounded-md border px-4 py-2 text-sm font-medium transition-colors duration-200',
                   isActive
                     ? 'bg-btn-focus text-btn-focus-text'
                     : 'bg-btn-bagic text-btn-text hover:bg-btn-focus hover:text-btn-focus-text',

--- a/src/components/admin/competitions/AdminCompetitionPostAction.tsx
+++ b/src/components/admin/competitions/AdminCompetitionPostAction.tsx
@@ -17,7 +17,7 @@ interface AdminCompetitionPostActionProps {
 }
 
 const actionButtonClass =
-  'inline-flex items-center justify-center rounded-md p-2 text-zinc-500 transition-colors duration-200 hover:bg-gray-100 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50';
+  'inline-flex items-center justify-center rounded-md p-2 text-text-secondary transition-colors duration-200 hover:bg-btn-basic cursor-pointer disabled:cursor-not-allowed disabled:opacity-50';
 
 export default function AdminCompetitionPostAction({
   id,

--- a/src/components/admin/competitions/AdminCompetitionsClient.tsx
+++ b/src/components/admin/competitions/AdminCompetitionsClient.tsx
@@ -33,7 +33,7 @@ const COMPETITION_COLUMNS: AdminTableColumn<AdminCompetitionRow>[] = [
     align: 'center',
     render: (row) =>
       row.publish_status === '삭제' ? (
-        <span className="text-sm text-zinc-400">-</span>
+        <span className="text-sm text-text-secondary">-</span>
       ) : (
         <AdminBadge
           label={row.status}

--- a/src/components/admin/dashboard/AdminDashboardCards.tsx
+++ b/src/components/admin/dashboard/AdminDashboardCards.tsx
@@ -14,7 +14,7 @@ interface AdminDashboardCardsProps {
 }
 
 const iconToneClassMap: Record<DashboardCardTone, string> = {
-  slate: 'bg-zinc-100 text-zinc-700 ring-zinc-200',
+  slate: 'bg-btn-basic text-text-primary ring-border',
   blue: 'bg-blue-50 text-blue-600 ring-blue-100',
   green: 'bg-emerald-50 text-emerald-600 ring-emerald-100',
   amber: 'bg-amber-50 text-amber-600 ring-amber-100',
@@ -22,7 +22,7 @@ const iconToneClassMap: Record<DashboardCardTone, string> = {
 };
 
 const topLineClassMap: Record<DashboardCardTone, string> = {
-  slate: 'bg-zinc-900',
+  slate: 'bg-btn-focus',
   blue: 'bg-blue-600',
   green: 'bg-emerald-600',
   amber: 'bg-amber-500',
@@ -40,8 +40,10 @@ function DashboardMetricCard({
 }) {
   const Icon = config.icon;
   const cardClassName = cn(
-    'group relative overflow-hidden rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm transition-transform duration-200',
-    config.href ? 'block cursor-pointer hover:-translate-y-0.5 hover:shadow-md' : '',
+    'group relative overflow-hidden rounded-3xl border border-border bg-bg-white p-6 shadow-sm transition-transform duration-200',
+    config.href
+      ? 'block cursor-pointer hover:-translate-y-0.5 hover:shadow-md'
+      : '',
   );
   const cardContent = (
     <article className={cardClassName}>
@@ -56,14 +58,16 @@ function DashboardMetricCard({
 
       <div className="space-y-3">
         <div className="space-y-1">
-          <p className="text-sm font-medium text-zinc-500">{config.label}</p>
+          <p className="text-sm font-medium text-text-secondary">
+            {config.label}
+          </p>
         </div>
 
         <div className="flex items-end gap-2">
-          <strong className="text-4xl font-semibold tracking-tight text-zinc-950">
+          <strong className="text-4xl font-semibold tracking-tight text-text-primary">
             {numberFormatter.format(value)}
           </strong>
-          <span className="pb-1 text-sm font-medium text-zinc-500">
+          <span className="pb-1 text-sm font-medium text-text-secondary">
             {config.suffix}
           </span>
         </div>
@@ -101,10 +105,10 @@ function DashboardSection({
   return (
     <section className="space-y-5">
       <div className="space-y-1 px-1">
-        <h2 className="text-xl font-semibold tracking-tight text-zinc-950">
+        <h2 className="text-xl font-semibold tracking-tight text-text-primary">
           {title}
         </h2>
-        <p className="text-sm text-zinc-500">{description}</p>
+        <p className="text-sm text-text-secondary">{description}</p>
       </div>
 
       <div className={cn('grid gap-4', columnsClassName)}>

--- a/src/components/admin/dashboard/AdminDashboardCards.tsx
+++ b/src/components/admin/dashboard/AdminDashboardCards.tsx
@@ -14,7 +14,7 @@ interface AdminDashboardCardsProps {
 }
 
 const iconToneClassMap: Record<DashboardCardTone, string> = {
-  slate: 'bg-btn-basic text-text-primary ring-border',
+  slate: 'bg-gray-100 text-gray-700 ring-gray-200',
   blue: 'bg-blue-50 text-blue-600 ring-blue-100',
   green: 'bg-emerald-50 text-emerald-600 ring-emerald-100',
   amber: 'bg-amber-50 text-amber-600 ring-amber-100',
@@ -40,7 +40,7 @@ function DashboardMetricCard({
 }) {
   const Icon = config.icon;
   const cardClassName = cn(
-    'group relative overflow-hidden rounded-3xl border border-border bg-bg-white p-6 shadow-sm transition-transform duration-200',
+    'group relative overflow-hidden rounded-3xl border border-border bg-bg-page p-6 shadow-sm transition-transform duration-200',
     config.href
       ? 'block cursor-pointer hover:-translate-y-0.5 hover:shadow-md'
       : '',

--- a/src/components/admin/posts/AdminPostsActions.tsx
+++ b/src/components/admin/posts/AdminPostsActions.tsx
@@ -38,9 +38,9 @@ export default function AdminPostActions({
   const isDeleted = Boolean(deleted_at);
   const canViewDetail = status !== 'hidden';
   const actionButtonClass =
-    'inline-flex items-center justify-center rounded-md p-2 text-zinc-500 transition-colors duration-200 hover:bg-gray-100 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50';
+    'inline-flex items-center justify-center rounded-md p-2 text-text-secondary transition-colors duration-200 hover:bg-btn-basic cursor-pointer disabled:cursor-not-allowed disabled:opacity-50';
   const actionPlaceholderClass =
-    'inline-flex h-[34px] w-[34px] items-center justify-center text-sm text-zinc-400';
+    'inline-flex h-[34px] w-[34px] items-center justify-center text-sm text-text-secondary';
 
   const handleView = () => {
     window.open(ROUTES.COMMUNITY_DETAIL(id), '_blank', 'noopener,noreferrer');

--- a/src/components/admin/support/AdminSupportDojangActions.tsx
+++ b/src/components/admin/support/AdminSupportDojangActions.tsx
@@ -45,11 +45,9 @@ const actionButtonClass =
 
 function DetailItem({ label, value }: DetailItemProps) {
   return (
-    <div className="grid grid-cols-[104px_minmax(0,1fr)] items-start gap-3 rounded-lg bg-btn-basic px-4 py-3">
-      <dt className="text-sm font-medium text-text-secondary">{label}</dt>
-      <dd className="min-w-0 text-sm text-text-primary wrap-break-word">
-        {value}
-      </dd>
+    <div className="grid grid-cols-[104px_minmax(0,1fr)] items-start gap-3 rounded-lg bg-gray-100 px-4 py-3">
+      <dt className="text-sm font-medium text-gray-500">{label}</dt>
+      <dd className="min-w-0 text-sm text-gray-800 wrap-break-word">{value}</dd>
     </div>
   );
 }
@@ -102,7 +100,7 @@ export default function AdminSupportDojangActions({
 
         <DialogContent className="sm:max-w-2xl">
           <DialogHeader className="gap-3">
-            <DialogTitle className="text-xl font-semibold text-text-primary">
+            <DialogTitle className="text-xl font-semibold text-gray-900">
               {row.dojang_name}
             </DialogTitle>
             <DialogDescription className="flex items-center gap-2">
@@ -110,14 +108,14 @@ export default function AdminSupportDojangActions({
                 label={row.status}
                 variant={DOJANG_STATUS_BADGE_VARIANT_MAP[row.status]}
               />
-              <span className="text-sm text-text-secondary">
+              <span className="text-sm text-gray-500">
                 요청일 {row.requested_at}
               </span>
             </DialogDescription>
           </DialogHeader>
 
           <section className="space-y-3">
-            <h3 className="text-sm font-semibold text-text-primary">
+            <h3 className="text-sm font-semibold text-gray-900">
               도장 인증 정보
             </h3>
 
@@ -167,7 +165,7 @@ export default function AdminSupportDojangActions({
                   })
                 }
                 disabled={isPending}
-                className={`${actionButtonClass} h-9 border-green-200 bg-green-50 px-3 text-green-700 hover:bg-green-100`}
+                className="h-9 rounded-md border border-green-300 bg-green-200 px-3 text-sm font-medium text-green-700 hover:bg-green-400 hover:text-white transition-colors duration-200 cursor-pointer"
               >
                 승인
               </button>
@@ -186,7 +184,7 @@ export default function AdminSupportDojangActions({
                   })
                 }
                 disabled={isPending}
-                className={`${actionButtonClass} h-9 border-red-200 bg-red-50 px-3 text-red-600 hover:bg-red-100`}
+                className="h-9 rounded-md border border-red-300 bg-red-200 px-3 text-sm font-medium text-red-700 hover:bg-red-400 hover:text-white transition-colors duration-200 cursor-pointer"
               >
                 거부
               </button>
@@ -210,7 +208,7 @@ export default function AdminSupportDojangActions({
                   })
                 }
                 disabled={isPending}
-                className={`${actionButtonClass} h-9 border-amber-200 bg-amber-50 px-3 text-amber-700 hover:bg-amber-100`}
+                className="h-9 rounded-md border border-amber-300 bg-amber-200 px-3 text-sm font-medium text-amber-700 hover:bg-amber-400 hover:text-white transition-colors duration-200 cursor-pointer"
               >
                 승인 취소
               </button>
@@ -229,7 +227,7 @@ export default function AdminSupportDojangActions({
                   })
                 }
                 disabled={isPending}
-                className={`${actionButtonClass} h-9 border-red-200 bg-red-50 px-3 text-red-600 hover:bg-red-100`}
+                className="h-9 rounded-md border border-red-300 bg-red-200 px-3 text-sm font-medium text-red-700 hover:bg-red-400 hover:text-white transition-colors duration-200 cursor-pointer"
               >
                 거부
               </button>
@@ -253,7 +251,7 @@ export default function AdminSupportDojangActions({
                   })
                 }
                 disabled={isPending}
-                className={`${actionButtonClass} h-9 border-blue-200 bg-blue-50 px-3 text-blue-700 hover:bg-blue-100`}
+                className="h-9 rounded-md border border-blue-300 bg-blue-200 px-3 text-sm font-medium text-blue-700 hover:bg-blue-400 hover:text-white transition-colors duration-200 cursor-pointer"
               >
                 재검토
               </button>
@@ -272,7 +270,7 @@ export default function AdminSupportDojangActions({
                   })
                 }
                 disabled={isPending}
-                className={`${actionButtonClass} h-9 border-green-200 bg-green-50 px-3 text-green-700 hover:bg-green-100`}
+                className="h-9 rounded-md border border-green-300 bg-green-200 px-3 text-sm font-medium text-green-700 hover:bg-green-400 hover:text-white transition-colors duration-200 cursor-pointer"
               >
                 승인
               </button>

--- a/src/components/admin/support/AdminSupportDojangActions.tsx
+++ b/src/components/admin/support/AdminSupportDojangActions.tsx
@@ -41,13 +41,15 @@ type ConfirmDojangAction = {
 } | null;
 
 const actionButtonClass =
-  'inline-flex items-center justify-center rounded-md p-2 text-zinc-500 transition-colors duration-200 hover:bg-gray-100 cursor-pointer';
+  'inline-flex items-center justify-center rounded-md p-2 text-text-secondary transition-colors duration-200 hover:bg-btn-basic cursor-pointer';
 
 function DetailItem({ label, value }: DetailItemProps) {
   return (
-    <div className="grid grid-cols-[104px_minmax(0,1fr)] items-start gap-3 rounded-lg bg-zinc-50 px-4 py-3">
-      <dt className="text-sm font-medium text-zinc-500">{label}</dt>
-      <dd className="min-w-0 text-sm text-zinc-800 break-words">{value}</dd>
+    <div className="grid grid-cols-[104px_minmax(0,1fr)] items-start gap-3 rounded-lg bg-btn-basic px-4 py-3">
+      <dt className="text-sm font-medium text-text-secondary">{label}</dt>
+      <dd className="min-w-0 text-sm text-text-primary wrap-break-word">
+        {value}
+      </dd>
     </div>
   );
 }
@@ -100,7 +102,7 @@ export default function AdminSupportDojangActions({
 
         <DialogContent className="sm:max-w-2xl">
           <DialogHeader className="gap-3">
-            <DialogTitle className="text-xl font-semibold text-zinc-900">
+            <DialogTitle className="text-xl font-semibold text-text-primary">
               {row.dojang_name}
             </DialogTitle>
             <DialogDescription className="flex items-center gap-2">
@@ -108,14 +110,14 @@ export default function AdminSupportDojangActions({
                 label={row.status}
                 variant={DOJANG_STATUS_BADGE_VARIANT_MAP[row.status]}
               />
-              <span className="text-sm text-zinc-500">
+              <span className="text-sm text-text-secondary">
                 요청일 {row.requested_at}
               </span>
             </DialogDescription>
           </DialogHeader>
 
           <section className="space-y-3">
-            <h3 className="text-sm font-semibold text-zinc-900">
+            <h3 className="text-sm font-semibold text-text-primary">
               도장 인증 정보
             </h3>
 

--- a/src/components/admin/support/AdminSupportReportActions.tsx
+++ b/src/components/admin/support/AdminSupportReportActions.tsx
@@ -42,15 +42,17 @@ type ConfirmReportAction = {
 } | null;
 
 const actionButtonClass =
-  'inline-flex items-center justify-center rounded-md p-2 text-zinc-500 transition-colors duration-200 hover:bg-gray-100 cursor-pointer';
+  'inline-flex items-center justify-center rounded-md p-2 text-text-secondary transition-colors duration-200 hover:bg-btn-basic cursor-pointer';
 const actionPlaceholderClass =
-  'inline-flex h-[34px] w-[34px] items-center justify-center text-sm text-zinc-400';
+  'inline-flex h-[34px] w-[34px] items-center justify-center text-sm text-text-secondary';
 
 function DetailItem({ label, value }: DetailItemProps) {
   return (
-    <div className="grid grid-cols-[104px_minmax(0,1fr)] items-start gap-3 rounded-lg bg-zinc-50 px-4 py-3">
-      <dt className="text-sm font-medium text-zinc-500">{label}</dt>
-      <dd className="min-w-0 text-sm text-zinc-800 break-words">{value}</dd>
+    <div className="grid grid-cols-[104px_minmax(0,1fr)] items-start gap-3 rounded-lg bg-btn-basic px-4 py-3">
+      <dt className="text-sm font-medium text-text-secondary">{label}</dt>
+      <dd className="min-w-0 text-sm text-text-primary wrap-break-word">
+        {value}
+      </dd>
     </div>
   );
 }
@@ -155,10 +157,10 @@ export default function AdminSupportReportActions({
 
         <DialogContent className="sm:max-w-2xl">
           <DialogHeader className="gap-3">
-            <DialogTitle className="text-xl font-semibold text-zinc-900">
+            <DialogTitle className="text-xl font-semibold text-text-primary">
               신고 상세
             </DialogTitle>
-            <DialogDescription className="text-sm text-zinc-500">
+            <DialogDescription className="text-sm text-text-secondary">
               신고 상태와 처리 결과를 확인하세요.
             </DialogDescription>
           </DialogHeader>
@@ -184,7 +186,7 @@ export default function AdminSupportReportActions({
                 label="처리 결과"
                 value={
                   row.action_result === '-' ? (
-                    <span className="text-sm text-zinc-400">-</span>
+                    <span className="text-sm text-text-secondary">-</span>
                   ) : (
                     <AdminBadge
                       label={row.action_result}
@@ -213,7 +215,7 @@ export default function AdminSupportReportActions({
                   })
                 }
                 disabled={isSubmitting}
-                className={`${actionButtonClass} h-9 border-zinc-200 bg-zinc-50 px-3 text-zinc-700 hover:bg-zinc-100`}
+                className={`${actionButtonClass} h-9 border-border bg-btn-basic px-3 text-text-primary hover:bg-btn-basic`}
               >
                 문제 없음 처리
               </button>

--- a/src/components/admin/support/AdminSupportReportActions.tsx
+++ b/src/components/admin/support/AdminSupportReportActions.tsx
@@ -48,11 +48,9 @@ const actionPlaceholderClass =
 
 function DetailItem({ label, value }: DetailItemProps) {
   return (
-    <div className="grid grid-cols-[104px_minmax(0,1fr)] items-start gap-3 rounded-lg bg-btn-basic px-4 py-3">
-      <dt className="text-sm font-medium text-text-secondary">{label}</dt>
-      <dd className="min-w-0 text-sm text-text-primary wrap-break-word">
-        {value}
-      </dd>
+    <div className="grid grid-cols-[104px_minmax(0,1fr)] items-start gap-3 rounded-lg bg-gray-100 px-4 py-3">
+      <dt className="text-sm font-medium text-gray-500">{label}</dt>
+      <dd className="min-w-0 text-sm text-gray-800 wrap-break-word">{value}</dd>
     </div>
   );
 }
@@ -157,10 +155,10 @@ export default function AdminSupportReportActions({
 
         <DialogContent className="sm:max-w-2xl">
           <DialogHeader className="gap-3">
-            <DialogTitle className="text-xl font-semibold text-text-primary">
+            <DialogTitle className="text-xl font-semibold text-gray-900">
               신고 상세
             </DialogTitle>
-            <DialogDescription className="text-sm text-text-secondary">
+            <DialogDescription className="text-sm text-gray-500">
               신고 상태와 처리 결과를 확인하세요.
             </DialogDescription>
           </DialogHeader>
@@ -186,7 +184,7 @@ export default function AdminSupportReportActions({
                 label="처리 결과"
                 value={
                   row.action_result === '-' ? (
-                    <span className="text-sm text-text-secondary">-</span>
+                    <span className="text-sm text-gray-500">-</span>
                   ) : (
                     <AdminBadge
                       label={row.action_result}
@@ -215,7 +213,7 @@ export default function AdminSupportReportActions({
                   })
                 }
                 disabled={isSubmitting}
-                className={`${actionButtonClass} h-9 border-border bg-btn-basic px-3 text-text-primary hover:bg-btn-basic`}
+                className={`h-9 border border-gray-300 bg-gray-300 px-3 text-gray-700 hover:bg-gray-400 hover:text-white rounded-md text-sm font-medium cursor-pointer`}
               >
                 문제 없음 처리
               </button>
@@ -231,7 +229,7 @@ export default function AdminSupportReportActions({
                   })
                 }
                 disabled={isSubmitting}
-                className={`${actionButtonClass} h-9 border-blue-200 bg-blue-50 px-3 text-blue-700 hover:bg-blue-100`}
+                className={`h-9 border border-blue-300 bg-blue-300 px-3 text-blue-700 hover:bg-blue-400 hover:text-white rounded-md text-sm font-medium cursor-pointer`}
               >
                 게시글 숨김 처리
               </button>
@@ -247,7 +245,7 @@ export default function AdminSupportReportActions({
                   })
                 }
                 disabled={isSubmitting}
-                className={`${actionButtonClass} h-9 border-red-200 bg-red-50 px-3 text-red-600 hover:bg-red-100`}
+                className={`h-9 border border-red-300 bg-red-300 px-3 text-red-700 hover:bg-red-400 hover:text-white rounded-md text-sm font-medium cursor-pointer`}
               >
                 게시글 삭제 처리
               </button>

--- a/src/components/admin/support/AdminSupportTableClient.tsx
+++ b/src/components/admin/support/AdminSupportTableClient.tsx
@@ -99,16 +99,15 @@ const REPORT_COLUMNS: AdminTableColumn<AdminReportRow>[] = [
     width: '11%',
     align: 'center',
     truncate: false,
-    render: (row) => (
+    render: (row) =>
       row.action_result === '-' ? (
-        <span className="text-sm text-zinc-400">-</span>
+        <span className="text-sm text-text-secondary">-</span>
       ) : (
         <AdminBadge
           label={row.action_result}
           variant={REPORT_ACTION_BADGE_VARIANT_MAP[row.action_result]}
         />
-      )
-    ),
+      ),
   },
   { key: 'handled_at', header: '처리 날짜', width: '11%', align: 'center' },
   {
@@ -144,9 +143,7 @@ export default function AdminSupportTableClient({
   };
 
   const searchPlaceholder =
-    activeSection === 'dojang'
-      ? '도장명, 주소 검색...'
-      : '게시글 제목 검색...';
+    activeSection === 'dojang' ? '도장명, 주소 검색...' : '게시글 제목 검색...';
 
   return (
     <>

--- a/src/components/admin/users/AdminUserActions.tsx
+++ b/src/components/admin/users/AdminUserActions.tsx
@@ -37,15 +37,13 @@ interface DetailItemProps {
 }
 
 const actionButtonClass =
-  'inline-flex items-center justify-center rounded-md p-2 text-text-secondary transition-colors duration-200 hover:bg-btn-basic cursor-pointer disabled:cursor-not-allowed disabled:opacity-50';
+  'inline-flex items-center justify-center rounded-md p-2 text-gray-500 transition-colors duration-200 hover:bg-btn-basic cursor-pointer disabled:cursor-not-allowed disabled:opacity-50';
 
 function DetailItem({ label, value }: DetailItemProps) {
   return (
-    <div className="grid grid-cols-[104px_minmax(0,1fr)] items-start gap-3 rounded-lg bg-btn-basic px-4 py-3">
-      <dt className="text-sm font-medium text-text-secondary">{label}</dt>
-      <dd className="min-w-0 text-sm text-text-primary wrap-break-word">
-        {value}
-      </dd>
+    <div className="grid grid-cols-[104px_minmax(0,1fr)] items-start gap-3 rounded-lg bg-gray-100 px-4 py-3">
+      <dt className="text-sm font-medium text-gray-500">{label}</dt>
+      <dd className="min-w-0 text-sm text-gray-800 wrap-break-word">{value}</dd>
     </div>
   );
 }
@@ -72,7 +70,7 @@ function UserAvatar({
 
   return (
     <div
-      className={`${sizeClassName} flex shrink-0 items-center justify-center rounded-full bg-btn-basic text-sm font-semibold text-text-secondary`}
+      className={`${sizeClassName} flex shrink-0 items-center justify-center rounded-full bg-btn-basic text-sm font-semibold text-gray-500`}
       aria-hidden="true"
     >
       {nickname.slice(0, 1)}
@@ -136,7 +134,7 @@ export default function AdminUserActions({ user }: AdminUserActionsProps) {
 
               <div className="space-y-2">
                 <div className="flex flex-wrap items-center gap-2">
-                  <DialogTitle className="text-xl font-semibold text-text-primary">
+                  <DialogTitle className="text-xl font-semibold text-gray-900">
                     {user.nickname}
                   </DialogTitle>
 
@@ -153,7 +151,7 @@ export default function AdminUserActions({ user }: AdminUserActionsProps) {
                   />
                 </div>
 
-                <DialogDescription className="text-sm text-text-secondary">
+                <DialogDescription className="text-sm text-gray-500">
                   {user.email}
                 </DialogDescription>
               </div>
@@ -162,9 +160,7 @@ export default function AdminUserActions({ user }: AdminUserActionsProps) {
 
           <div className="space-y-5">
             <section className="space-y-3">
-              <h3 className="text-sm font-semibold text-text-primary">
-                기본 정보
-              </h3>
+              <h3 className="text-sm font-semibold text-gray-900">기본 정보</h3>
 
               <dl className="space-y-2">
                 <DetailItem label="이름" value={user.name} />
@@ -182,7 +178,7 @@ export default function AdminUserActions({ user }: AdminUserActionsProps) {
 
             {user.user_type === '도장' ? (
               <section className="space-y-3">
-                <h3 className="text-sm font-semibold text-text-primary">
+                <h3 className="text-sm font-semibold text-gray-900">
                   도장 정보
                 </h3>
 

--- a/src/components/admin/users/AdminUserActions.tsx
+++ b/src/components/admin/users/AdminUserActions.tsx
@@ -37,13 +37,15 @@ interface DetailItemProps {
 }
 
 const actionButtonClass =
-  'inline-flex items-center justify-center rounded-md p-2 text-zinc-500 transition-colors duration-200 hover:bg-gray-100 cursor-pointer disabled:cursor-not-allowed disabled:opacity-50';
+  'inline-flex items-center justify-center rounded-md p-2 text-text-secondary transition-colors duration-200 hover:bg-btn-basic cursor-pointer disabled:cursor-not-allowed disabled:opacity-50';
 
 function DetailItem({ label, value }: DetailItemProps) {
   return (
-    <div className="grid grid-cols-[104px_minmax(0,1fr)] items-start gap-3 rounded-lg bg-zinc-50 px-4 py-3">
-      <dt className="text-sm font-medium text-zinc-500">{label}</dt>
-      <dd className="min-w-0 text-sm text-zinc-800 break-words">{value}</dd>
+    <div className="grid grid-cols-[104px_minmax(0,1fr)] items-start gap-3 rounded-lg bg-btn-basic px-4 py-3">
+      <dt className="text-sm font-medium text-text-secondary">{label}</dt>
+      <dd className="min-w-0 text-sm text-text-primary wrap-break-word">
+        {value}
+      </dd>
     </div>
   );
 }
@@ -70,7 +72,7 @@ function UserAvatar({
 
   return (
     <div
-      className={`${sizeClassName} flex shrink-0 items-center justify-center rounded-full bg-zinc-100 text-sm font-semibold text-zinc-500`}
+      className={`${sizeClassName} flex shrink-0 items-center justify-center rounded-full bg-btn-basic text-sm font-semibold text-text-secondary`}
       aria-hidden="true"
     >
       {nickname.slice(0, 1)}
@@ -134,7 +136,7 @@ export default function AdminUserActions({ user }: AdminUserActionsProps) {
 
               <div className="space-y-2">
                 <div className="flex flex-wrap items-center gap-2">
-                  <DialogTitle className="text-xl font-semibold text-zinc-900">
+                  <DialogTitle className="text-xl font-semibold text-text-primary">
                     {user.nickname}
                   </DialogTitle>
 
@@ -151,7 +153,7 @@ export default function AdminUserActions({ user }: AdminUserActionsProps) {
                   />
                 </div>
 
-                <DialogDescription className="text-sm text-zinc-500">
+                <DialogDescription className="text-sm text-text-secondary">
                   {user.email}
                 </DialogDescription>
               </div>
@@ -160,7 +162,9 @@ export default function AdminUserActions({ user }: AdminUserActionsProps) {
 
           <div className="space-y-5">
             <section className="space-y-3">
-              <h3 className="text-sm font-semibold text-zinc-900">기본 정보</h3>
+              <h3 className="text-sm font-semibold text-text-primary">
+                기본 정보
+              </h3>
 
               <dl className="space-y-2">
                 <DetailItem label="이름" value={user.name} />
@@ -178,7 +182,7 @@ export default function AdminUserActions({ user }: AdminUserActionsProps) {
 
             {user.user_type === '도장' ? (
               <section className="space-y-3">
-                <h3 className="text-sm font-semibold text-zinc-900">
+                <h3 className="text-sm font-semibold text-text-primary">
                   도장 정보
                 </h3>
 

--- a/src/components/admin/users/AdminUsersClient.tsx
+++ b/src/components/admin/users/AdminUsersClient.tsx
@@ -44,7 +44,7 @@ function UserAvatarCell({
 
   return (
     <div
-      className="mx-auto flex aspect-square w-[clamp(2.25rem,3vw,2.75rem)] items-center justify-center rounded-full bg-zinc-100 text-sm font-semibold text-zinc-500"
+      className="mx-auto flex aspect-square w-[clamp(2.25rem,3vw,2.75rem)] items-center justify-center rounded-full bg-btn-basic text-sm font-semibold text-text-secondary"
       aria-hidden="true"
     >
       {nickname.slice(0, 1)}
@@ -72,12 +72,15 @@ const USER_COLUMNS: AdminTableColumn<AdminUserRow>[] = [
     render: (row) => (
       <div className="flex min-w-0 flex-col gap-1">
         <span
-          className="block truncate text-[15px] font-semibold text-zinc-950"
+          className="block truncate text-[15px] font-semibold text-text-primary"
           title={row.nickname}
         >
           {row.nickname}
         </span>
-        <span className="block truncate text-sm text-zinc-500" title={row.name}>
+        <span
+          className="block truncate text-sm text-text-secondary"
+          title={row.name}
+        >
           {row.name}
         </span>
       </div>
@@ -135,7 +138,7 @@ const USER_COLUMNS: AdminTableColumn<AdminUserRow>[] = [
           }
         />
       ) : (
-        <span className="text-zinc-400">-</span>
+        <span className="text-text-secondary">-</span>
       ),
   },
   { key: 'joined_at', header: '가입일', width: '10%', align: 'center' },

--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -25,10 +25,10 @@ const confirmButtonVariantClassMap: Record<
   NonNullable<ConfirmModalProps['confirmVariant']>,
   string
 > = {
-  default: 'bg-black text-white hover:bg-gray-700',
-  danger: 'bg-red-600 text-white hover:bg-red-700',
-  success: 'bg-green-600 text-white hover:bg-green-700',
-  warning: 'bg-amber-500 text-white hover:bg-amber-600',
+  default: 'bg-btn-focus text-btn-focus-text hover:opacity-80',
+  danger: 'bg-danger text-btn-focus-text hover:opacity-80',
+  success: 'bg-state-green-text text-white hover:opacity-80',
+  warning: 'bg-state-yellow text-white hover:opacity-80',
 };
 
 export default function ConfirmModal({
@@ -54,7 +54,7 @@ export default function ConfirmModal({
             type="button"
             onClick={onClose}
             disabled={disabled}
-            className="flex-1 rounded-lg bg-gray-100 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-50"
+            className="flex-1 rounded-lg bg-btn-basic py-2 text-sm font-medium text-btn-text transition-colors hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {cancelLabel}
           </button>

--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -26,7 +26,7 @@ const confirmButtonVariantClassMap: Record<
   string
 > = {
   default: 'bg-btn-focus text-btn-focus-text hover:opacity-80',
-  danger: 'bg-danger text-btn-focus-text hover:opacity-80',
+  danger: 'bg-danger text-white hover:opacity-80',
   success: 'bg-state-green-text text-white hover:opacity-80',
   warning: 'bg-state-yellow text-white hover:opacity-80',
 };
@@ -54,7 +54,7 @@ export default function ConfirmModal({
             type="button"
             onClick={onClose}
             disabled={disabled}
-            className="flex-1 rounded-lg bg-btn-basic py-2 text-sm font-medium text-btn-text transition-colors hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-50"
+            className="flex-1 rounded-lg bg-btn-basic border border-border py-2 text-sm font-medium text-btn-text transition-colors hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {cancelLabel}
           </button>

--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -25,11 +25,11 @@ export default class ErrorBoundary extends Component<Props, State> {
     if (this.state.hasError) {
       return (
         this.props.fallback ?? (
-          <div className="flex flex-col items-center justify-center py-16 text-gray-400">
+          <div className="flex flex-col items-center justify-center py-16 text-text-secondary">
             <p className="text-sm">오류가 발생했습니다.</p>
             <button
               onClick={() => this.setState({ hasError: false })}
-              className="mt-4 px-4 py-2 text-sm border rounded-lg hover:bg-gray-100"
+              className="mt-4 px-4 py-2 text-sm border border-border rounded-lg hover:bg-btn-basic text-text-primary"
             >
               다시 시도
             </button>

--- a/src/components/common/LimitedInput.tsx
+++ b/src/components/common/LimitedInput.tsx
@@ -43,18 +43,18 @@ export function LimitedInput({
     ? 'text-red-500'
     : isWarn
       ? 'text-yellow-500'
-      : 'text-gray-400';
+      : 'text-text-secondary';
 
   const borderColor = isError
     ? 'border-red-400 focus:ring-red-400'
     : isWarn
       ? 'border-yellow-400 focus:ring-yellow-400'
-      : 'border-gray-300 focus:ring-blue-400';
+      : 'border-border focus:ring-btn-focus';
 
   return (
     <div className={className}>
       {label && (
-        <label className="block text-sm font-medium text-gray-700 mb-1">
+        <label className="block text-sm font-medium text-text-primary mb-1">
           {label}
         </label>
       )}
@@ -70,7 +70,7 @@ export function LimitedInput({
           maxLength={maxLength}
           className={`w-full pr-20 px-3 py-2 text-sm border rounded-lg
             focus:outline-none focus:ring-1 transition-colors
-            disabled:bg-gray-50 disabled:text-gray-400
+            disabled:bg-btn-basic disabled:text-text-secondary
             ${borderColor}`}
         />
         <span

--- a/src/components/common/LimitedTextarea.tsx
+++ b/src/components/common/LimitedTextarea.tsx
@@ -57,18 +57,18 @@ export function LimitedTextarea({
     ? 'text-red-500'
     : isWarn
       ? 'text-yellow-500'
-      : 'text-gray-400';
+      : 'text-text-secondary';
 
   const borderColor = isError
     ? 'border-red-400 focus:ring-red-400'
     : isWarn
       ? 'border-yellow-400 focus:ring-yellow-400'
-      : 'border-gray-300 focus:ring-blue-400';
+      : 'border-border focus:ring-btn-focus';
 
   return (
     <div className={className}>
       {label && (
-        <label className="block text-sm font-medium text-gray-700 mb-1">
+        <label className="block text-sm font-medium text-text-primary mb-1">
           {label}
         </label>
       )}
@@ -83,7 +83,7 @@ export function LimitedTextarea({
           rows={rows}
           className={`w-full px-3 py-2 pb-6 text-sm border rounded-lg resize-none
             focus:outline-none focus:ring-1 transition-colors
-            disabled:bg-gray-50 disabled:text-gray-400
+            disabled:bg-btn-basic disabled:text-text-secondary
             ${borderColor}`}
         />
         <span className={`absolute right-3 bottom-2 text-xs ${counterColor}`}>

--- a/src/components/common/LoadingSpinner.tsx
+++ b/src/components/common/LoadingSpinner.tsx
@@ -2,7 +2,7 @@ export default function LoadingSpinner() {
   return (
     <div className="col-span-2 flex items-center justify-center py-20">
       <div
-        className="w-8 h-8 border-4 border-gray-200 border-t-btn-focus rounded-full animate-spin"
+        className="w-8 h-8 border-4 border-border border-t-btn-focus rounded-full animate-spin"
         aria-label="로딩 중"
       />
     </div>

--- a/src/components/common/ScrollToTop.tsx
+++ b/src/components/common/ScrollToTop.tsx
@@ -32,7 +32,7 @@ export default function ScrollToTop() {
       {!isTop && (
         <button
           onClick={scrollToTop}
-          className="w-12 h-12 bg-gray-300 text-gray-600 rounded-full flex items-center justify-center cursor-pointer hover:bg-btn-focus hover:text-btn-focus-text transition-all"
+          className="w-12 h-12 bg-btn-basic text-btn-text rounded-full flex items-center justify-center cursor-pointer hover:bg-btn-focus hover:text-btn-focus-text transition-all border border-border-custom"
         >
           <ArrowUp size={20} />
         </button>
@@ -40,7 +40,7 @@ export default function ScrollToTop() {
       {!isBottom && (
         <button
           onClick={scrollToBottom}
-          className="w-12 h-12 bg-gray-300 text-gray-600 rounded-full flex items-center justify-center cursor-pointer hover:bg-btn-focus hover:text-btn-focus-text transition-all"
+          className="w-12 h-12 bg-btn-basic text-btn-text rounded-full flex items-center justify-center cursor-pointer hover:bg-btn-focus hover:text-btn-focus-text transition-all border border-border-custom"
         >
           <ArrowDown size={20} />
         </button>

--- a/src/components/common/SearchInput.tsx
+++ b/src/components/common/SearchInput.tsx
@@ -23,7 +23,7 @@ export default function SearchInput({
       <Input
         placeholder={placeholder}
         aria-label="검색"
-        className="pl-9 flex-1 h-12 bg-input-bg"
+        className="pl-9 flex-1 h-12 bg-input-bg text-text-primary placeholder:text-text-secondary"
         value={searchQuery}
         onChange={(e) => setSearchQuery(e.target.value)}
       />

--- a/src/components/community/CommunityClient.tsx
+++ b/src/components/community/CommunityClient.tsx
@@ -92,7 +92,7 @@ export default function CommunityClient({
     <main className="w-full min-h-screen" aria-label="커뮤니티 게시글 목록">
       <div
         ref={headerRef}
-        className="fixed top-0 left-50 right-0 z-10 bg-white shadow-sm flex justify-center"
+        className="fixed top-0 left-50 right-0 z-10 bg-bg-white shadow-sm flex justify-center"
       >
         <div className="w-full max-w-7xl px-6">
           <Pageheader

--- a/src/components/community/EditClient.tsx
+++ b/src/components/community/EditClient.tsx
@@ -71,11 +71,11 @@ export default function EditClient({ id, initialPost }: Props) {
         <h1 className="text-lg font-semibold mx-auto">게시글 수정</h1>
       </div>
 
-      <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
-        <p className="text-sm text-gray-500 mb-2">게시글 유형</p>
+      <div className="bg-bg-white rounded-xl p-4 mb-4 shadow-sm">
+        <p className="text-sm text-text-secondary mb-2">게시글 유형</p>
         <div
           aria-label={`게시글 유형: ${category === 'promo' ? '도장 홍보' : category === 'notice' ? '공지' : '일반 게시글'}`}
-          className="py-2 px-3 rounded-lg text-sm font-medium bg-black text-white text-center"
+          className="py-2 px-3 rounded-lg text-sm font-medium bg-btn-focus text-btn-focus-text text-center"
         >
           {category === 'promo'
             ? '도장 홍보'
@@ -85,10 +85,10 @@ export default function EditClient({ id, initialPost }: Props) {
         </div>
       </div>
 
-      <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
+      <div className="bg-bg-white rounded-xl p-4 mb-4 shadow-sm">
         <label
           htmlFor="post-title"
-          className="text-sm text-gray-500 mb-2 block"
+          className="text-sm text-text-secondary mb-2 block"
         >
           제목
         </label>
@@ -109,10 +109,10 @@ export default function EditClient({ id, initialPost }: Props) {
         }}
       />
 
-      <div className="bg-white rounded-xl p-4 mb-6 shadow-sm">
+      <div className="bg-bg-white rounded-xl p-4 mb-6 shadow-sm">
         <label
           htmlFor="post-content"
-          className="text-sm text-gray-500 mb-2 block"
+          className="text-sm text-text-secondary mb-2 block"
         >
           내용
         </label>

--- a/src/components/community/ImageUpload.tsx
+++ b/src/components/community/ImageUpload.tsx
@@ -21,8 +21,8 @@ export default function ImageUpload({
   };
 
   return (
-    <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
-      <p className="text-sm text-gray-500 mb-2">{label}</p>
+    <div className="bg-bg-white rounded-xl p-4 mb-4 shadow-sm">
+      <p className="text-sm text-text-secondary mb-2">{label}</p>
       <label className="block cursor-pointer">
         {preview ? (
           <div className="relative w-full h-48 rounded-lg overflow-hidden">
@@ -34,10 +34,14 @@ export default function ImageUpload({
             />
           </div>
         ) : (
-          <div className="flex flex-col items-center justify-center h-32 bg-gray-50 rounded-lg border-2 border-dashed border-gray-200">
+          <div className="flex flex-col items-center justify-center h-32 bg-btn-basic rounded-lg border-2 border-dashed border-border">
             <span className="text-2xl mb-1">↑</span>
-            <p className="text-sm text-gray-500">클릭하여 이미지 업로드</p>
-            <p className="text-xs text-gray-400">JPG, PNG, GIF (최대 10MB)</p>
+            <p className="text-sm text-text-secondary">
+              클릭하여 이미지 업로드
+            </p>
+            <p className="text-xs text-text-secondary">
+              JPG, PNG, GIF (최대 10MB)
+            </p>
           </div>
         )}
         <input

--- a/src/components/community/PostDetailCard.tsx
+++ b/src/components/community/PostDetailCard.tsx
@@ -33,13 +33,13 @@ export default function PostDetailCard({
       ? { label: '도장', className: 'bg-blue-50 text-blue-600' }
       : post.role === 'admin'
         ? { label: '관리자', className: 'bg-red-50 text-red-600' }
-        : { label: '일반', className: 'bg-gray-100 text-gray-600' };
+        : { label: '일반', className: 'bg-btn-basic text-btn-text' };
 
   return (
-    <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden">
+    <div className="bg-bg-white rounded-2xl shadow-sm border border-border overflow-hidden">
       <div className="flex items-center justify-between px-5 pt-5 pb-4">
         <div className="flex items-center gap-3">
-          <div className="w-10 h-10 rounded-full bg-gray-200 overflow-hidden shrink-0">
+          <div className="w-10 h-10 rounded-full bg-btn-basic overflow-hidden shrink-0">
             {post.avatar_url && (
               <Image
                 src={post.avatar_url}
@@ -52,7 +52,7 @@ export default function PostDetailCard({
           </div>
           <div>
             <div className="flex items-center gap-1.5">
-              <span className="text-sm font-semibold text-gray-900">
+              <span className="text-sm font-semibold text-text-primary">
                 {post.nickname}
               </span>
               {post.role && (
@@ -63,7 +63,7 @@ export default function PostDetailCard({
                 </span>
               )}
             </div>
-            <p className="text-xs text-gray-400 mt-0.5 flex items-center gap-1">
+            <p className="text-xs text-text-secondary mt-0.5 flex items-center gap-1">
               <Image
                 src="/postTime.svg"
                 alt=""
@@ -77,14 +77,14 @@ export default function PostDetailCard({
           </div>
         </div>
         {headerActions && (
-          <div className="flex items-center gap-1 [&_button]:cursor-pointer">
+          <div className="flex items-center gap-3 [&_button]:cursor-pointer">
             {headerActions}
           </div>
         )}
       </div>
 
       <div className="px-5 pb-3">
-        <h1 className="text-lg font-bold text-gray-900">{post.title}</h1>
+        <h1 className="text-lg font-bold text-text-primary">{post.title}</h1>
       </div>
 
       {post.image_url && (
@@ -102,12 +102,12 @@ export default function PostDetailCard({
       )}
 
       <div className="px-5 pb-5">
-        <p className="text-sm text-gray-700 whitespace-pre-line leading-relaxed">
+        <p className="text-sm text-text-primary whitespace-pre-line leading-relaxed">
           {post.content}
         </p>
       </div>
 
-      <div className="px-5 py-3 border-t border-gray-100 flex items-center gap-4">
+      <div className="px-5 py-3 border-t border-border flex items-center gap-4">
         <button
           onClick={onLike}
           disabled={!onLike}
@@ -117,14 +117,16 @@ export default function PostDetailCard({
         >
           <Heart
             size={16}
-            className={isLiked ? 'fill-danger text-danger' : 'text-gray-500'}
+            className={
+              isLiked ? 'fill-danger text-danger' : 'text-text-secondary'
+            }
           />
-          <span className={isLiked ? 'text-danger' : 'text-gray-500'}>
+          <span className={isLiked ? 'text-danger' : 'text-text-secondary'}>
             좋아요 {post.likeCount}
           </span>
         </button>
 
-        <div className="flex items-center gap-1.5 text-xs text-gray-500">
+        <div className="flex items-center gap-1.5 text-xs text-text-secondary">
           <Image
             src="/postComment.svg"
             alt=""
@@ -134,7 +136,9 @@ export default function PostDetailCard({
           />
           <span>댓글 {post.commentCount}</span>
         </div>
-        <span className="text-xs text-gray-500">조회 {post.view_count}</span>
+        <span className="text-xs text-text-secondary">
+          조회 {post.view_count}
+        </span>
       </div>
     </div>
   );

--- a/src/components/community/PostDetailCard.tsx
+++ b/src/components/community/PostDetailCard.tsx
@@ -30,10 +30,19 @@ export default function PostDetailCard({
 }: PostDetailCardProps) {
   const roleBadge =
     post.role === 'manager'
-      ? { label: '도장', className: 'bg-blue-50 text-blue-600' }
+      ? {
+          label: '도장',
+          className: 'bg-category-promo-bg text-category-text',
+        }
       : post.role === 'admin'
-        ? { label: '관리자', className: 'bg-red-50 text-red-600' }
-        : { label: '일반', className: 'bg-btn-basic text-btn-text' };
+        ? {
+            label: '공지',
+            className: 'bg-category-notice-bg text-category-text',
+          }
+        : {
+            label: '일반',
+            className: 'bg-category-personal-bg text-category-text',
+          };
 
   return (
     <div className="bg-bg-white rounded-2xl shadow-sm border border-border overflow-hidden">

--- a/src/components/community/PostDetailCard.tsx
+++ b/src/components/community/PostDetailCard.tsx
@@ -36,7 +36,7 @@ export default function PostDetailCard({
         }
       : post.role === 'admin'
         ? {
-            label: '공지',
+            label: '관리자',
             className: 'bg-category-notice-bg text-category-text',
           }
         : {

--- a/src/components/community/PostDetailClient.tsx
+++ b/src/components/community/PostDetailClient.tsx
@@ -21,6 +21,7 @@ import PostDetailCard, {
 } from '@/components/community/PostDetailCard';
 import { timeAgo } from '@/utils/timeAgo';
 import { LimitedTextarea } from '../common/LimitedTextarea';
+import { Pencil, Trash2, Flag, Share2 } from 'lucide-react';
 
 interface Props {
   id: string;
@@ -183,7 +184,7 @@ export default function PostDetailClient({
       <button
         onClick={() => router.push('/community')}
         aria-label="커뮤니티 목록으로 이동"
-        className="flex items-center gap-2 px-2.5 py-2 border-2 border-white bg-white text-black text-sm font-medium rounded-xl hover:bg-(--color-btn-focus) hover:text-white transition-colors duration-200 cursor-pointer"
+        className="flex items-center gap-2 px-2.5 py-2 border-2 border-border bg-bg-white text-text-primary text-sm font-medium rounded-xl hover:bg-btn-focus hover:text-btn-focus-text transition-colors duration-200 cursor-pointer"
       >
         <svg
           width="16"
@@ -221,15 +222,23 @@ export default function PostDetailClient({
                   title="수정하기"
                   aria-label="게시글 수정"
                   onClick={() => router.push(`/community/${id}/edit`)}
+                  className="p-1"
                 >
-                  <Image src="/postEdit.svg" alt="" width={30} height={30} />
+                  <Pencil
+                    size={20}
+                    className="text-text-secondary hover:text-text-primary"
+                  />
                 </button>
                 <button
                   title="삭제하기"
                   aria-label="게시글 삭제"
                   onClick={() => setDeletePostModalOpen(true)}
+                  className="p-1"
                 >
-                  <Image src="/postDelete.svg" alt="" width={32} height={32} />
+                  <Trash2
+                    size={20}
+                    className="text-text-secondary hover:text-red-500"
+                  />
                 </button>
               </>
             ) : (
@@ -237,34 +246,40 @@ export default function PostDetailClient({
                 title="신고하기"
                 aria-label="게시글 신고"
                 onClick={() => setReportModalOpen(true)}
-                className="w-8 h-8 flex items-center justify-center"
+                className="p-1"
               >
-                <Image src="/postReport.svg" alt="" width={27} height={27} />
+                <Flag
+                  size={20}
+                  className="text-text-secondary hover:text-text-primary"
+                />
               </button>
             )}
             <button
               title="공유하기"
               aria-label="게시글 공유"
               onClick={handleShare}
-              className="w-8 h-8 flex items-center justify-center"
+              className="p-1"
             >
-              <Image src="/postShare.svg" alt="" width={18} height={18} />
+              <Share2
+                size={18}
+                className="text-text-secondary hover:text-text-primary"
+              />
             </button>
           </>
         }
       />
 
-      <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden">
-        <div className="px-5 pt-5 pb-3 flex items-center gap-2 border-b border-gray-100">
+      <div className="bg-bg-white rounded-2xl shadow-sm border border-border overflow-hidden">
+        <div className="px-5 pt-5 pb-3 flex items-center gap-2 border-b border-border">
           <Image
             src="/postComment.svg"
             alt=""
             aria-hidden="true"
             width={16}
             height={16}
-            className="opacity-40"
+            className="opacity-40 dark:invert"
           />
-          <h2 className="text-sm font-semibold text-gray-800">댓글</h2>
+          <h2 className="text-sm font-semibold text-text-primary">댓글</h2>
         </div>
 
         <div className="px-5 py-4">
@@ -294,6 +309,7 @@ export default function PostDetailClient({
                 aria-hidden="true"
                 width={30}
                 height={30}
+                className="dark:invert"
               />
             </button>
           </div>
@@ -302,9 +318,9 @@ export default function PostDetailClient({
         <div className="px-5 pb-5 space-y-4">
           {comments.map((c, index) => (
             <div key={c.id}>
-              {index > 0 && <div className="border-t border-gray-50 mb-4" />}
+              {index > 0 && <div className="border-t border-border mb-4" />}
               <div className="flex gap-3">
-                <div className="w-8 h-8 rounded-full bg-gray-200 shrink-0 overflow-hidden">
+                <div className="w-8 h-8 rounded-full  bg-btn-basic shrink-0 overflow-hidden">
                   {c.avatar_url && (
                     <Image
                       src={c.avatar_url}
@@ -317,11 +333,11 @@ export default function PostDetailClient({
                 </div>
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-1.5 mb-1">
-                    <span className="text-sm font-semibold text-gray-900">
+                    <span className="text-sm font-semibold text-text-primary">
                       {c.nickname}
                     </span>
                     {c.belt_level && (
-                      <span className="text-xs text-gray-400">
+                      <span className="text-xs text-text-secondary">
                         {c.belt_level}
                       </span>
                     )}
@@ -356,18 +372,18 @@ export default function PostDetailClient({
                       <button
                         onClick={() => setEditingCommentId(null)}
                         aria-label="댓글 수정 취소"
-                        className="text-xs text-gray-400"
+                        className="text-xs text-text-secondary"
                       >
                         취소
                       </button>
                     </div>
                   ) : (
-                    <p className="text-sm text-gray-700 leading-relaxed">
+                    <p className="text-sm text-text-primary leading-relaxed">
                       {c.content}
                     </p>
                   )}
                   <div className="flex items-center gap-3 mt-1.5">
-                    <span className="flex items-center gap-1 text-xs text-gray-400">
+                    <span className="flex items-center gap-1 text-xs text-text-secondary">
                       <Image
                         src="/postTime.svg"
                         alt=""
@@ -386,7 +402,7 @@ export default function PostDetailClient({
                             setEditingContent(c.content);
                           }}
                           aria-label={`${c.nickname}의 댓글 수정`}
-                          className="text-xs text-gray-400 hover:text-gray-600 transition-colors"
+                          className="text-xs text-text-secondary hover:text-text-primary transition-colors"
                         >
                           수정
                         </button>
@@ -405,7 +421,7 @@ export default function PostDetailClient({
             </div>
           ))}
           {comments.length === 0 && (
-            <p className="text-center text-sm text-gray-400 py-4">
+            <p className="text-center text-sm text-text-secondary py-4">
               첫 번째 댓글을 남겨보세요!
             </p>
           )}

--- a/src/components/community/PostDetailClient.tsx
+++ b/src/components/community/PostDetailClient.tsx
@@ -19,7 +19,10 @@ import ConfirmModal from '@/components/common/ConfirmModal';
 import PostDetailCard, {
   PostDetailCardData,
 } from '@/components/community/PostDetailCard';
-import { canManageContent, type ContentUserRole } from '@/lib/contentPermissions';
+import {
+  canManageContent,
+  type ContentUserRole,
+} from '@/lib/contentPermissions';
 import { timeAgo } from '@/utils/timeAgo';
 import { LimitedTextarea } from '../common/LimitedTextarea';
 import { Pencil, Trash2, Flag, Share2 } from 'lucide-react';
@@ -192,7 +195,7 @@ export default function PostDetailClient({
       <button
         onClick={() => router.push('/community')}
         aria-label="커뮤니티 목록으로 이동"
-        className="flex items-center gap-2 px-2.5 py-2 border-2 border-border bg-bg-white text-text-primary text-sm font-medium rounded-xl hover:bg-btn-focus hover:text-btn-focus-text transition-colors duration-200 cursor-pointer"
+        className="flex items-center gap-2 px-2.5 py-2 border-2 border-border bg-btn-basic text-text-primary text-sm font-medium rounded-xl hover:bg-btn-focus hover:text-btn-focus-text  transition-colors duration-200 cursor-pointer"
       >
         <svg
           width="16"

--- a/src/components/community/PostFormActions.tsx
+++ b/src/components/community/PostFormActions.tsx
@@ -18,17 +18,17 @@ export default function PostFormActions({
       <button
         onClick={onCancel}
         disabled={isLoading}
-        className="flex-1 py-3 rounded-xl bg-btn-basic border border-gray-300 text-black hover:bg-gray-200 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+        className="flex-1 py-3 rounded-xl bg-btn-basic border border-border text-text-primary hover:bg-btn-basic cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
       >
         취소
       </button>
       <button
         onClick={onSubmit}
         disabled={isLoading}
-        className={`flex-3 py-3 rounded-xl text-white text-sm font-medium transition-colors duration-200 ${
+        className={`flex-3 py-3 rounded-xl text-btn-focus-text text-sm font-medium transition-colors duration-200 ${
           isLoading
-            ? 'bg-gray-400 cursor-not-allowed'
-            : 'bg-black cursor-pointer'
+            ? 'bg-btn-basic cursor-not-allowed'
+            : 'bg-btn-focus cursor-pointer'
         }`}
       >
         {isLoading ? '처리 중...' : submitLabel}

--- a/src/components/community/Postcard.tsx
+++ b/src/components/community/Postcard.tsx
@@ -24,9 +24,9 @@ interface PostCardProps {
 }
 
 const categoryMap: Record<string, { label: string; color: string }> = {
-  promo: { label: '도장', color: 'bg-[#155DFC]' },
-  notice: { label: '공지', color: 'bg-[#e7000b]' },
-  personal: { label: '일반', color: 'bg-[#364153]' },
+  promo: { label: '도장', color: 'bg-category-promo-bg' },
+  notice: { label: '공지', color: 'bg-category-notice-bg' },
+  personal: { label: '일반', color: 'bg-category-personal-bg' },
 };
 
 export default function PostCard({ post, userId }: PostCardProps) {

--- a/src/components/community/WriteClient.tsx
+++ b/src/components/community/WriteClient.tsx
@@ -67,13 +67,15 @@ export default function WriteClient() {
         <h1 className="text-lg font-semibold mx-auto">게시글 작성</h1>
       </div>
 
-      <div role="tablist" className="flex bg-gray-100 rounded-xl p-1 mb-6">
+      <div role="tablist" className="flex bg-btn-basic rounded-xl p-1 mb-6">
         <button
           role="tab"
           aria-selected={tab === 'write'}
           onClick={() => setTab('write')}
           className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
-            tab === 'write' ? 'bg-white text-black shadow-sm' : 'text-gray-500'
+            tab === 'write'
+              ? 'bg-bg-white text-text-primary shadow-sm'
+              : 'text-text-secondary'
           }`}
         >
           작성
@@ -84,8 +86,8 @@ export default function WriteClient() {
           onClick={() => setTab('preview')}
           className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
             tab === 'preview'
-              ? 'bg-white text-black shadow-sm'
-              : 'text-gray-500'
+              ? 'bg-bg-white text-text-primary shadow-sm'
+              : 'text-text-secondary'
           }`}
         >
           미리보기
@@ -94,8 +96,8 @@ export default function WriteClient() {
 
       {tab === 'write' && (
         <>
-          <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
-            <p className="text-sm text-gray-500 mb-2">게시글 유형</p>
+          <div className="bg-bg-white rounded-xl p-4 mb-4 shadow-sm">
+            <p className="text-sm text-text-secondary mb-2">게시글 유형</p>
             {user?.role === 'manager' ? (
               <div className="flex gap-2">
                 {(['personal', 'promo'] as PostCategory[]).map((type) => (
@@ -105,8 +107,8 @@ export default function WriteClient() {
                     onClick={() => setCategory(type)}
                     className={`flex-1 py-2 rounded-lg text-sm font-medium cursor-pointer transition-colors ${
                       category === type
-                        ? 'bg-black text-white'
-                        : 'bg-gray-100 text-gray-600'
+                        ? 'bg-btn-focus text-btn-focus-text'
+                        : 'bg-btn-basic text-btn-text'
                     }`}
                   >
                     {type === 'personal' ? '일반 게시글' : '도장 홍보'}
@@ -116,17 +118,17 @@ export default function WriteClient() {
             ) : (
               <div
                 aria-label={`게시글 유형: ${user?.role === 'admin' ? '공지' : '일반 게시글'}`}
-                className="py-2 px-3 rounded-lg text-sm font-medium bg-black text-white text-center"
+                className="py-2 px-3 rounded-lg text-sm font-medium bg-btn-focus text-btn-focus-text text-center"
               >
                 {user?.role === 'admin' ? '공지' : '일반 게시글'}
               </div>
             )}
           </div>
 
-          <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
+          <div className="bg-bg-white rounded-xl p-4 mb-4 shadow-sm">
             <label
               htmlFor="post-title"
-              className="text-sm text-gray-500 mb-2 block"
+              className="text-sm text-text-secondary mb-2 block"
             >
               제목
             </label>
@@ -147,10 +149,10 @@ export default function WriteClient() {
             }}
           />
 
-          <div className="bg-white rounded-xl p-4 mb-6 shadow-sm">
+          <div className="bg-bg-white rounded-xl p-4 mb-6 shadow-sm">
             <label
               htmlFor="post-content"
-              className="text-sm text-gray-500 mb-2 block"
+              className="text-sm text-text-secondary mb-2 block"
             >
               내용
             </label>

--- a/src/components/community/WriteClient.tsx
+++ b/src/components/community/WriteClient.tsx
@@ -67,7 +67,7 @@ export default function WriteClient() {
         <h1 className="text-lg font-semibold mx-auto">게시글 작성</h1>
       </div>
 
-      <div role="tablist" className="flex bg-btn-basic rounded-xl p-1 mb-6">
+      <div role="tablist" className="flex bg-table-top rounded-xl p-1 mb-6">
         <button
           role="tab"
           aria-selected={tab === 'write'}

--- a/src/components/competition/CompetitionClient.tsx
+++ b/src/components/competition/CompetitionClient.tsx
@@ -98,7 +98,7 @@ export default function CompetitionClient({
     <div className="w-full min-h-screen">
       <div
         ref={headerRef}
-        className="fixed top-0 left-50 right-0 z-10 bg-white shadow-md flex justify-center"
+        className="fixed top-0 left-50 right-0 z-10 bg-bg-white shadow-md flex justify-center"
       >
         <div className="w-full max-w-7xl px-6">
           <Pageheader

--- a/src/components/competition/CompetitionDetailCard.tsx
+++ b/src/components/competition/CompetitionDetailCard.tsx
@@ -42,17 +42,17 @@ export default function CompetitionDetailCard({
       ? 'text-red-500'
       : dday.startsWith('D-')
         ? 'text-blue-500'
-        : 'text-gray-400';
+        : 'text-text-secondary';
 
   return (
     <article
-      className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden"
+      className="bg-bg-white rounded-2xl shadow-sm border border-border overflow-hidden"
       aria-label={`${data.name} 대회 상세`}
     >
       {/* 상단: 프로필 + 버튼 */}
       <div className="flex items-center justify-between px-5 pt-5 pb-3">
         <div className="flex items-center gap-3">
-          <div className="w-10 h-10 rounded-full bg-gray-200 overflow-hidden shrink-0">
+          <div className="w-10 h-10 rounded-full bg-btn-basic overflow-hidden shrink-0">
             <Image
               src={
                 data.avatar_url?.startsWith('http')
@@ -72,21 +72,24 @@ export default function CompetitionDetailCard({
           <div>
             <div className="flex items-center gap-2">
               <span
-                className="text-sm font-semibold text-gray-900"
+                className="text-sm font-semibold text-text-primary"
                 aria-label={`작성자: ${data.nickname ?? '알 수 없음'}`}
               >
                 {data.nickname ?? '알 수 없음'}
               </span>
               {data.role && (
                 <span
-                  className="text-xs px-1.5 py-0.5 bg-gray-100 text-gray-500 rounded"
+                  className="text-xs px-1.5 py-0.5 bg-state-basic-bg text-text-secondary rounded"
                   aria-label={`역할: ${data.role}`}
                 >
                   {data.role}
                 </span>
               )}
             </div>
-            <time dateTime={data.created_at} className="text-xs text-gray-400">
+            <time
+              dateTime={data.created_at}
+              className="text-xs text-text-secondary"
+            >
               {data.created_at ? timeAgo(data.created_at) : '방금 전'}
             </time>
           </div>
@@ -104,14 +107,14 @@ export default function CompetitionDetailCard({
 
       {/* 제목 */}
       <div className="px-5 pb-3">
-        <h1 className="text-base font-bold text-gray-900">
+        <h1 className="text-base font-bold text-text-primary">
           {data.name || '대회 제목'}
         </h1>
       </div>
 
       {/* 이미지 */}
       {data.image_url && (
-        <div className="relative w-full aspect-video bg-gray-100">
+        <div className="relative w-full aspect-video bg-btn-basic">
           <Image
             src={data.image_url}
             alt={`${data.name} 대회 이미지`}
@@ -129,24 +132,24 @@ export default function CompetitionDetailCard({
 
       {/* 날짜/장소/신청마감 요약 바 */}
       <dl
-        className="grid grid-cols-3 divide-x divide-gray-100 border-y border-gray-100 text-center py-3 px-2"
+        className="grid grid-cols-3 divide-x divide-border border-y border-border text-center py-3 px-2"
         aria-label="대회 정보"
       >
         <div className="px-2">
-          <dt className="text-xs text-gray-400 mb-1">일시</dt>
-          <dd className="text-xs font-medium text-gray-700">
+          <dt className="text-xs text-text-secondary mb-1">일시</dt>
+          <dd className="text-xs font-medium text-text-primary">
             {data.event_data || '-'}
           </dd>
         </div>
         <div className="px-2">
-          <dt className="text-xs text-gray-400 mb-1">장소</dt>
-          <dd className="text-xs font-medium text-gray-700">
+          <dt className="text-xs text-text-secondary mb-1">장소</dt>
+          <dd className="text-xs font-medium text-text-primary">
             {data.location || '-'}
           </dd>
         </div>
         <div className="px-2">
-          <dt className="text-xs text-gray-400 mb-1">신청마감</dt>
-          <dd className="text-xs font-medium text-gray-700">
+          <dt className="text-xs text-text-secondary mb-1">신청마감</dt>
+          <dd className="text-xs font-medium text-text-primary">
             {data.apply_deadline || '-'}
           </dd>
           {status !== '모집완료' && data.apply_deadline && (
@@ -162,13 +165,13 @@ export default function CompetitionDetailCard({
 
       {/* 본문 */}
       <div className="px-5 py-4">
-        <p className="text-sm text-gray-700 leading-relaxed whitespace-pre-line">
+        <p className="text-sm text-text-primary leading-relaxed whitespace-pre-line">
           {data.description || '대회 설명이 여기에 표시됩니다.'}
         </p>
       </div>
 
       {/* 구분선 */}
-      <div className="border-t border-gray-100 mx-5 mb-3" aria-hidden="true" />
+      <div className="border-t border-border mx-5 mb-3" aria-hidden="true" />
     </article>
   );
 }

--- a/src/components/competition/CompetitionDetailCard.tsx
+++ b/src/components/competition/CompetitionDetailCard.tsx
@@ -32,16 +32,16 @@ export default function CompetitionDetailCard({
 
   const statusColor =
     {
-      모집중: 'bg-green-500',
-      마감임박: 'bg-orange-500',
-      모집완료: 'bg-gray-400',
-    }[status] ?? 'bg-gray-400';
+      모집중: 'bg-state-recruiting-bg text-state-recruiting-text',
+      마감임박: 'bg-state-deadline-bg text-state-deadline-text',
+      모집완료: 'bg-state-closed-bg text-state-closed-text',
+    }[status] ?? 'bg-state-closed-bg text-state-closed-text';
 
   const ddayColor =
     dday === 'D-DAY'
       ? 'text-red-500'
       : dday.startsWith('D-')
-        ? 'text-blue-500'
+        ? 'text-dday-imminent'
         : 'text-text-secondary';
 
   return (
@@ -79,7 +79,7 @@ export default function CompetitionDetailCard({
               </span>
               {data.role && (
                 <span
-                  className="text-xs px-1.5 py-0.5 bg-state-basic-bg text-text-secondary rounded"
+                  className="text-xs px-1.5 py-0.5 bg-state-basic-bg text-category-text rounded"
                   aria-label={`역할: ${data.role}`}
                 >
                   {data.role}
@@ -122,7 +122,7 @@ export default function CompetitionDetailCard({
             className="object-cover"
           />
           <span
-            className={`absolute top-3 left-3 px-2.5 py-1 text-xs text-white rounded-full ${statusColor}`}
+            className={`absolute top-3 left-3 px-2.5 py-1 text-xs rounded-full ${statusColor}`}
             aria-label={`모집 상태: ${status}`}
           >
             {status}

--- a/src/components/competition/CompetitionDetailClient.tsx
+++ b/src/components/competition/CompetitionDetailClient.tsx
@@ -7,10 +7,10 @@ import { getStatus } from '@/utils/formatDate';
 import { handleShare } from '@/utils/share';
 import type { Competition } from '@/types/competition';
 import CompetitionDetailCard from '@/components/competition/CompetitionDetailCard';
-import Image from 'next/image';
 import { deleteCompetition } from '@/services/competitionService';
 import { useState } from 'react';
 import ConfirmModal from '../common/ConfirmModal';
+import { Pencil, Trash2, Share2 } from 'lucide-react';
 
 interface CompetitionDetailClientProps {
   competition: Competition;
@@ -51,7 +51,7 @@ export default function CompetitionDetailClient({
       <button
         onClick={() => router.push('/competitions')}
         aria-label="대회일정 목록으로 돌아가기"
-        className="flex items-center gap-2 px-2.5 py-2 border-2 border-white bg-white text-black text-sm font-medium rounded-xl hover:bg-(--color-btn-focus) hover:text-white transition-colors duration-200 cursor-pointer"
+        className="flex items-center gap-2 px-2.5 py-2 border-2 border-border bg-bg-white text-text-primary text-sm font-medium rounded-xl hover:bg-btn-focus hover:text-btn-focus-text transition-colors duration-200 cursor-pointer"
       >
         <svg
           width="16"
@@ -93,28 +93,22 @@ export default function CompetitionDetailClient({
                   title="수정하기"
                   aria-label="대회 게시글 수정하기"
                   onClick={() => router.push(`/competitions/${id}/edit`)}
-                  className="cursor-pointer"
+                  className="p-1 cursor-pointer"
                 >
-                  <Image
-                    src="/postEdit.svg"
-                    alt=""
-                    width={30}
-                    height={30}
-                    aria-hidden="true"
+                  <Pencil
+                    size={20}
+                    className="text-text-secondary hover:text-text-primary"
                   />
                 </button>
                 <button
                   title="삭제하기"
                   aria-label="대회 게시글 삭제하기"
                   onClick={() => setDeleteModalOpen(true)}
-                  className="cursor-pointer"
+                  className="p-1 cursor-pointer"
                 >
-                  <Image
-                    src="/postDelete.svg"
-                    alt=""
-                    width={32}
-                    height={32}
-                    aria-hidden="true"
+                  <Trash2
+                    size={20}
+                    className="text-text-secondary hover:text-red-500"
                   />
                 </button>
               </>
@@ -123,14 +117,11 @@ export default function CompetitionDetailClient({
               title="공유하기"
               aria-label="대회 게시글 링크 공유하기"
               onClick={() => handleShare()}
-              className="w-8 h-8 flex items-center justify-center cursor-pointer"
+              className="p-1 cursor-pointer"
             >
-              <Image
-                src="/postShare.svg"
-                alt=""
-                width={18}
-                height={18}
-                aria-hidden="true"
+              <Share2
+                size={18}
+                className="text-text-secondary hover:text-text-primary"
               />
             </button>
           </>
@@ -151,11 +142,11 @@ export default function CompetitionDetailClient({
             : `${competition.name} 대회 신청하기`
         }
         aria-disabled={status === '모집완료'}
-        className={`block w-full py-4 text-center text-sm font-bold text-white rounded-2xl transition-all
+        className={`block w-full py-4 text-center text-sm font-bold rounded-2xl transition-all
           ${
             status === '모집완료'
-              ? 'bg-gray-400 cursor-not-allowed pointer-events-none'
-              : 'bg-[#2c2c2c] hover:bg-black'
+              ? 'bg-state-basic-bg text-text-secondary cursor-not-allowed pointer-events-none'
+              : 'bg-btn-focus text-btn-focus-text hover:opacity-80'
           }`}
       >
         {status === '모집완료' ? '모집 완료' : '대회 신청하기'}

--- a/src/components/competition/CompetitionDetailClient.tsx
+++ b/src/components/competition/CompetitionDetailClient.tsx
@@ -62,7 +62,7 @@ export default function CompetitionDetailClient({
       <button
         onClick={() => router.push('/competitions')}
         aria-label="대회일정 목록으로 돌아가기"
-        className="flex items-center gap-2 px-2.5 py-2 border-2 border-border bg-bg-white text-text-primary text-sm font-medium rounded-xl hover:bg-btn-focus hover:text-btn-focus-text transition-colors duration-200 cursor-pointer"
+        className="flex items-center gap-2 px-2.5 py-2 border-2 border-border bg-btn-basic text-text-primary text-sm font-medium rounded-xl hover:bg-btn-focus hover:text-btn-focus-text transition-colors duration-200 cursor-pointer"
       >
         <svg
           width="16"

--- a/src/components/competition/CompetitionForm.tsx
+++ b/src/components/competition/CompetitionForm.tsx
@@ -36,10 +36,10 @@ export default function CompetitionForm({
 
   return (
     <div role="form" aria-label="대회 정보 입력 폼">
-      <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
+      <div className="bg-bg-white rounded-xl p-4 mb-4 shadow-sm">
         <label
           htmlFor="competition-name"
-          className="text-sm text-gray-500 mb-2 block"
+          className="text-sm text-text-secondary mb-2 block"
         >
           대회 제목{' '}
           <span aria-hidden="true" className="text-red-400">
@@ -65,10 +65,10 @@ export default function CompetitionForm({
         }}
       />
 
-      <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
+      <div className="bg-bg-white rounded-xl p-4 mb-4 shadow-sm">
         <label
           htmlFor="event-date"
-          className="text-sm text-gray-500 mb-2 block"
+          className="text-sm text-text-secondary mb-2 block"
         >
           대회 날짜{' '}
           <span aria-hidden="true" className="text-red-400">
@@ -78,7 +78,7 @@ export default function CompetitionForm({
         </label>
         <div className="relative">
           <span
-            className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary"
             aria-hidden="true"
           >
             📅
@@ -91,15 +91,15 @@ export default function CompetitionForm({
             onChange={(e) => update('eventDate', e.target.value)}
             onClick={(e) => (e.target as HTMLInputElement).showPicker?.()}
             aria-required="true"
-            className="w-full bg-gray-50 rounded-lg pl-9 pr-3 py-2 text-sm outline-none text-gray-700 cursor-pointer"
+            className="w-full bg-input-bg rounded-lg pl-9 pr-3 py-2 text-sm outline-none text-input-text cursor-pointer"
           />
         </div>
       </div>
 
-      <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
+      <div className="bg-bg-white rounded-xl p-4 mb-4 shadow-sm">
         <label
           htmlFor="apply-deadline"
-          className="text-sm text-gray-500 mb-2 block"
+          className="text-sm text-text-secondary mb-2 block"
         >
           신청 마감 날짜{' '}
           <span aria-hidden="true" className="text-red-400">
@@ -109,7 +109,7 @@ export default function CompetitionForm({
         </label>
         <div className="relative">
           <span
-            className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary"
             aria-hidden="true"
           >
             📅
@@ -122,15 +122,15 @@ export default function CompetitionForm({
             onChange={(e) => update('applyDeadline', e.target.value)}
             onClick={(e) => (e.target as HTMLInputElement).showPicker?.()}
             aria-required="true"
-            className="w-full bg-gray-50 rounded-lg pl-9 pr-3 py-2 text-sm outline-none text-gray-700 cursor-pointer"
+            className="w-full bg-input-bg rounded-lg pl-9 pr-3 py-2 text-sm outline-none text-input-text cursor-pointer"
           />
         </div>
       </div>
 
-      <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
+      <div className="bg-bg-white rounded-xl p-4 mb-4 shadow-sm">
         <label
           htmlFor="competition-location"
-          className="text-sm text-gray-500 mb-2 block"
+          className="text-sm text-text-secondary mb-2 block"
         >
           대회 장소{' '}
           <span aria-hidden="true" className="text-red-400">
@@ -140,7 +140,7 @@ export default function CompetitionForm({
         </label>
         <div className="relative">
           <span
-            className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary"
             aria-hidden="true"
           >
             📍
@@ -152,21 +152,21 @@ export default function CompetitionForm({
             value={values.location}
             onChange={(e) => update('location', e.target.value)}
             aria-required="true"
-            className="w-full bg-gray-50 rounded-lg pl-9 pr-3 py-2 text-sm outline-none"
+            className="w-full bg-input-bg rounded-lg pl-9 pr-3 py-2 text-sm outline-none text-input-text"
           />
         </div>
       </div>
 
-      <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
+      <div className="bg-bg-white rounded-xl p-4 mb-4 shadow-sm">
         <label
           htmlFor="competition-participants"
-          className="text-sm text-gray-500 mb-2 block"
+          className="text-sm text-text-secondary mb-2 block"
         >
           모집 인원
         </label>
         <div className="relative">
           <span
-            className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary"
             aria-hidden="true"
           >
             👥
@@ -178,18 +178,21 @@ export default function CompetitionForm({
             value={values.participants}
             onChange={(e) => update('participants', e.target.value)}
             min={1}
-            className="w-full bg-gray-50 rounded-lg pl-9 pr-3 py-2 text-sm outline-none"
+            className="w-full bg-input-bg rounded-lg pl-9 pr-3 py-2 text-sm outline-none text-input-text"
           />
         </div>
       </div>
 
-      <div className="bg-white rounded-xl p-4 mb-4 shadow-sm">
-        <label htmlFor="apply-url" className="text-sm text-gray-500 mb-2 block">
+      <div className="bg-bg-white rounded-xl p-4 mb-4 shadow-sm">
+        <label
+          htmlFor="apply-url"
+          className="text-sm text-text-secondary mb-2 block"
+        >
           참가 신청 링크
         </label>
         <div className="relative">
           <span
-            className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary"
             aria-hidden="true"
           >
             🔗
@@ -200,15 +203,15 @@ export default function CompetitionForm({
             placeholder="https://example.com/register"
             value={values.applyUrl}
             onChange={(e) => update('applyUrl', e.target.value)}
-            className="w-full bg-gray-50 rounded-lg pl-9 pr-3 py-2 text-sm outline-none"
+            className="w-full bg-input-bg rounded-lg pl-9 pr-3 py-2 text-sm outline-none text-input-text"
           />
         </div>
       </div>
 
-      <div className="bg-white rounded-xl p-4 mb-6 shadow-sm">
+      <div className="bg-bg-white rounded-xl p-4 mb-6 shadow-sm">
         <label
           htmlFor="competition-description"
-          className="text-sm text-gray-500 mb-2 block"
+          className="text-sm text-text-secondary mb-2 block"
         >
           대회 설명
         </label>

--- a/src/components/competition/CompetitionWriteClient.tsx
+++ b/src/components/competition/CompetitionWriteClient.tsx
@@ -91,11 +91,13 @@ export default function CompetitionWriteClient({ userId }: { userId: string }) {
         <h1 className="text-lg font-semibold">대회 추가</h1>
       </div>
 
-      <div className="flex bg-gray-100 rounded-xl p-1 mb-6">
+      <div className="flex bg-table-top rounded-xl p-1 mb-6">
         <button
           onClick={() => setTab('write')}
           className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
-            tab === 'write' ? 'bg-white text-black shadow-sm' : 'text-gray-500'
+            tab === 'write'
+              ? 'bg-bg-white text-text-primary shadow-sm'
+              : 'text-text-secondary'
           }`}
         >
           작성
@@ -104,8 +106,8 @@ export default function CompetitionWriteClient({ userId }: { userId: string }) {
           onClick={() => setTab('preview')}
           className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
             tab === 'preview'
-              ? 'bg-white text-black shadow-sm'
-              : 'text-gray-500'
+              ? 'bg-bg-white text-text-primary shadow-sm'
+              : 'text-text-secondary'
           }`}
         >
           미리보기
@@ -118,7 +120,7 @@ export default function CompetitionWriteClient({ userId }: { userId: string }) {
 
       {tab === 'preview' &&
         (!values.name && !values.description ? (
-          <div className="flex flex-col items-center justify-center py-16 text-gray-400 mb-6">
+          <div className="flex flex-col items-center justify-center py-16 text-text-secondary mb-6">
             <p className="text-sm">작성 탭에서 내용을 입력하면</p>
             <p className="text-sm">여기서 미리볼 수 있어요.</p>
           </div>

--- a/src/components/dojang/DojangCard.tsx
+++ b/src/components/dojang/DojangCard.tsx
@@ -34,7 +34,7 @@ export default function DojangCard({
         </h3>
         {isVerified && (
           <span
-            className="shrink-0 px-2 py-0.5 text-xs text-white bg-[#155DFC] rounded-full"
+            className="shrink-0 px-2 py-0.5 text-xs text-category-text bg-category-promo-bg rounded-full"
             aria-label="인증된 도장"
           >
             ✓ 인증

--- a/src/components/dojang/DojangCard.tsx
+++ b/src/components/dojang/DojangCard.tsx
@@ -22,8 +22,8 @@ export default function DojangCard({
 }: DojangCardProps) {
   return (
     <article
-      className={`p-4 border rounded-lg bg-white hover:shadow-md transition-all cursor-pointer
-        ${isSelected ? 'border-btn-focus border-2 shadow-md' : 'border-gray-200'}`}
+      className={`p-4 border rounded-lg bg-bg-white hover:shadow-md transition-all cursor-pointer
+        ${isSelected ? 'border-btn-focus border-2 shadow-md' : 'border-border'}`}
       aria-label={`${dojang.place_name} 도장${isVerified ? ', 인증 도장' : ''}${isSelected ? ', 선택됨' : ''}`}
       aria-current={isSelected}
     >
@@ -43,7 +43,7 @@ export default function DojangCard({
       </div>
 
       {/* 주소 */}
-      <address className="text-sm text-gray-500 mt-1 not-italic">
+      <address className="text-sm text-text-secondary mt-1 not-italic">
         {dojang.address_name}
       </address>
 
@@ -51,7 +51,7 @@ export default function DojangCard({
       {dojang.phone && (
         <a
           href={'tel:' + dojang.phone}
-          className="text-sm text-gray-400 mt-1 block hover:text-gray-600 transition-colors"
+          className="text-sm text-text-secondary mt-1 block hover:text-text-primary transition-colors"
           aria-label={'전화번호: ' + dojang.phone}
         >
           {dojang.phone}
@@ -65,7 +65,7 @@ export default function DojangCard({
         target="_blank"
         rel="noopener noreferrer"
         aria-label={dojang.place_name + ' 상세보기 (새 탭에서 열림)'}
-        className="mt-3 block w-full py-2 text-sm font-bold text-white text-center rounded-lg bg-[#2c2c2c] hover:bg-black transition-all"
+        className="mt-3 block w-full py-2 text-sm font-bold text-center rounded-lg bg-btn-focus hover:bg-btn-focus text-btn-focus-text transition-all"
       >
         상세보기
       </a>

--- a/src/components/dojang/DojangClient.tsx
+++ b/src/components/dojang/DojangClient.tsx
@@ -159,14 +159,14 @@ export default function DojangClient({
                   aria-label="지도 불러오는 중"
                 >
                   <div
-                    className="w-8 h-8 border-4 border-gray-200 border-t-btn-focus rounded-full animate-spin"
+                    className="w-8 h-8 border-4 border-border border-t-btn-focus rounded-full animate-spin"
                     aria-hidden="true"
                   />
                 </div>
               )}
               <div
                 ref={mapRef}
-                className="w-full h-100 rounded-lg overflow-hidden border border-gray-200"
+                className="w-full h-100 rounded-lg overflow-hidden border border-border"
                 style={{ zIndex: 0 }}
                 role="application"
                 aria-label="도장 위치 지도"
@@ -178,7 +178,7 @@ export default function DojangClient({
               <div role="status" aria-label="도장 검색 중">
                 <div className="flex items-center justify-center py-20">
                   <div
-                    className="w-8 h-8 border-4 border-gray-200 border-t-btn-focus rounded-full animate-spin"
+                    className="w-8 h-8 border-4 border-border border-t-btn-focus rounded-full animate-spin"
                     aria-hidden="true"
                   />
                 </div>

--- a/src/components/error/ErrorScreenActions.tsx
+++ b/src/components/error/ErrorScreenActions.tsx
@@ -14,7 +14,7 @@ interface Props {
 }
 
 const buttonBase =
-  'h-12 min-w-[136px] cursor-pointer rounded-2xl px-6 font-semibold border-2 border-[var(--color-btn-focus)] bg-white text-black transition-colors duration-200 hover:text-white';
+  'h-12 min-w-[136px] cursor-pointer rounded-2xl px-6 font-semibold border-2 border-btn-focus bg-bg-white text-text-primary transition-colors duration-200 hover:text-btn-focus-text';
 
 export default function ErrorScreenActions({ variant, onRetry }: Props) {
   const router = useRouter();
@@ -31,8 +31,8 @@ export default function ErrorScreenActions({ variant, onRetry }: Props) {
   const isError = variant !== 'not-found';
   const buttonHover =
     variant === 'not-found'
-      ? 'hover:!bg-[var(--color-error-not-found)] hover:text-white'
-      : 'hover:!bg-[var(--color-error-runtime)] hover:text-white';
+      ? 'hover:!bg-[var(--color-error-not-found)] hover:text-btn-focus-text'
+      : 'hover:!bg-[var(--color-error-runtime)] hover:text-btn-focus-text';
 
   return (
     <nav

--- a/src/components/layout/LogoutButton.tsx
+++ b/src/components/layout/LogoutButton.tsx
@@ -4,7 +4,7 @@ import { LogOut } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
 
 const NAV_LINK_CLASS =
-  'flex items-center gap-2 px-6 py-3 border-2 border-btn-focus text-black text-sm font-medium rounded-xl hover:bg-btn-focus hover:text-white transition-colors duration-200 cursor-pointer';
+  'flex items-center gap-2 px-6 py-3 border-2 border-btn-focus bg-bg-white text-text-primary text-sm font-medium rounded-xl hover:bg-btn-focus hover:text-btn-focus-text transition-colors duration-200 cursor-pointer';
 
 export default function LogoutButton() {
   const { logout } = useAuth();

--- a/src/components/layout/PageHeader.tsx
+++ b/src/components/layout/PageHeader.tsx
@@ -116,7 +116,7 @@ export default function Pageheader({
               className={`cursor-pointer ${
                 activeTab === tab
                   ? 'bg-btn-focus text-btn-focus-text'
-                  : 'bg-btn-basic text-btn-text hover:bg-gray-200'
+                  : 'bg-btn-basic text-btn-text hover:bg-btn-focus hover:text-btn-focus-text'
               } h-10 p-6 transition-all duration-200`}
             >
               {tab}

--- a/src/components/layout/PageHeader.tsx
+++ b/src/components/layout/PageHeader.tsx
@@ -50,7 +50,7 @@ export default function Pageheader({
   };
 
   return (
-    <div className="flex flex-col gap-5 bg-white z-10 py-6">
+    <div className="flex flex-col gap-5 bg-bg-white z-10 py-6">
       <div className="flex flex-col gap-1">
         <h1 className="text-4xl font-bold text-text-primary">{title}</h1>
         <p className="text-sm text-text-secondary" aria-label={description}>

--- a/src/components/layout/PageHeader.tsx
+++ b/src/components/layout/PageHeader.tsx
@@ -93,6 +93,7 @@ export default function Pageheader({
                 width={16}
                 height={16}
                 aria-hidden="true"
+                className="dark:invert"
               />
               {writeLinkText ?? '글쓰기'}
             </Button>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -11,8 +11,12 @@ import {
   Users,
   HelpCircle,
   Calendar,
+  Moon,
+  Sun,
 } from 'lucide-react';
+import { useTheme } from 'next-themes';
 import { useAuth } from '../../hooks/useAuth';
+import { useState, useEffect } from 'react';
 
 const navItems = [
   { label: '커뮤니티', href: '/community', icon: '/whitebelt.svg' },
@@ -36,6 +40,13 @@ export default function Sidebar() {
   const pathname = usePathname();
   const { user, loading, logout } = useAuth();
   const isAdmin = user?.role === 'admin';
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setMounted(true), 0);
+    return () => clearTimeout(timer);
+  }, []);
 
   const handleLogout = async () => {
     await logout();
@@ -121,6 +132,27 @@ export default function Sidebar() {
             })}
           </nav>
         )}
+
+        <Button
+          variant="ghost"
+          className="w-full h-10 gap-2 text-text-secondary hover:text-text-primary cursor-pointer"
+          onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
+          aria-label="다크모드 전환"
+        >
+          {mounted &&
+            (resolvedTheme === 'dark' ? (
+              <Sun size={15} aria-hidden="true" />
+            ) : (
+              <Moon size={15} aria-hidden="true" />
+            ))}
+          <span className="text-sm">
+            {mounted
+              ? resolvedTheme === 'dark'
+                ? '라이트 모드'
+                : '다크 모드'
+              : '테마'}
+          </span>
+        </Button>
 
         {loading ? (
           <div className="h-12" aria-hidden="true" />

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -54,7 +54,7 @@ export default function Sidebar() {
 
   return (
     <aside
-      className="fixed left-0 top-0 flex flex-col border-r w-50 h-screen bg-bg-white border-gray-200"
+      className="fixed left-0 top-0 flex flex-col border-r w-50 h-screen bg-bg-white border-border"
       style={{ boxShadow: '4px 0 10px rgba(0,0,0,0.08)' }}
       aria-label="사이드바 내비게이션"
     >
@@ -70,7 +70,7 @@ export default function Sidebar() {
         </div>
       </Link>
 
-      <div className="border-t border-gray-200" aria-hidden="true" />
+      <div className="border-t border-border" aria-hidden="true" />
 
       <nav
         className="flex flex-col gap-1 px-3 py-3 flex-1"
@@ -104,7 +104,7 @@ export default function Sidebar() {
         })}
       </nav>
 
-      <div className="border-t border-gray-200" aria-hidden="true" />
+      <div className="border-t border-border" aria-hidden="true" />
 
       <div className="px-3 py-4 flex flex-col gap-2">
         {isAdmin && (

--- a/src/components/layout/ThemeToggle.tsx
+++ b/src/components/layout/ThemeToggle.tsx
@@ -2,9 +2,16 @@
 
 import { useTheme } from 'next-themes';
 import { Moon, Sun } from 'lucide-react';
+import { useState, useEffect } from 'react';
 
 export default function ThemeToggle() {
   const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setMounted(true), 0);
+    return () => clearTimeout(timer);
+  }, []);
 
   return (
     <button
@@ -12,7 +19,8 @@ export default function ThemeToggle() {
       className="p-2 rounded-lg hover:bg-btn-basic transition-colors"
       aria-label="다크모드 전환"
     >
-      {resolvedTheme === 'dark' ? <Sun size={20} /> : <Moon size={20} />}
+      {mounted &&
+        (resolvedTheme === 'dark' ? <Sun size={20} /> : <Moon size={20} />)}
     </button>
   );
 }

--- a/src/components/layout/ThemeToggle.tsx
+++ b/src/components/layout/ThemeToggle.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useTheme } from 'next-themes';
+import { Moon, Sun } from 'lucide-react';
+
+export default function ThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme();
+
+  return (
+    <button
+      onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
+      className="p-2 rounded-lg hover:bg-btn-basic transition-colors"
+      aria-label="다크모드 전환"
+    >
+      {resolvedTheme === 'dark' ? <Sun size={20} /> : <Moon size={20} />}
+    </button>
+  );
+}

--- a/src/components/mypage/PostList.tsx
+++ b/src/components/mypage/PostList.tsx
@@ -37,7 +37,7 @@ export default function PostList({ userId }: PostListProps) {
 
   if (posts.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center py-20 text-gray-400">
+      <div className="flex flex-col items-center justify-center py-20 text-text-secondary">
         <p className="text-lg">아직 작성한 게시글이 없어요</p>
       </div>
     );

--- a/src/components/mypage/ProfileCard.tsx
+++ b/src/components/mypage/ProfileCard.tsx
@@ -1,6 +1,14 @@
 import Image from 'next/image';
 import { Profile, BeltLevel } from '@/types/user';
-import { BELT_COLORS } from '@/utils/beltColors';
+
+const BELT_COLORS: Record<BeltLevel, string> = {
+  White: 'var(--color-belt-white)',
+  Blue: 'var(--color-belt-blue)',
+  Purple: 'var(--color-belt-purple)',
+  Brown: 'var(--color-belt-brown)',
+  Black: 'var(--color-belt-black)',
+};
+
 interface ProfileCardProps {
   profile: Profile;
   postCount?: number;

--- a/src/components/mypage/ProfileCard.tsx
+++ b/src/components/mypage/ProfileCard.tsx
@@ -1,14 +1,6 @@
 import Image from 'next/image';
 import { Profile, BeltLevel } from '@/types/user';
-
-const BELT_COLORS: Record<BeltLevel, string> = {
-  White: '#e8e8e8',
-  Blue: '#2e6fdb',
-  Purple: '#7c4ddb',
-  Brown: '#8b5a2b',
-  Black: '#1a1a1a',
-};
-
+import { BELT_COLORS } from '@/utils/beltColors';
 interface ProfileCardProps {
   profile: Profile;
   postCount?: number;
@@ -59,7 +51,7 @@ export default function ProfileCard({
       )}
 
       {/* 게시글 / 댓글 수 */}
-      <div className="flex gap-12 pt-4 border-t border-gray-100 w-full justify-center">
+      <div className="flex gap-12 pt-4 border-t border-border w-full justify-center">
         <div className="flex flex-col items-center gap-1">
           <span className="text-2xl font-bold text-text-primary">
             {postCount}

--- a/src/components/mypage/SettingsTab.tsx
+++ b/src/components/mypage/SettingsTab.tsx
@@ -15,13 +15,20 @@ import {
 import { useRouter } from 'next/navigation';
 import { LimitedInput } from '@/components/common/LimitedInput';
 import { LimitedTextarea } from '@/components/common/LimitedTextarea';
-import { BELT_COLORS } from '@/utils/beltColors';
 
 interface SettingsTabProps {
   profile: Profile;
 }
 
 const BELTS: BeltLevel[] = ['White', 'Blue', 'Purple', 'Brown', 'Black'];
+
+const BELT_COLORS: Record<BeltLevel, string> = {
+  White: 'var(--color-belt-white)',
+  Blue: 'var(--color-belt-blue)',
+  Purple: 'var(--color-belt-purple)',
+  Brown: 'var(--color-belt-brown)',
+  Black: 'var(--color-belt-black)',
+};
 
 export default function SettingsTab({ profile }: SettingsTabProps) {
   const [nickname, setNickname] = useState(profile.nickname ?? '');

--- a/src/components/mypage/SettingsTab.tsx
+++ b/src/components/mypage/SettingsTab.tsx
@@ -15,20 +15,13 @@ import {
 import { useRouter } from 'next/navigation';
 import { LimitedInput } from '@/components/common/LimitedInput';
 import { LimitedTextarea } from '@/components/common/LimitedTextarea';
+import { BELT_COLORS } from '@/utils/beltColors';
 
 interface SettingsTabProps {
   profile: Profile;
 }
 
 const BELTS: BeltLevel[] = ['White', 'Blue', 'Purple', 'Brown', 'Black'];
-
-const BELT_COLORS: Record<BeltLevel, string> = {
-  White: '#e8e8e8',
-  Blue: '#2e6fdb',
-  Purple: '#7c4ddb',
-  Brown: '#8b5a2b',
-  Black: '#1a1a1a',
-};
 
 export default function SettingsTab({ profile }: SettingsTabProps) {
   const [nickname, setNickname] = useState(profile.nickname ?? '');
@@ -163,7 +156,7 @@ export default function SettingsTab({ profile }: SettingsTabProps) {
               벨트
             </label>
             <div
-              className={`relative flex items-center rounded-xl px-4 py-3 ${isEditing ? 'bg-white border border-btn-focus' : 'bg-input-bg'}`}
+              className={`relative flex items-center rounded-xl px-4 py-3 ${isEditing ? 'bg-bg-white border border-btn-focus' : 'bg-input-bg'}`}
             >
               <span
                 className="w-3 h-3 rounded-full mr-2 shrink-0"

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -1,9 +1,12 @@
 import toast from 'react-hot-toast';
 
 export const showErrorToast = (message: string) => {
+  const isDark = document.documentElement.classList.contains('dark');
   toast.error(message, {
     position: 'bottom-center',
     style: {
+      background: isDark ? '#1a1a1a' : '#fff',
+      color: isDark ? '#e5e7eb' : '#111',
       fontWeight: '600',
       borderRadius: '12px',
       boxShadow: '0 4px 16px rgba(0,0,0,0.12)',
@@ -12,11 +15,12 @@ export const showErrorToast = (message: string) => {
 };
 
 export const showSuccessToast = (message: string, icon?: string) => {
+  const isDark = document.documentElement.classList.contains('dark');
   toast.success(message, {
     duration: 2000,
     position: 'bottom-center',
     style: {
-      background: '#111',
+      background: isDark ? '#1a1a1a' : '#111',
       color: '#fff',
       fontWeight: '600',
       borderRadius: '12px',

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -5,8 +5,8 @@ export const showErrorToast = (message: string) => {
   toast.error(message, {
     position: 'bottom-center',
     style: {
-      background: isDark ? '#1a1a1a' : '#fff',
-      color: isDark ? '#e5e7eb' : '#111',
+      background: isDark ? '#e5e7eb' : '#111',
+      color: isDark ? '#111' : '#fff',
       fontWeight: '600',
       borderRadius: '12px',
       boxShadow: '0 4px 16px rgba(0,0,0,0.12)',
@@ -20,8 +20,8 @@ export const showSuccessToast = (message: string, icon?: string) => {
     duration: 2000,
     position: 'bottom-center',
     style: {
-      background: isDark ? '#1a1a1a' : '#111',
-      color: '#fff',
+      background: isDark ? '#e5e7eb' : '#111',
+      color: isDark ? '#111' : '#fff',
       fontWeight: '600',
       borderRadius: '12px',
       padding: '12px 20px',

--- a/src/utils/beltColors.ts
+++ b/src/utils/beltColors.ts
@@ -1,0 +1,9 @@
+import { BeltLevel } from '@/types/user';
+
+export const BELT_COLORS: Record<BeltLevel, string> = {
+  White: 'var(--color-belt-white)',
+  Blue: 'var(--color-belt-blue)',
+  Purple: 'var(--color-belt-purple)',
+  Brown: 'var(--color-belt-brown)',
+  Black: 'var(--color-belt-black)',
+};

--- a/src/utils/beltColors.ts
+++ b/src/utils/beltColors.ts
@@ -1,9 +1,0 @@
-import { BeltLevel } from '@/types/user';
-
-export const BELT_COLORS: Record<BeltLevel, string> = {
-  White: 'var(--color-belt-white)',
-  Blue: 'var(--color-belt-blue)',
-  Purple: 'var(--color-belt-purple)',
-  Brown: 'var(--color-belt-brown)',
-  Black: 'var(--color-belt-black)',
-};


### PR DESCRIPTION
## 📌 개요
- 서비스 전체 페이지 및 공통 컴포넌트 다크모드 지원 추가
- 관리자 페이지 Dialog 내 버튼 및 텍스트 스타일 개선

## 💻 작업 사항

**global.css**
- 다크모드 CSS 변수 추가 (텍스트, 배경, 버튼, 상태, 카테고리, 벨트 등 전체 토큰화)
- 기존 하드코딩 색상값을 CSS 변수로 교체
- `.dark input`, `.dark textarea`, `.dark select` 다크모드 스타일 추가
- `ThemeProvider` 적용을 위한 레이아웃 수정

**다크모드 토글**
- `ThemeToggle` 컴포넌트 신규 추가 (라이트/다크/시스템 전환)
- `Sidebar`, 홈, 인증 레이아웃에 `ThemeToggle` 배치
- `next-themes` 기반 `ThemeProvider` 루트 레이아웃에 적용

**페이지 다크모드 적용**
- 홈, 에러, 커뮤니티, 게시글 작성/수정/상세, 도장찾기, 대회일정 목록/작성/상세, 마이페이지 전체 다크모드 스타일 적용
- 하드코딩 색상(`bg-white`, `text-gray-*`, `border-gray-*` 등) → CSS 변수 토큰(`bg-bg-white`, `text-text-primary`, `border-border` 등)으로 교체

**관리자 페이지 다크모드 적용**
- 대시보드, 게시글 관리, 대회일정 관리, 유저 관리, 고객지원 전체 적용
- Dialog 내부는 다크모드 미적용 영역으로 확정, 텍스트 하드코딩(`text-gray-900`, `text-gray-500`)으로 통일
- `text-text-primary`, `text-text-secondary` 커스텀 토큰 → 하드코딩으로 교체
- Dialog 안 액션 버튼 `actionButtonClass` 혼용 제거 및 버튼 가시성 개선
- `border` 클래스 누락 및 className `$` 오타 수정

**공통 컴포넌트 다크모드 적용**
- `ConfirmModal`, `ErrorBoundary`, `LimitedInput`, `LimitedTextarea`, `LoadingSpinner`, `ScrollToTop`, `SearchInput` 다크모드 스타일 적용
- `Sidebar`, `PageHeader`, `LogoutButton` 다크모드 스타일 적용
- 토스트(`showErrorToast`, `showSuccessToast`) 다크모드 배경/텍스트 색상 분기 처리
- `PostDetailCard`, `PostDetailClient`, `Postcard`, `ImageUpload` 등 커뮤니티 컴포넌트 다크모드 적용
- `CompetitionDetailCard`, `CompetitionDetailClient`, `CompetitionForm` 등 대회 컴포넌트 다크모드 적용
- `DojangCard`, `DojangClient` 다크모드 적용
- `ProfileCard`, `SettingsTab`, `PostList` 마이페이지 컴포넌트 다크모드 적용
- 벨트 색상 하드코딩 → CSS 변수(`var(--color-belt-*)`)로 교체
- 카테고리/역할 뱃지 색상 하드코딩 → CSS 변수 토큰으로 교체
- SVG 아이콘 일부 `dark:invert` 적용

## 💡 관련 Issue

Closes #179 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #179 )
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
