### PR TITLE
[Fix] 관리자 페이지 데이터패칭 서버 페이지네이션 방식 적용

### DIFF
--- a/src/app/(admin)/admin/competitions/page.tsx
+++ b/src/app/(admin)/admin/competitions/page.tsx
@@ -1,17 +1,66 @@
 import type { Metadata } from 'next';
 
 import AdminCompetitionsClient from '@/components/admin/competitions/AdminCompetitionsClient';
+import {
+  ADMIN_COMPETITION_FILTERS,
+  COMPETITION_DEADLINE_WARNING_DAYS,
+} from '@/components/admin/competitions/constants';
 import type { CompetitionQueryRow } from '@/components/admin/competitions/types';
 import { mapCompetitionQueryRowsToAdminCompetitionRows } from '@/components/admin/competitions/utils';
 import { getAdminPageMetadata } from '@/constants/adminMeta';
+import {
+  ADMIN_TABLE_PAGE_SIZE,
+  buildAdminPaginationRange,
+  parseAdminTableServerQuery,
+  type AdminTableRouteSearchParams,
+} from '@/lib/adminTableServerPagination';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 
 export const metadata: Metadata = getAdminPageMetadata('competitions');
 
-async function getAdminCompetitions() {
-  const supabase = await createSupabaseServerClient();
+type AdminCompetitionsPageSearchParams = Promise<
+  AdminTableRouteSearchParams & {
+    status?: string | string[] | undefined;
+  }
+>;
 
-  const { data, error } = await supabase
+function formatDateOnly(date: Date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function getCompetitionFilterDates() {
+  const today = new Date();
+
+  today.setHours(0, 0, 0, 0);
+
+  const warningDeadline = new Date(today);
+  warningDeadline.setDate(today.getDate() + COMPETITION_DEADLINE_WARNING_DAYS);
+
+  return {
+    today: formatDateOnly(today),
+    warningDeadline: formatDateOnly(warningDeadline),
+  };
+}
+
+async function getAdminCompetitions(
+  searchParams: Awaited<AdminCompetitionsPageSearchParams>,
+) {
+  const supabase = await createSupabaseServerClient();
+  const { requestedPage, activeFilter, normalizedSearchQuery } =
+    parseAdminTableServerQuery({
+      searchParams,
+      filterParamName: 'status',
+      validFilters: ADMIN_COMPETITION_FILTERS.map((filter) => filter.value),
+      defaultFilter: 'all',
+    });
+  const { today, warningDeadline } = getCompetitionFilterDates();
+
+  let countQuery = supabase.from('competition').select('id', {
+    count: 'exact',
+    head: true,
+  });
+
+  let dataQuery = supabase
     .from('competition')
     .select(
       `
@@ -26,17 +75,75 @@ async function getAdminCompetitions() {
     )
     .order('created_at', { ascending: false });
 
+  if (activeFilter === '모집완료') {
+    countQuery = countQuery.lt('apply_deadline', today);
+    dataQuery = dataQuery.lt('apply_deadline', today);
+  }
+
+  if (activeFilter === '마감임박') {
+    countQuery = countQuery
+      .gte('apply_deadline', today)
+      .lte('apply_deadline', warningDeadline);
+    dataQuery = dataQuery
+      .gte('apply_deadline', today)
+      .lte('apply_deadline', warningDeadline);
+  }
+
+  if (activeFilter === '모집중') {
+    countQuery = countQuery.gt('apply_deadline', warningDeadline);
+    dataQuery = dataQuery.gt('apply_deadline', warningDeadline);
+  }
+
+  if (normalizedSearchQuery.length > 0) {
+    countQuery = countQuery.ilike('name', `%${normalizedSearchQuery}%`);
+    dataQuery = dataQuery.ilike('name', `%${normalizedSearchQuery}%`);
+  }
+
+  const { count, error: countError } = await countQuery;
+
+  if (countError) {
+    throw new Error(countError.message);
+  }
+
+  const totalCount = count ?? 0;
+  const { from, to, pageSize } = buildAdminPaginationRange({
+    requestedPage,
+    totalCount,
+    pageSize: ADMIN_TABLE_PAGE_SIZE,
+  });
+
+  const { data, error } = await dataQuery.range(from, to);
+
   if (error) {
     throw new Error(error.message);
   }
 
-  return mapCompetitionQueryRowsToAdminCompetitionRows(
-    (data ?? []) as CompetitionQueryRow[],
-  );
+  return {
+    rows: mapCompetitionQueryRowsToAdminCompetitionRows(
+      (data ?? []) as CompetitionQueryRow[],
+    ),
+    totalCount,
+    pageSize,
+  };
 }
 
-export default async function AdminCompetitionsPage() {
-  const data = await getAdminCompetitions();
+interface AdminCompetitionsPageProps {
+  searchParams: AdminCompetitionsPageSearchParams;
+}
 
-  return <AdminCompetitionsClient data={data} />;
+export default async function AdminCompetitionsPage({
+  searchParams,
+}: AdminCompetitionsPageProps) {
+  const resolvedSearchParams = await searchParams;
+  const { rows, totalCount, pageSize } = await getAdminCompetitions(
+    resolvedSearchParams,
+  );
+
+  return (
+    <AdminCompetitionsClient
+      data={rows}
+      totalCount={totalCount}
+      pageSize={pageSize}
+    />
+  );
 }

--- a/src/app/(admin)/admin/posts/page.tsx
+++ b/src/app/(admin)/admin/posts/page.tsx
@@ -1,17 +1,89 @@
 import type { Metadata } from 'next';
 
 import AdminPostTableClient from '@/components/admin/posts/AdminPostsTableClient';
+import {
+  ADMIN_POST_FILTERS,
+  ADMIN_POSTS_PAGE_SIZE,
+  CATEGORY_QUERY_VALUE_MAP,
+} from '@/components/admin/posts/constants';
 import type { PostQueryRow } from '@/components/admin/posts/types';
+import type { AdminPostFilterValue } from '@/components/admin/posts/types';
 import { mapPostQueryRowsToAdminPostRows } from '@/components/admin/posts/utils';
 import { getAdminPageMetadata } from '@/constants/adminMeta';
+import { parseEnumParam, parsePositiveIntParam } from '@/lib/urlSearchParams';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 
 export const metadata: Metadata = getAdminPageMetadata('posts');
 
-async function getAdminPosts() {
-  const supabase = await createSupabaseServerClient();
+type AdminPostsPageSearchParams = Promise<{
+  page?: string | string[] | undefined;
+  search?: string | string[] | undefined;
+  category?: string | string[] | undefined;
+  status?: string | string[] | undefined;
+}>;
 
-  const { data, error } = await supabase
+type AdminPostStatusFilterValue =
+  | 'all'
+  | 'published'
+  | 'hidden'
+  | 'deleted';
+
+const ADMIN_POST_STATUS_FILTERS = [
+  'all',
+  'published',
+  'hidden',
+  'deleted',
+] as const satisfies readonly AdminPostStatusFilterValue[];
+
+function getSingleSearchParam(
+  value: string | string[] | undefined,
+): string | null {
+  if (Array.isArray(value)) {
+    return value[0] ?? null;
+  }
+
+  return value ?? null;
+}
+
+async function getAdminPosts(searchParams: Awaited<AdminPostsPageSearchParams>) {
+  const supabase = await createSupabaseServerClient();
+  const requestedPage = parsePositiveIntParam(
+    getSingleSearchParam(searchParams.page),
+    1,
+  ).value;
+  const activeCategory = parseEnumParam<AdminPostFilterValue>(
+    getSingleSearchParam(searchParams.category),
+    ADMIN_POST_FILTERS.map((filter) => filter.value),
+    'all',
+  );
+  const activeStatus = parseEnumParam<AdminPostStatusFilterValue>(
+    getSingleSearchParam(searchParams.status),
+    ADMIN_POST_STATUS_FILTERS,
+    'all',
+  );
+  const normalizedSearchQuery =
+    getSingleSearchParam(searchParams.search)?.trim() ?? '';
+  let authorIds: string[] = [];
+
+  if (normalizedSearchQuery.length > 0) {
+    const { data: matchingProfiles, error: authorSearchError } = await supabase
+      .from('profiles')
+      .select('id')
+      .ilike('nickname', `%${normalizedSearchQuery}%`);
+
+    if (authorSearchError) {
+      throw new Error(authorSearchError.message);
+    }
+
+    authorIds = (matchingProfiles ?? []).map((profile) => profile.id);
+  }
+
+  let countQuery = supabase.from('posts').select('id', {
+    count: 'exact',
+    head: true,
+  });
+
+  let dataQuery = supabase
     .from('posts')
     .select(
       `
@@ -30,15 +102,86 @@ async function getAdminPosts() {
     )
     .order('created_at', { ascending: false });
 
+  if (activeCategory !== 'all') {
+    const dbCategory = CATEGORY_QUERY_VALUE_MAP[activeCategory];
+
+    countQuery = countQuery.eq('category', dbCategory);
+    dataQuery = dataQuery.eq('category', dbCategory);
+  }
+
+  if (activeStatus === 'published') {
+    countQuery = countQuery.eq('status', 'published').is('deleted_at', null);
+    dataQuery = dataQuery.eq('status', 'published').is('deleted_at', null);
+  }
+
+  if (activeStatus === 'hidden') {
+    countQuery = countQuery.eq('status', 'hidden').is('deleted_at', null);
+    dataQuery = dataQuery.eq('status', 'hidden').is('deleted_at', null);
+  }
+
+  if (activeStatus === 'deleted') {
+    countQuery = countQuery.not('deleted_at', 'is', null);
+    dataQuery = dataQuery.not('deleted_at', 'is', null);
+  }
+
+  if (normalizedSearchQuery.length > 0) {
+    const titleFilter = `title.ilike.%${normalizedSearchQuery}%`;
+
+    if (authorIds.length > 0) {
+      const authorFilter = `user_id.in.(${authorIds.join(',')})`;
+      const searchFilter = `${titleFilter},${authorFilter}`;
+
+      countQuery = countQuery.or(searchFilter);
+      dataQuery = dataQuery.or(searchFilter);
+    } else {
+      countQuery = countQuery.ilike('title', `%${normalizedSearchQuery}%`);
+      dataQuery = dataQuery.ilike('title', `%${normalizedSearchQuery}%`);
+    }
+  }
+
+  const { count, error: countError } = await countQuery;
+
+  if (countError) {
+    throw new Error(countError.message);
+  }
+
+  const totalCount = count ?? 0;
+  const totalPages = Math.max(1, Math.ceil(totalCount / ADMIN_POSTS_PAGE_SIZE));
+  const currentPage =
+    totalCount === 0 ? 1 : Math.min(requestedPage, totalPages);
+  const from = (currentPage - 1) * ADMIN_POSTS_PAGE_SIZE;
+  const to = from + ADMIN_POSTS_PAGE_SIZE - 1;
+
+  const { data, error } = await dataQuery.range(from, to);
+
   if (error) {
     throw new Error(error.message);
   }
 
-  return mapPostQueryRowsToAdminPostRows((data ?? []) as PostQueryRow[]);
+  return {
+    rows: mapPostQueryRowsToAdminPostRows((data ?? []) as PostQueryRow[]),
+    totalCount,
+    pageSize: ADMIN_POSTS_PAGE_SIZE,
+  };
 }
 
-export default async function AdminPostPage() {
-  const postData = await getAdminPosts();
+interface AdminPostPageProps {
+  searchParams: AdminPostsPageSearchParams;
+}
 
-  return <AdminPostTableClient data={postData} />;
+export default async function AdminPostPage({
+  searchParams,
+}: AdminPostPageProps) {
+  const resolvedSearchParams = await searchParams;
+  const { rows, totalCount, pageSize } = await getAdminPosts(
+    resolvedSearchParams,
+  );
+
+  return (
+    <AdminPostTableClient
+      data={rows}
+      totalCount={totalCount}
+      pageSize={pageSize}
+    />
+  );
 }

--- a/src/app/(admin)/admin/posts/page.tsx
+++ b/src/app/(admin)/admin/posts/page.tsx
@@ -3,24 +3,27 @@ import type { Metadata } from 'next';
 import AdminPostTableClient from '@/components/admin/posts/AdminPostsTableClient';
 import {
   ADMIN_POST_FILTERS,
-  ADMIN_POSTS_PAGE_SIZE,
   CATEGORY_QUERY_VALUE_MAP,
 } from '@/components/admin/posts/constants';
 import type { PostQueryRow } from '@/components/admin/posts/types';
-import type { AdminPostFilterValue } from '@/components/admin/posts/types';
 import { mapPostQueryRowsToAdminPostRows } from '@/components/admin/posts/utils';
 import { getAdminPageMetadata } from '@/constants/adminMeta';
-import { parseEnumParam, parsePositiveIntParam } from '@/lib/urlSearchParams';
+import {
+  ADMIN_TABLE_PAGE_SIZE,
+  buildAdminPaginationRange,
+  parseAdminTableServerQuery,
+  type AdminTableRouteSearchParams,
+} from '@/lib/adminTableServerPagination';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 
 export const metadata: Metadata = getAdminPageMetadata('posts');
 
-type AdminPostsPageSearchParams = Promise<{
-  page?: string | string[] | undefined;
-  search?: string | string[] | undefined;
-  category?: string | string[] | undefined;
-  status?: string | string[] | undefined;
-}>;
+type AdminPostsPageSearchParams = Promise<
+  AdminTableRouteSearchParams & {
+    category?: string | string[] | undefined;
+    status?: string | string[] | undefined;
+  }
+>;
 
 type AdminPostStatusFilterValue =
   | 'all'
@@ -35,34 +38,21 @@ const ADMIN_POST_STATUS_FILTERS = [
   'deleted',
 ] as const satisfies readonly AdminPostStatusFilterValue[];
 
-function getSingleSearchParam(
-  value: string | string[] | undefined,
-): string | null {
-  if (Array.isArray(value)) {
-    return value[0] ?? null;
-  }
-
-  return value ?? null;
-}
-
 async function getAdminPosts(searchParams: Awaited<AdminPostsPageSearchParams>) {
   const supabase = await createSupabaseServerClient();
-  const requestedPage = parsePositiveIntParam(
-    getSingleSearchParam(searchParams.page),
-    1,
-  ).value;
-  const activeCategory = parseEnumParam<AdminPostFilterValue>(
-    getSingleSearchParam(searchParams.category),
-    ADMIN_POST_FILTERS.map((filter) => filter.value),
-    'all',
-  );
-  const activeStatus = parseEnumParam<AdminPostStatusFilterValue>(
-    getSingleSearchParam(searchParams.status),
-    ADMIN_POST_STATUS_FILTERS,
-    'all',
-  );
-  const normalizedSearchQuery =
-    getSingleSearchParam(searchParams.search)?.trim() ?? '';
+  const { requestedPage, activeFilter: activeCategory, normalizedSearchQuery } =
+    parseAdminTableServerQuery({
+      searchParams,
+      filterParamName: 'category',
+      validFilters: ADMIN_POST_FILTERS.map((filter) => filter.value),
+      defaultFilter: 'all',
+    });
+  const { activeFilter: activeStatus } = parseAdminTableServerQuery({
+    searchParams,
+    filterParamName: 'status',
+    validFilters: ADMIN_POST_STATUS_FILTERS,
+    defaultFilter: 'all',
+  });
 
   let countQuery = supabase.from('posts').select('id', {
     count: 'exact',
@@ -122,11 +112,11 @@ async function getAdminPosts(searchParams: Awaited<AdminPostsPageSearchParams>) 
   }
 
   const totalCount = count ?? 0;
-  const totalPages = Math.max(1, Math.ceil(totalCount / ADMIN_POSTS_PAGE_SIZE));
-  const currentPage =
-    totalCount === 0 ? 1 : Math.min(requestedPage, totalPages);
-  const from = (currentPage - 1) * ADMIN_POSTS_PAGE_SIZE;
-  const to = from + ADMIN_POSTS_PAGE_SIZE - 1;
+  const { from, to, pageSize } = buildAdminPaginationRange({
+    requestedPage,
+    totalCount,
+    pageSize: ADMIN_TABLE_PAGE_SIZE,
+  });
 
   const { data, error } = await dataQuery.range(from, to);
 
@@ -137,7 +127,7 @@ async function getAdminPosts(searchParams: Awaited<AdminPostsPageSearchParams>) 
   return {
     rows: mapPostQueryRowsToAdminPostRows((data ?? []) as PostQueryRow[]),
     totalCount,
-    pageSize: ADMIN_POSTS_PAGE_SIZE,
+    pageSize,
   };
 }
 

--- a/src/app/(admin)/admin/posts/page.tsx
+++ b/src/app/(admin)/admin/posts/page.tsx
@@ -63,20 +63,6 @@ async function getAdminPosts(searchParams: Awaited<AdminPostsPageSearchParams>) 
   );
   const normalizedSearchQuery =
     getSingleSearchParam(searchParams.search)?.trim() ?? '';
-  let authorIds: string[] = [];
-
-  if (normalizedSearchQuery.length > 0) {
-    const { data: matchingProfiles, error: authorSearchError } = await supabase
-      .from('profiles')
-      .select('id')
-      .ilike('nickname', `%${normalizedSearchQuery}%`);
-
-    if (authorSearchError) {
-      throw new Error(authorSearchError.message);
-    }
-
-    authorIds = (matchingProfiles ?? []).map((profile) => profile.id);
-  }
 
   let countQuery = supabase.from('posts').select('id', {
     count: 'exact',
@@ -125,18 +111,8 @@ async function getAdminPosts(searchParams: Awaited<AdminPostsPageSearchParams>) 
   }
 
   if (normalizedSearchQuery.length > 0) {
-    const titleFilter = `title.ilike.%${normalizedSearchQuery}%`;
-
-    if (authorIds.length > 0) {
-      const authorFilter = `user_id.in.(${authorIds.join(',')})`;
-      const searchFilter = `${titleFilter},${authorFilter}`;
-
-      countQuery = countQuery.or(searchFilter);
-      dataQuery = dataQuery.or(searchFilter);
-    } else {
-      countQuery = countQuery.ilike('title', `%${normalizedSearchQuery}%`);
-      dataQuery = dataQuery.ilike('title', `%${normalizedSearchQuery}%`);
-    }
+    countQuery = countQuery.ilike('title', `%${normalizedSearchQuery}%`);
+    dataQuery = dataQuery.ilike('title', `%${normalizedSearchQuery}%`);
   }
 
   const { count, error: countError } = await countQuery;

--- a/src/app/(admin)/admin/support/page.tsx
+++ b/src/app/(admin)/admin/support/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 
 import AdminSupportTableClient from '@/components/admin/support/AdminSupportTableClient';
+import { SUPPORT_SECTION_FILTERS } from '@/components/admin/support/constants';
 import type {
   SupportDojangQueryRow,
   SupportPostQueryRow,
@@ -10,21 +11,58 @@ import type {
 import {
   mapDojangQueryRowsToAdminDojangVerificationRows,
   mapReportQueryRowsToAdminReportRows,
-  sortSupportReportQueryRows,
 } from '@/components/admin/support/utils';
 import { getAdminPageMetadata } from '@/constants/adminMeta';
+import {
+  ADMIN_TABLE_PAGE_SIZE,
+  buildAdminPaginationRange,
+  parseAdminTableServerQuery,
+  type AdminTableRouteSearchParams,
+} from '@/lib/adminTableServerPagination';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 
 export const metadata: Metadata = getAdminPageMetadata('support');
 
-async function getAdminSupportData() {
-  const supabase = await createSupabaseServerClient();
+type AdminSupportPageSearchParams = Promise<
+  AdminTableRouteSearchParams & {
+    section?: string | string[] | undefined;
+  }
+>;
 
-  const [dojangResult, reportsResult] = await Promise.all([
-    supabase
-      .from('dojang')
-      .select(
-        `
+async function getAdminDojangSupportData(
+  searchParams: Awaited<AdminSupportPageSearchParams>,
+) {
+  const supabase = await createSupabaseServerClient();
+  const { requestedPage, normalizedSearchQuery } = parseAdminTableServerQuery({
+    searchParams,
+    filterParamName: 'section',
+    validFilters: SUPPORT_SECTION_FILTERS.map((filter) => filter.value),
+    defaultFilter: 'dojang',
+  });
+  let matchingProfileIds: string[] = [];
+
+  if (normalizedSearchQuery.length > 0) {
+    const { data: matchingProfiles, error: matchingProfilesError } =
+      await supabase
+        .from('profiles')
+        .select('id')
+        .ilike('nickname', `%${normalizedSearchQuery}%`);
+
+    if (matchingProfilesError) {
+      throw new Error(matchingProfilesError.message);
+    }
+
+    matchingProfileIds = (matchingProfiles ?? []).map((profile) => profile.id);
+  }
+
+  let countQuery = supabase.from('dojang').select('id', {
+    count: 'exact',
+    head: true,
+  });
+  let dataQuery = supabase
+    .from('dojang')
+    .select(
+      `
         id,
         profile_id,
         business_number,
@@ -36,55 +74,45 @@ async function getAdminSupportData() {
         created_at,
         updated_at
       `,
-      )
-      .order('created_at', { ascending: false }),
-    supabase
-      .from('reports')
-      .select(
-        `
-        id,
-        reporter_id,
-        post_id,
-        reason,
-        created_at,
-        reports_status,
-        handled_at,
-        action_type
-      `,
-      )
-      .order('created_at', { ascending: false }),
-  ]);
+    )
+    .order('created_at', { ascending: false });
+
+  if (normalizedSearchQuery.length > 0) {
+    if (matchingProfileIds.length > 0) {
+      const dojangSearchFilter = [
+        `address.ilike.%${normalizedSearchQuery}%`,
+        `profile_id.in.(${matchingProfileIds.join(',')})`,
+      ].join(',');
+
+      countQuery = countQuery.or(dojangSearchFilter);
+      dataQuery = dataQuery.or(dojangSearchFilter);
+    } else {
+      countQuery = countQuery.ilike('address', `%${normalizedSearchQuery}%`);
+      dataQuery = dataQuery.ilike('address', `%${normalizedSearchQuery}%`);
+    }
+  }
+
+  const { count, error: dojangCountError } = await countQuery;
+
+  if (dojangCountError) {
+    throw new Error(dojangCountError.message);
+  }
+
+  const totalCount = count ?? 0;
+  const { from, to, pageSize } = buildAdminPaginationRange({
+    requestedPage,
+    totalCount,
+    pageSize: ADMIN_TABLE_PAGE_SIZE,
+  });
+
+  const dojangResult = await dataQuery.range(from, to);
 
   if (dojangResult.error) {
     throw new Error(dojangResult.error.message);
   }
 
-  if (reportsResult.error) {
-    throw new Error(reportsResult.error.message);
-  }
-
   const dojangs = (dojangResult.data ?? []) as SupportDojangQueryRow[];
-  const reports = sortSupportReportQueryRows(
-    (reportsResult.data ?? []) as SupportReportQueryRow[],
-  );
-
-  const profileIds = Array.from(
-    new Set([
-      ...dojangs.map((dojang) => dojang.profile_id),
-      ...reports
-        .map((report) => report.reporter_id)
-        .filter((reporterId): reporterId is string => Boolean(reporterId)),
-    ]),
-  );
-
-  const postIds = Array.from(
-    new Set(
-      reports
-        .map((report) => report.post_id)
-        .filter((postId): postId is string => Boolean(postId)),
-    ),
-  );
-
+  const profileIds = Array.from(new Set(dojangs.map((dojang) => dojang.profile_id)));
   const profilesResult =
     profileIds.length > 0
       ? await supabase
@@ -99,9 +127,130 @@ async function getAdminSupportData() {
           .in('id', profileIds)
       : { data: [] as SupportProfileQueryRow[], error: null };
 
-  const postsResult =
+  if (profilesResult.error) {
+    throw new Error(profilesResult.error.message);
+  }
+
+  return {
+    dojangVerifications: mapDojangQueryRowsToAdminDojangVerificationRows(
+      dojangs,
+      (profilesResult.data ?? []) as SupportProfileQueryRow[],
+    ),
+    reports: [],
+    totalCount,
+    pageSize,
+  };
+}
+
+async function getAdminReportsSupportData(
+  searchParams: Awaited<AdminSupportPageSearchParams>,
+) {
+  const supabase = await createSupabaseServerClient();
+  const { requestedPage, normalizedSearchQuery } = parseAdminTableServerQuery({
+    searchParams,
+    filterParamName: 'section',
+    validFilters: SUPPORT_SECTION_FILTERS.map((filter) => filter.value),
+    defaultFilter: 'dojang',
+  });
+  let matchingPostIds: string[] = [];
+
+  if (normalizedSearchQuery.length > 0) {
+    const { data: matchingPosts, error: matchingPostsError } = await supabase
+      .from('posts')
+      .select('id')
+      .ilike('title', `%${normalizedSearchQuery}%`);
+
+    if (matchingPostsError) {
+      throw new Error(matchingPostsError.message);
+    }
+
+    matchingPostIds = (matchingPosts ?? []).map((post) => post.id);
+  }
+
+  if (normalizedSearchQuery.length > 0 && matchingPostIds.length === 0) {
+    return {
+      dojangVerifications: [],
+      reports: [],
+      totalCount: 0,
+      pageSize: ADMIN_TABLE_PAGE_SIZE,
+    };
+  }
+
+  let countQuery = supabase.from('reports').select('id', {
+    count: 'exact',
+    head: true,
+  });
+  let dataQuery = supabase
+    .from('reports')
+    .select(
+      `
+        id,
+        reporter_id,
+        post_id,
+        reason,
+        created_at,
+        reports_status,
+        handled_at,
+        action_type
+      `,
+    )
+    .order('reports_status', { ascending: true })
+    .order('created_at', { ascending: false });
+
+  if (matchingPostIds.length > 0) {
+    countQuery = countQuery.in('post_id', matchingPostIds);
+    dataQuery = dataQuery.in('post_id', matchingPostIds);
+  }
+
+  const { count, error: reportsCountError } = await countQuery;
+
+  if (reportsCountError) {
+    throw new Error(reportsCountError.message);
+  }
+
+  const totalCount = count ?? 0;
+  const { from, to, pageSize } = buildAdminPaginationRange({
+    requestedPage,
+    totalCount,
+    pageSize: ADMIN_TABLE_PAGE_SIZE,
+  });
+
+  const reportsResult = await dataQuery.range(from, to);
+
+  if (reportsResult.error) {
+    throw new Error(reportsResult.error.message);
+  }
+
+  const reports = (reportsResult.data ?? []) as SupportReportQueryRow[];
+  const profileIds = Array.from(
+    new Set(
+      reports
+        .map((report) => report.reporter_id)
+        .filter((reporterId): reporterId is string => Boolean(reporterId)),
+    ),
+  );
+  const postIds = Array.from(
+    new Set(
+      reports
+        .map((report) => report.post_id)
+        .filter((postId): postId is string => Boolean(postId)),
+    ),
+  );
+  const [profilesResult, postsResult] = await Promise.all([
+    profileIds.length > 0
+      ? supabase
+          .from('profiles')
+          .select(
+            `
+            id,
+            nickname,
+            email_value
+          `,
+          )
+          .in('id', profileIds)
+      : Promise.resolve({ data: [] as SupportProfileQueryRow[], error: null }),
     postIds.length > 0
-      ? await supabase
+      ? supabase
           .from('posts')
           .select(
             `
@@ -112,7 +261,8 @@ async function getAdminSupportData() {
           `,
           )
           .in('id', postIds)
-      : { data: [] as SupportPostQueryRow[], error: null };
+      : Promise.resolve({ data: [] as SupportPostQueryRow[], error: null }),
+  ]);
 
   if (profilesResult.error) {
     throw new Error(profilesResult.error.message);
@@ -122,25 +272,51 @@ async function getAdminSupportData() {
     throw new Error(postsResult.error.message);
   }
 
-  const profiles = (profilesResult.data ?? []) as SupportProfileQueryRow[];
-  const posts = (postsResult.data ?? []) as SupportPostQueryRow[];
-
   return {
-    dojangVerifications: mapDojangQueryRowsToAdminDojangVerificationRows(
-      dojangs,
-      profiles,
+    dojangVerifications: [],
+    reports: mapReportQueryRowsToAdminReportRows(
+      reports,
+      (postsResult.data ?? []) as SupportPostQueryRow[],
+      (profilesResult.data ?? []) as SupportProfileQueryRow[],
     ),
-    reports: mapReportQueryRowsToAdminReportRows(reports, posts, profiles),
+    totalCount,
+    pageSize,
   };
 }
 
-export default async function AdminSupportPage() {
-  const data = await getAdminSupportData();
+async function getAdminSupportData(
+  searchParams: Awaited<AdminSupportPageSearchParams>,
+) {
+  const { activeFilter } = parseAdminTableServerQuery({
+    searchParams,
+    filterParamName: 'section',
+    validFilters: SUPPORT_SECTION_FILTERS.map((filter) => filter.value),
+    defaultFilter: 'dojang',
+  });
+
+  if (activeFilter === 'reports') {
+    return getAdminReportsSupportData(searchParams);
+  }
+
+  return getAdminDojangSupportData(searchParams);
+}
+
+interface AdminSupportPageProps {
+  searchParams: AdminSupportPageSearchParams;
+}
+
+export default async function AdminSupportPage({
+  searchParams,
+}: AdminSupportPageProps) {
+  const resolvedSearchParams = await searchParams;
+  const data = await getAdminSupportData(resolvedSearchParams);
 
   return (
     <AdminSupportTableClient
       dojangVerifications={data.dojangVerifications}
+      pageSize={data.pageSize}
       reports={data.reports}
+      totalCount={data.totalCount}
     />
   );
 }

--- a/src/app/(admin)/admin/users/page.tsx
+++ b/src/app/(admin)/admin/users/page.tsx
@@ -1,39 +1,116 @@
 import type { Metadata } from 'next';
 
 import AdminUsersClient from '@/components/admin/users/AdminUsersClient';
+import { ADMIN_USER_FILTERS } from '@/components/admin/users/constants';
 import type {
   DojangQueryRow,
   ProfileQueryRow,
 } from '@/components/admin/users/types';
 import { mapProfilesToAdminUserRows } from '@/components/admin/users/utils';
 import { getAdminPageMetadata } from '@/constants/adminMeta';
+import {
+  ADMIN_TABLE_PAGE_SIZE,
+  buildAdminPaginationRange,
+  parseAdminTableServerQuery,
+  type AdminTableRouteSearchParams,
+} from '@/lib/adminTableServerPagination';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 
 export const metadata: Metadata = getAdminPageMetadata('users');
 
-async function getAdminUsers() {
-  const supabase = await createSupabaseServerClient();
+type AdminUsersPageSearchParams = Promise<
+  AdminTableRouteSearchParams & {
+    status?: string | string[] | undefined;
+  }
+>;
 
-  const [profilesResult, dojangsResult] = await Promise.all([
-    supabase
-      .from('profiles')
-      .select(
-        `
-        id,
-        nickname,
-        avatar_url,
-        bio,
-        belt_level,
-        created_at,
-        role,
-        email_value,
-        name,
-        account_status
-      `,
-      )
-      .order('created_at', { ascending: false }),
-    supabase.from('dojang').select(
+const DOJANG_ROLE_VALUES = ['manager', 'dojang', 'pending'] as const;
+
+async function getAdminUsers(searchParams: Awaited<AdminUsersPageSearchParams>) {
+  const supabase = await createSupabaseServerClient();
+  const { requestedPage, activeFilter, normalizedSearchQuery } =
+    parseAdminTableServerQuery({
+      searchParams,
+      filterParamName: 'status',
+      validFilters: ADMIN_USER_FILTERS.map((filter) => filter.value),
+      defaultFilter: 'all',
+    });
+
+  let profilesCountQuery = supabase.from('profiles').select('id', {
+    count: 'exact',
+    head: true,
+  });
+
+  let profilesDataQuery = supabase
+    .from('profiles')
+    .select(
       `
+        created_at,
+        account_status,
+        avatar_url,
+        belt_level,
+        bio,
+        email_value,
+        id,
+        name,
+        nickname,
+        role
+      `,
+    )
+    .order('created_at', { ascending: false });
+
+  if (activeFilter === '관리자') {
+    profilesCountQuery = profilesCountQuery.eq('role', 'admin');
+    profilesDataQuery = profilesDataQuery.eq('role', 'admin');
+  }
+
+  if (activeFilter === '도장') {
+    profilesCountQuery = profilesCountQuery.in('role', [...DOJANG_ROLE_VALUES]);
+    profilesDataQuery = profilesDataQuery.in('role', [...DOJANG_ROLE_VALUES]);
+  }
+
+  if (activeFilter === '일반') {
+    profilesCountQuery = profilesCountQuery.eq('role', 'user');
+    profilesDataQuery = profilesDataQuery.eq('role', 'user');
+  }
+
+  if (normalizedSearchQuery.length > 0) {
+    const userSearchFilter = [
+      `nickname.ilike.%${normalizedSearchQuery}%`,
+      `name.ilike.%${normalizedSearchQuery}%`,
+      `email_value.ilike.%${normalizedSearchQuery}%`,
+    ].join(',');
+
+    profilesCountQuery = profilesCountQuery.or(userSearchFilter);
+    profilesDataQuery = profilesDataQuery.or(userSearchFilter);
+  }
+
+  const { count, error: profilesCountError } = await profilesCountQuery;
+
+  if (profilesCountError) {
+    throw new Error(profilesCountError.message);
+  }
+
+  const totalCount = count ?? 0;
+  const { from, to, pageSize } = buildAdminPaginationRange({
+    requestedPage,
+    totalCount,
+    pageSize: ADMIN_TABLE_PAGE_SIZE,
+  });
+
+  const profilesResult = await profilesDataQuery.range(from, to);
+
+  if (profilesResult.error) {
+    throw new Error(profilesResult.error.message);
+  }
+
+  const profiles = (profilesResult.data ?? []) as ProfileQueryRow[];
+  const profileIds = profiles.map((profile) => profile.id);
+
+  const dojangsResult =
+    profileIds.length > 0
+      ? await supabase.from('dojang').select(
+          `
         id,
         profile_id,
         business_number,
@@ -45,25 +122,40 @@ async function getAdminUsers() {
         created_at,
         updated_at
       `,
-    ),
-  ]);
-
-  if (profilesResult.error) {
-    throw new Error(profilesResult.error.message);
-  }
+        ).in('profile_id', profileIds)
+      : { data: [] as DojangQueryRow[], error: null };
 
   if (dojangsResult.error) {
     throw new Error(dojangsResult.error.message);
   }
 
-  return mapProfilesToAdminUserRows(
-    (profilesResult.data ?? []) as ProfileQueryRow[],
-    (dojangsResult.data ?? []) as DojangQueryRow[],
-  );
+  return {
+    rows: mapProfilesToAdminUserRows(
+      profiles,
+      (dojangsResult.data ?? []) as DojangQueryRow[],
+    ),
+    totalCount,
+    pageSize,
+  };
 }
 
-export default async function AdminUsersPage() {
-  const data = await getAdminUsers();
+interface AdminUsersPageProps {
+  searchParams: AdminUsersPageSearchParams;
+}
 
-  return <AdminUsersClient data={data} />;
+export default async function AdminUsersPage({
+  searchParams,
+}: AdminUsersPageProps) {
+  const resolvedSearchParams = await searchParams;
+  const { rows, totalCount, pageSize } = await getAdminUsers(
+    resolvedSearchParams,
+  );
+
+  return (
+    <AdminUsersClient
+      data={rows}
+      totalCount={totalCount}
+      pageSize={pageSize}
+    />
+  );
 }

--- a/src/components/admin/AdminDataTable.tsx
+++ b/src/components/admin/AdminDataTable.tsx
@@ -21,6 +21,8 @@ interface AdminDataTableProps<T> {
   initialPageSize?: number;
   pageSizeOptions?: readonly number[];
   currentPage?: number;
+  totalItems?: number;
+  serverPagination?: boolean;
   // eslint-disable-next-line no-unused-vars
   onPageChange?: (_page: number) => void;
   // eslint-disable-next-line no-unused-vars
@@ -34,12 +36,15 @@ export default function AdminDataTable<T>({
   initialPageSize,
   pageSizeOptions,
   currentPage,
+  totalItems,
+  serverPagination,
   onPageChange,
   getRowKey,
 }: AdminDataTableProps<T>) {
   const {
     pageSize,
     currentPage: safeCurrentPage,
+    totalItems: resolvedTotalItems,
     totalPages,
     paginatedData,
     pageSizeOptions: normalizedPageSizeOptions,
@@ -50,6 +55,8 @@ export default function AdminDataTable<T>({
     initialPageSize,
     pageSizeOptions,
     currentPage,
+    totalItems,
+    serverPagination,
     onPageChange,
   });
 
@@ -127,7 +134,7 @@ export default function AdminDataTable<T>({
       <AdminTablePagination
         currentPage={safeCurrentPage}
         totalPages={totalPages}
-        totalItems={data.length}
+        totalItems={resolvedTotalItems}
         pageSize={pageSize}
         pageSizeOptions={normalizedPageSizeOptions}
         onPageChange={handlePageChange}

--- a/src/components/admin/AdminDataTable.tsx
+++ b/src/components/admin/AdminDataTable.tsx
@@ -137,6 +137,7 @@ export default function AdminDataTable<T>({
         totalItems={resolvedTotalItems}
         pageSize={pageSize}
         pageSizeOptions={normalizedPageSizeOptions}
+        showPageSizeSelector={!serverPagination}
         onPageChange={handlePageChange}
         onPageSizeChange={handlePageSizeChange}
       />

--- a/src/components/admin/AdminTablePagination.tsx
+++ b/src/components/admin/AdminTablePagination.tsx
@@ -12,6 +12,7 @@ interface AdminTablePaginationProps {
   totalItems: number;
   pageSize: number;
   pageSizeOptions: readonly number[];
+  showPageSizeSelector?: boolean;
   // eslint-disable-next-line no-unused-vars
   onPageChange: (page: number) => void;
   // eslint-disable-next-line no-unused-vars
@@ -56,6 +57,7 @@ export default function AdminTablePagination({
   totalItems,
   pageSize,
   pageSizeOptions,
+  showPageSizeSelector = true,
   onPageChange,
   onPageSizeChange,
 }: AdminTablePaginationProps) {
@@ -74,21 +76,22 @@ export default function AdminTablePagination({
           총 {totalItems}개 중 {startItem}-{endItem}개 표시
         </p>
 
-        <label className="flex items-center gap-2 text-sm text-text-secondary">
-          페이지당
-          <select
-            className="h-9 cursor-pointer rounded-md border border-zinc-200 bg-bg-white px-3 text-sm text-text-primary outline-none transition-colors duration-200 focus:border-btn-focus"
-            value={pageSize}
-            disabled={pageSizeOptions.length <= 1}
-            onChange={(event) => onPageSizeChange(Number(event.target.value))}
-          >
-            {pageSizeOptions.map((option) => (
-              <option key={option} value={option}>
-                {option}개
-              </option>
-            ))}
-          </select>
-        </label>
+        {showPageSizeSelector ? (
+          <label className="flex items-center gap-2 text-sm text-text-secondary">
+            페이지당
+            <select
+              className="h-9 cursor-pointer rounded-md border border-zinc-200 bg-bg-white px-3 text-sm text-text-primary outline-none transition-colors duration-200 focus:border-btn-focus"
+              value={pageSize}
+              onChange={(event) => onPageSizeChange(Number(event.target.value))}
+            >
+              {pageSizeOptions.map((option) => (
+                <option key={option} value={option}>
+                  {option}개
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : null}
       </div>
 
       {totalPages > 1 ? (

--- a/src/components/admin/AdminTablePagination.tsx
+++ b/src/components/admin/AdminTablePagination.tsx
@@ -79,6 +79,7 @@ export default function AdminTablePagination({
           <select
             className="h-9 cursor-pointer rounded-md border border-zinc-200 bg-bg-white px-3 text-sm text-text-primary outline-none transition-colors duration-200 focus:border-btn-focus"
             value={pageSize}
+            disabled={pageSizeOptions.length <= 1}
             onChange={(event) => onPageSizeChange(Number(event.target.value))}
           >
             {pageSizeOptions.map((option) => (

--- a/src/components/admin/competitions/AdminCompetitionsClient.tsx
+++ b/src/components/admin/competitions/AdminCompetitionsClient.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { useMemo } from 'react';
-
 import AdminBadge from '@/components/admin/AdminBadge';
 import AdminDataTable, {
   type AdminTableColumn,
@@ -18,10 +16,12 @@ import type {
   AdminCompetitionRow,
 } from '@/components/admin/competitions/types';
 import { useAdminTableQueryState } from '@/hooks/useAdminTableQueryState';
-import { filterAdminCompetitions } from '@/components/admin/competitions/utils';
+import { ADMIN_TABLE_PAGE_SIZE } from '@/lib/adminTableServerPagination';
 
 interface AdminCompetitionsClientProps {
   data: AdminCompetitionRow[];
+  totalCount: number;
+  pageSize?: number;
 }
 
 const COMPETITION_COLUMNS: AdminTableColumn<AdminCompetitionRow>[] = [
@@ -81,6 +81,8 @@ const COMPETITION_COLUMNS: AdminTableColumn<AdminCompetitionRow>[] = [
 
 export default function AdminCompetitionsClient({
   data,
+  totalCount,
+  pageSize = ADMIN_TABLE_PAGE_SIZE,
 }: AdminCompetitionsClientProps) {
   const {
     activeFilter,
@@ -95,10 +97,6 @@ export default function AdminCompetitionsClient({
     defaultFilter: 'all',
     validFilters: ADMIN_COMPETITION_FILTERS.map((filter) => filter.value),
   });
-
-  const filteredData = useMemo(() => {
-    return filterAdminCompetitions(data, activeFilter, searchQuery);
-  }, [activeFilter, data, searchQuery]);
 
   return (
     <>
@@ -115,10 +113,14 @@ export default function AdminCompetitionsClient({
       <AdminDataTable
         columns={COMPETITION_COLUMNS}
         currentPage={currentPage}
-        data={filteredData}
+        data={data}
         emptyMessage="등록된 대회가 없습니다."
         getRowKey={(row) => row.id}
+        initialPageSize={pageSize}
         onPageChange={setPage}
+        pageSizeOptions={[pageSize]}
+        serverPagination
+        totalItems={totalCount}
       />
     </>
   );

--- a/src/components/admin/posts/AdminPostsTableClient.tsx
+++ b/src/components/admin/posts/AdminPostsTableClient.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useMemo } from 'react';
 import AdminBadge from '@/components/admin/AdminBadge';
 import AdminDataTable, {
   type AdminTableColumn,
@@ -8,6 +7,7 @@ import AdminDataTable, {
 import AdminPostActions from '@/components/admin/posts/AdminPostsActions';
 import AdminTableToolbar from '@/components/admin/AdminTableToolbar';
 import {
+  ADMIN_POSTS_PAGE_SIZE,
   ADMIN_POST_FILTERS,
   CATEGORY_BADGE_VARIANT_MAP,
 } from '@/components/admin/posts/constants';
@@ -16,13 +16,12 @@ import type {
   AdminPostRow,
 } from '@/components/admin/posts/types';
 import { useAdminTableQueryState } from '@/hooks/useAdminTableQueryState';
-import {
-  filterAdminPosts,
-  getPostStatusBadge,
-} from '@/components/admin/posts/utils';
+import { getPostStatusBadge } from '@/components/admin/posts/utils';
 
 interface AdminPostTableClientProps {
   data: AdminPostRow[];
+  totalCount: number;
+  pageSize?: number;
 }
 
 const POST_COLUMNS: AdminTableColumn<AdminPostRow>[] = [
@@ -72,6 +71,8 @@ const POST_COLUMNS: AdminTableColumn<AdminPostRow>[] = [
 
 export default function AdminPostTableClient({
   data,
+  totalCount,
+  pageSize = ADMIN_POSTS_PAGE_SIZE,
 }: AdminPostTableClientProps) {
   const {
     activeFilter,
@@ -87,10 +88,6 @@ export default function AdminPostTableClient({
     validFilters: ADMIN_POST_FILTERS.map((filter) => filter.value),
   });
 
-  const filteredData = useMemo(() => {
-    return filterAdminPosts(data, activeFilter, searchQuery);
-  }, [data, activeFilter, searchQuery]);
-
   return (
     <>
       <AdminTableToolbar
@@ -104,10 +101,15 @@ export default function AdminPostTableClient({
 
       <AdminDataTable
         columns={POST_COLUMNS}
-        data={filteredData}
+        data={data}
+        emptyMessage="등록된 게시글이 없습니다."
         currentPage={currentPage}
         getRowKey={(row) => row.id}
+        initialPageSize={pageSize}
         onPageChange={setPage}
+        pageSizeOptions={[pageSize]}
+        serverPagination
+        totalItems={totalCount}
       />
     </>
   );

--- a/src/components/admin/posts/AdminPostsTableClient.tsx
+++ b/src/components/admin/posts/AdminPostsTableClient.tsx
@@ -7,7 +7,6 @@ import AdminDataTable, {
 import AdminPostActions from '@/components/admin/posts/AdminPostsActions';
 import AdminTableToolbar from '@/components/admin/AdminTableToolbar';
 import {
-  ADMIN_POSTS_PAGE_SIZE,
   ADMIN_POST_FILTERS,
   CATEGORY_BADGE_VARIANT_MAP,
 } from '@/components/admin/posts/constants';
@@ -17,6 +16,7 @@ import type {
 } from '@/components/admin/posts/types';
 import { useAdminTableQueryState } from '@/hooks/useAdminTableQueryState';
 import { getPostStatusBadge } from '@/components/admin/posts/utils';
+import { ADMIN_TABLE_PAGE_SIZE } from '@/lib/adminTableServerPagination';
 
 interface AdminPostTableClientProps {
   data: AdminPostRow[];
@@ -72,7 +72,7 @@ const POST_COLUMNS: AdminTableColumn<AdminPostRow>[] = [
 export default function AdminPostTableClient({
   data,
   totalCount,
-  pageSize = ADMIN_POSTS_PAGE_SIZE,
+  pageSize = ADMIN_TABLE_PAGE_SIZE,
 }: AdminPostTableClientProps) {
   const {
     activeFilter,

--- a/src/components/admin/posts/constants.ts
+++ b/src/components/admin/posts/constants.ts
@@ -1,4 +1,5 @@
 import type { AdminBadgeVariant } from '@/components/admin/AdminBadge';
+import { ADMIN_TABLE_PAGE_SIZE } from '@/lib/adminTableServerPagination';
 
 import type {
   AdminPostCategory,
@@ -7,7 +8,7 @@ import type {
 } from './types';
 
 export const UNKNOWN_POST_AUTHOR = '알 수 없음';
-export const ADMIN_POSTS_PAGE_SIZE = 10;
+export const ADMIN_POSTS_PAGE_SIZE = ADMIN_TABLE_PAGE_SIZE;
 
 export const ADMIN_POST_FILTERS = [
   { label: '전체', value: 'all' },

--- a/src/components/admin/posts/constants.ts
+++ b/src/components/admin/posts/constants.ts
@@ -7,6 +7,7 @@ import type {
 } from './types';
 
 export const UNKNOWN_POST_AUTHOR = '알 수 없음';
+export const ADMIN_POSTS_PAGE_SIZE = 10;
 
 export const ADMIN_POST_FILTERS = [
   { label: '전체', value: 'all' },
@@ -19,6 +20,15 @@ export const CATEGORY_LABEL_MAP: Record<DbPostCategory, AdminPostCategory> = {
   personal: '일반',
   promo: '도장홍보',
   notice: '공지',
+};
+
+export const CATEGORY_QUERY_VALUE_MAP: Record<
+  AdminPostCategory,
+  DbPostCategory
+> = {
+  일반: 'personal',
+  도장홍보: 'promo',
+  공지: 'notice',
 };
 
 export const CATEGORY_BADGE_VARIANT_MAP: Record<

--- a/src/components/admin/posts/constants.ts
+++ b/src/components/admin/posts/constants.ts
@@ -1,5 +1,4 @@
 import type { AdminBadgeVariant } from '@/components/admin/AdminBadge';
-import { ADMIN_TABLE_PAGE_SIZE } from '@/lib/adminTableServerPagination';
 
 import type {
   AdminPostCategory,
@@ -8,7 +7,6 @@ import type {
 } from './types';
 
 export const UNKNOWN_POST_AUTHOR = '알 수 없음';
-export const ADMIN_POSTS_PAGE_SIZE = ADMIN_TABLE_PAGE_SIZE;
 
 export const ADMIN_POST_FILTERS = [
   { label: '전체', value: 'all' },

--- a/src/components/admin/support/AdminSupportTableClient.tsx
+++ b/src/components/admin/support/AdminSupportTableClient.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { useMemo } from 'react';
-
 import AdminBadge from '@/components/admin/AdminBadge';
 import AdminDataTable, {
   type AdminTableColumn,
@@ -22,14 +20,13 @@ import type {
   SupportSection,
 } from '@/components/admin/support/types';
 import { useAdminTableQueryState } from '@/hooks/useAdminTableQueryState';
-import {
-  filterDojangVerifications,
-  filterReports,
-} from '@/components/admin/support/utils';
+import { ADMIN_TABLE_PAGE_SIZE } from '@/lib/adminTableServerPagination';
 
 interface AdminSupportTableClientProps {
   dojangVerifications: AdminDojangVerificationRow[];
   reports: AdminReportRow[];
+  totalCount: number;
+  pageSize?: number;
 }
 
 const DOJANG_COLUMNS: AdminTableColumn<AdminDojangVerificationRow>[] = [
@@ -122,7 +119,9 @@ const REPORT_COLUMNS: AdminTableColumn<AdminReportRow>[] = [
 
 export default function AdminSupportTableClient({
   dojangVerifications,
+  pageSize = ADMIN_TABLE_PAGE_SIZE,
   reports,
+  totalCount,
 }: AdminSupportTableClientProps) {
   const {
     activeFilter: activeSection,
@@ -138,14 +137,6 @@ export default function AdminSupportTableClient({
     validFilters: SUPPORT_SECTION_FILTERS.map((filter) => filter.value),
     resetSearchOnFilterChange: true,
   });
-
-  const filteredDojangVerifications = useMemo(() => {
-    return filterDojangVerifications(dojangVerifications, searchQuery);
-  }, [dojangVerifications, searchQuery]);
-
-  const filteredReports = useMemo(() => {
-    return filterReports(reports, searchQuery);
-  }, [reports, searchQuery]);
 
   const searchPlaceholder =
     activeSection === 'dojang'
@@ -168,19 +159,27 @@ export default function AdminSupportTableClient({
         <AdminDataTable
           columns={DOJANG_COLUMNS}
           currentPage={currentPage}
-          data={filteredDojangVerifications}
+          data={dojangVerifications}
           emptyMessage="도장 인증 요청이 없습니다."
           getRowKey={(row) => row.id}
+          initialPageSize={pageSize}
           onPageChange={setPage}
+          pageSizeOptions={[pageSize]}
+          serverPagination
+          totalItems={totalCount}
         />
       ) : (
         <AdminDataTable
           columns={REPORT_COLUMNS}
           currentPage={currentPage}
-          data={filteredReports}
+          data={reports}
           emptyMessage="신고 내역이 없습니다."
           getRowKey={(row) => row.id}
+          initialPageSize={pageSize}
           onPageChange={setPage}
+          pageSizeOptions={[pageSize]}
+          serverPagination
+          totalItems={totalCount}
         />
       )}
     </>

--- a/src/components/admin/users/AdminUsersClient.tsx
+++ b/src/components/admin/users/AdminUsersClient.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { useMemo } from 'react';
-
 import AdminBadge from '@/components/admin/AdminBadge';
 import AdminDataTable, {
   type AdminTableColumn,
@@ -19,10 +17,12 @@ import type {
   AdminUserRow,
 } from '@/components/admin/users/types';
 import { useAdminTableQueryState } from '@/hooks/useAdminTableQueryState';
-import { filterAdminUsers } from '@/components/admin/users/utils';
+import { ADMIN_TABLE_PAGE_SIZE } from '@/lib/adminTableServerPagination';
 
 interface AdminUsersClientProps {
   data: AdminUserRow[];
+  totalCount: number;
+  pageSize?: number;
 }
 
 function UserAvatarCell({
@@ -150,7 +150,11 @@ const USER_COLUMNS: AdminTableColumn<AdminUserRow>[] = [
   },
 ];
 
-export default function AdminUsersClient({ data }: AdminUsersClientProps) {
+export default function AdminUsersClient({
+  data,
+  totalCount,
+  pageSize = ADMIN_TABLE_PAGE_SIZE,
+}: AdminUsersClientProps) {
   const {
     activeFilter,
     currentPage,
@@ -164,10 +168,6 @@ export default function AdminUsersClient({ data }: AdminUsersClientProps) {
     defaultFilter: 'all',
     validFilters: ADMIN_USER_FILTERS.map((filter) => filter.value),
   });
-
-  const filteredData = useMemo(() => {
-    return filterAdminUsers(data, activeFilter, searchQuery);
-  }, [activeFilter, data, searchQuery]);
 
   return (
     <>
@@ -184,10 +184,14 @@ export default function AdminUsersClient({ data }: AdminUsersClientProps) {
       <AdminDataTable
         columns={USER_COLUMNS}
         currentPage={currentPage}
-        data={filteredData}
+        data={data}
         emptyMessage="등록된 사용자가 없습니다."
         getRowKey={(row) => row.id}
+        initialPageSize={pageSize}
         onPageChange={setPage}
+        pageSizeOptions={[pageSize]}
+        serverPagination
+        totalItems={totalCount}
       />
     </>
   );

--- a/src/hooks/useAdminTablePagination.ts
+++ b/src/hooks/useAdminTablePagination.ts
@@ -5,6 +5,8 @@ interface UseTablePaginationParams<T> {
   initialPageSize?: number;
   pageSizeOptions?: readonly number[];
   currentPage?: number;
+  totalItems?: number;
+  serverPagination?: boolean;
   // eslint-disable-next-line no-unused-vars
   onPageChange?: (_page: number) => void;
 }
@@ -17,6 +19,8 @@ export function useAdminTablePagination<T>({
   initialPageSize = DEFAULT_PAGE_SIZE,
   pageSizeOptions = DEFAULT_PAGE_SIZE_OPTIONS,
   currentPage,
+  totalItems,
+  serverPagination = false,
   onPageChange,
 }: UseTablePaginationParams<T>) {
   const normalizedPageSizeOptions = useMemo(() => {
@@ -35,7 +39,8 @@ export function useAdminTablePagination<T>({
   const [internalCurrentPage, setInternalCurrentPage] = useState(1);
   const resolvedCurrentPage = currentPage ?? internalCurrentPage;
 
-  const totalPages = Math.max(1, Math.ceil(data.length / pageSize));
+  const totalItemCount = serverPagination ? (totalItems ?? data.length) : data.length;
+  const totalPages = Math.max(1, Math.ceil(totalItemCount / pageSize));
   const safeCurrentPage = Math.min(resolvedCurrentPage, totalPages);
 
   useEffect(() => {
@@ -47,11 +52,15 @@ export function useAdminTablePagination<T>({
   }, [onPageChange, resolvedCurrentPage, safeCurrentPage]);
 
   const paginatedData = useMemo(() => {
+    if (serverPagination) {
+      return data;
+    }
+
     const startIndex = (safeCurrentPage - 1) * pageSize;
     const endIndex = startIndex + pageSize;
 
     return data.slice(startIndex, endIndex);
-  }, [data, pageSize, safeCurrentPage]);
+  }, [data, pageSize, safeCurrentPage, serverPagination]);
 
   const handlePageChange = useCallback(
     (page: number) => {
@@ -78,6 +87,7 @@ export function useAdminTablePagination<T>({
   return {
     pageSize,
     currentPage: safeCurrentPage,
+    totalItems: totalItemCount,
     totalPages,
     paginatedData,
     pageSizeOptions: normalizedPageSizeOptions,

--- a/src/lib/adminTableServerPagination.ts
+++ b/src/lib/adminTableServerPagination.ts
@@ -1,0 +1,79 @@
+import { parseEnumParam, parsePositiveIntParam } from '@/lib/urlSearchParams';
+
+export const ADMIN_TABLE_PAGE_SIZE = 10;
+
+export type AdminTableRouteSearchParams = Record<
+  string,
+  string | string[] | undefined
+>;
+
+export function getSingleSearchParam(
+  value: string | string[] | undefined,
+): string | null {
+  if (Array.isArray(value)) {
+    return value[0] ?? null;
+  }
+
+  return value ?? null;
+}
+
+interface ParseAdminTableServerQueryOptions<TFilter extends string> {
+  searchParams: AdminTableRouteSearchParams;
+  filterParamName: string;
+  validFilters: readonly TFilter[];
+  defaultFilter: TFilter;
+  defaultPage?: number;
+}
+
+export function parseAdminTableServerQuery<TFilter extends string>({
+  searchParams,
+  filterParamName,
+  validFilters,
+  defaultFilter,
+  defaultPage = 1,
+}: ParseAdminTableServerQueryOptions<TFilter>) {
+  const requestedPage = parsePositiveIntParam(
+    getSingleSearchParam(searchParams.page),
+    defaultPage,
+  ).value;
+
+  const activeFilter = parseEnumParam<TFilter>(
+    getSingleSearchParam(searchParams[filterParamName]),
+    validFilters,
+    defaultFilter,
+  );
+
+  const normalizedSearchQuery =
+    getSingleSearchParam(searchParams.search)?.trim() ?? '';
+
+  return {
+    requestedPage,
+    activeFilter,
+    normalizedSearchQuery,
+  };
+}
+
+interface BuildAdminPaginationRangeOptions {
+  requestedPage: number;
+  totalCount: number;
+  pageSize?: number;
+}
+
+export function buildAdminPaginationRange({
+  requestedPage,
+  totalCount,
+  pageSize = ADMIN_TABLE_PAGE_SIZE,
+}: BuildAdminPaginationRangeOptions) {
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+  const currentPage = totalCount === 0 ? 1 : Math.min(requestedPage, totalPages);
+  const from = (currentPage - 1) * pageSize;
+  const to = from + pageSize - 1;
+
+  return {
+    currentPage,
+    totalPages,
+    from,
+    to,
+    pageSize,
+  };
+}


### PR DESCRIPTION
<!--
  PR 작성 가이드
  - 리뷰어를 존중하는 표현을 사용해주세요.
  - 변경 의도와 주요 내용을 명확하게 작성해주세요.
 -->

## 📌 개요

- 관리자 페이지 데이터패칭 서버 페이지네이션 방식 적용

## 💻 작업 사항

## 이전 데이터 패칭
기존 관리자 페이지들은 서버에서 전체 데이터를 한 번에 조회한 뒤,
클라이언트에서 검색 / 필터 / `slice()` 기반 페이지네이션을 처리하고 있었습니다.
- 서버: 전체 목록 fetch
- 클라이언트: 검색/필터
- 클라이언트: 현재 페이지 데이터 `slice()`

이 구조는 데이터가 많아질수록 첫 로딩 비용이 커지고,
실제로 필요한 페이지 데이터보다 더 많은 데이터를 항상 내려받는 문제가 있었습니다.

## 개선된 서버 페이지네이션 데이터 패칭
이번 작업에서는 관리자 페이지들의 목록 조회를
**URL query 기반 서버 페이지네이션 구조**로 변경했습니다.

**현재 흐름**은 다음과 같습니다.
1. URL query(`page`, `search`, `status`, `category`, `section`)를 기준으로 현재 화면 상태를 결정
2. Next.js 서버 `page.tsx`에서 `searchParams`를 읽어 필터 값 파싱
3. Supabase에서 `count + range(from, to)` 기반으로 현재 페이지 데이터만 조회
4. 서버는 `현재 페이지 데이터 + totalCount`만 클라이언트에 전달
5. 클라이언트는 기존 테이블 UI를 유지하면서 전달받은 데이터만 렌더링

**역할 분리**
- 서버: 검색/필터/count/range 처리
- 클라이언트: URL 상태 관리 + 테이블 렌더링 + 페이지 이동 UI

**적용 페이지**
- 관리자 게시글 관리
- 관리자 대회 일정 관리
- 관리자 유저 관리
- 관리자 고객 지원

## 추가된 파일이나 함수 설명
### 공통 유틸
- `src/lib/adminTableServerPagination.ts`
  - 관리자 테이블 서버 페이지네이션용 공통 유틸 추가
  - `searchParams` 파싱
  - `page` 정규화
  - `count` 기준 `from/to` range 계산
  - 공통 페이지 크기 상수 관리

### 공통 테이블 개선
- `AdminDataTable`
  - 기존 클라이언트 페이지네이션 구조는 유지
  - `serverPagination` 모드를 추가해 서버에서 내려준 현재 페이지 데이터만 렌더링할 수 있도록 확장
- `useAdminTablePagination`
  - 클라이언트 `slice()` 기반 동작은 유지
  - 서버 페이지네이션 모드에서는 `totalItems` 기준으로 totalPages만 계산하도록 분리
- `AdminTablePagination`
  - 서버 페이지네이션 모드에서는 페이지당 개수 선택 UI를 숨기도록 처리

### 페이지별 변경
- `admin/posts/page.tsx`
  - `page/search/category/status` 기반 서버 조회
- `admin/competitions/page.tsx`
  - `page/search/status` 기반 서버 조회
- `admin/users/page.tsx`
  - `page/search/status` 기반 서버 조회
- `admin/support/page.tsx`
  - `page/search/section` 기반 서버 조회

## 기대 효과
- 전체 데이터 fetch 제거
- 현재 페이지에 필요한 데이터만 서버에서 조회
- 데이터가 많아져도 관리자 목록 페이지의 초기 로딩 부담 완화
- URL query 기준으로 검색/필터/페이지 상태를 유지하면서 서버 데이터와 일관성 있게 동작
- 기존 관리자 공통 테이블 UI/UX는 최대한 유지


## 💡 관련 Issue

Closes #132

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #)
- [x] 불필요한 console.log를 제거했습니다.
- [x] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
