### PR TITLE
[refactor] 접근성 및 seo, 권장사항 등 수정

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   cacheComponents: true,
   experimental: {
+    optimizeCss: true,
     staleTimes: {
       dynamic: 0,
       static: 30,

--- a/src/app/api/comments/[id]/route.ts
+++ b/src/app/api/comments/[id]/route.ts
@@ -27,7 +27,6 @@ export async function PUT(req: NextRequest, { params }: Props) {
     );
   }
 
-  // 권한 체크
   const { data: comment } = await supabase
     .from('comments')
     .select('user_id, post_id')
@@ -69,7 +68,6 @@ export async function DELETE(_req: NextRequest, { params }: Props) {
     );
   }
 
-  // 권한 체크
   const { data: comment } = await supabase
     .from('comments')
     .select('user_id, post_id')

--- a/src/components/common/ScrollToTop.tsx
+++ b/src/components/common/ScrollToTop.tsx
@@ -32,17 +32,19 @@ export default function ScrollToTop() {
       {!isTop && (
         <button
           onClick={scrollToTop}
+          aria-label="맨 위로 이동"
           className="w-12 h-12 bg-gray-300 text-gray-600 rounded-full flex items-center justify-center cursor-pointer hover:bg-btn-focus hover:text-btn-focus-text transition-all"
         >
-          <ArrowUp size={20} />
+          <ArrowUp size={20} aria-hidden="true" />
         </button>
       )}
       {!isBottom && (
         <button
           onClick={scrollToBottom}
+          aria-label="맨 아래로 이동"
           className="w-12 h-12 bg-gray-300 text-gray-600 rounded-full flex items-center justify-center cursor-pointer hover:bg-btn-focus hover:text-btn-focus-text transition-all"
         >
-          <ArrowDown size={20} />
+          <ArrowDown size={20} aria-hidden="true" />
         </button>
       )}
     </div>

--- a/src/components/community/CommunityClient.tsx
+++ b/src/components/community/CommunityClient.tsx
@@ -171,16 +171,21 @@ export default function CommunityClient({
             <div
               ref={observerRef}
               className="h-20 flex items-center justify-center"
-              aria-label="더 많은 게시글 불러오는 중"
-              aria-live="polite"
             >
-              {isFetchingNextPage && (
-                <div
-                  className="w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full animate-spin"
-                  role="status"
-                  aria-label="로딩 중"
-                />
-              )}
+              <div
+                role="status"
+                aria-live="polite"
+                aria-label={
+                  isFetchingNextPage ? '더 많은 게시글 불러오는 중' : ''
+                }
+              >
+                {isFetchingNextPage && (
+                  <div
+                    className="w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full animate-spin"
+                    aria-hidden="true"
+                  />
+                )}
+              </div>
             </div>
           )}
         </div>

--- a/src/components/community/PostLikeButtonContent.tsx
+++ b/src/components/community/PostLikeButtonContent.tsx
@@ -34,7 +34,7 @@ export default function PostLikeButtonContent({
         isLiked ? ', 좋아요 취소하기' : ', 좋아요 누르기'
       }`}
       className={cn(
-        'flex items-center gap-1 transition-all duration-200 cursor-pointer',
+        'flex items-center gap-1 transition-all duration-200 cursor-pointer p-3 -m-3',
         isDetail && 'gap-1.5 text-xs',
       )}
     >

--- a/src/components/competition/CompetitionCard.tsx
+++ b/src/components/competition/CompetitionCard.tsx
@@ -17,25 +17,29 @@ interface CompetitionCardProps {
     apply_url: string;
     comment_count?: number;
   };
+  index?: number;
 }
 
-export default function CompetitionCard({ competition }: CompetitionCardProps) {
+export default function CompetitionCard({
+  competition,
+  index,
+}: CompetitionCardProps) {
   const actualStatus = getStatus(competition.apply_deadline);
   const dday = getDday(competition.apply_deadline);
 
   const statusColor =
     {
-      모집중: 'bg-green-500',
-      마감임박: 'bg-orange-500',
-      모집완료: 'bg-gray-400',
-    }[actualStatus] ?? 'bg-gray-400';
+      모집중: 'bg-green-700',
+      마감임박: 'bg-orange-600',
+      모집완료: 'bg-gray-500',
+    }[actualStatus] ?? 'bg-gray-500';
 
   const ddayColor =
     dday === 'D-DAY'
       ? 'text-danger'
       : dday.startsWith('D-')
-        ? 'text-blue-500'
-        : 'text-gray-400';
+        ? 'text-blue-700'
+        : 'text-gray-600';
 
   return (
     <article
@@ -47,14 +51,15 @@ export default function CompetitionCard({ competition }: CompetitionCardProps) {
         className="flex flex-col flex-1"
         aria-label={`${competition.name} 대회 상세보기`}
       >
-        <div className="relative shrink-0">
+        <div className="relative shrink-0 h-50">
           {competition.image_url ? (
             <Image
               src={competition.image_url}
               alt={`${competition.name} 대회 이미지`}
-              width={400}
-              height={200}
-              className="w-full h-50 object-cover"
+              fill
+              sizes="(max-width: 768px) 100vw, 50vw"
+              priority={index === 0}
+              className="object-cover"
             />
           ) : (
             <div

--- a/src/components/competition/CompetitionCard.tsx
+++ b/src/components/competition/CompetitionCard.tsx
@@ -43,8 +43,8 @@ export default function CompetitionCard({
 
   return (
     <article
+      aria-labelledby={`competition-${competition.id}`}
       className="rounded-lg overflow-hidden bg-bg-white border border-gray-200 flex flex-col h-full cursor-pointer hover:shadow-lg hover:-translate-y-1 transition-all duration-200"
-      aria-label={`${competition.name} 대회`}
     >
       <Link
         href={buildCompetitionUrl(competition.name, competition.id)}
@@ -57,23 +57,24 @@ export default function CompetitionCard({
               src={competition.image_url}
               alt={`${competition.name} 대회 이미지`}
               fill
-              sizes="(max-width: 768px) 100vw, 50vw"
+              sizes="(max-width: 1280px) 50vw, 640px"
               priority={index === 0}
               className="object-cover"
             />
           ) : (
             <div
               className="w-full h-50 bg-gray-100 flex items-center justify-center"
-              aria-label="이미지 없음"
+              aria-hidden="true"
             >
-              <span className="text-gray-400 text-sm" aria-hidden="true">
-                이미지 없음
-              </span>
+              <span className="text-gray-400 text-sm">이미지 없음</span>
             </div>
           )}
 
           <div className="absolute bottom-0 left-0 right-0 bg-linear-to-t from-black/70 to-transparent p-3">
-            <h2 className="font-bold text-white text-base line-clamp-1">
+            <h2
+              id={`competition-${competition.id}`}
+              className="font-bold text-white text-base line-clamp-1"
+            >
               {competition.name}
             </h2>
           </div>
@@ -155,25 +156,25 @@ export default function CompetitionCard({
       <div className="px-4 pb-4">
         <div className="border-t border-gray-200 mb-3" aria-hidden="true" />
 
-        <a
-          href={competition.apply_url}
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label={
-            actualStatus === '모집완료'
-              ? `${competition.name} 모집 완료`
-              : `${competition.name} 신청하기`
-          }
-          aria-disabled={actualStatus === '모집완료'}
-          className={`w-full py-2 text-sm font-bold text-white text-center rounded-lg transition-all block
-            ${
-              actualStatus === '모집완료'
-                ? 'bg-gray-400 cursor-not-allowed pointer-events-none'
-                : 'bg-[#2c2c2c] hover:bg-black'
-            }`}
-        >
-          {actualStatus === '모집완료' ? '모집 완료' : '신청하기'}
-        </a>
+        {actualStatus === '모집완료' ? (
+          <span
+            role="button"
+            aria-disabled="true"
+            className="w-full py-2 text-sm font-bold text-white text-center rounded-lg bg-gray-400 cursor-not-allowed block"
+          >
+            모집 완료
+          </span>
+        ) : (
+          <a
+            href={competition.apply_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`${competition.name} 신청하기`}
+            className="w-full py-2 text-sm font-bold text-white text-center rounded-lg transition-all block bg-[#2c2c2c] hover:bg-black"
+          >
+            신청하기
+          </a>
+        )}
       </div>
     </article>
   );

--- a/src/components/competition/CompetitionClient.tsx
+++ b/src/components/competition/CompetitionClient.tsx
@@ -132,9 +132,10 @@ export default function CompetitionClient({
               }
             >
               {filteredCompetitions.length > 0 ? (
-                filteredCompetitions.map((competition) => (
+                // ✅ index 추가
+                filteredCompetitions.map((competition, index) => (
                   <li key={competition.id} className="h-full">
-                    <CompetitionCard competition={competition} />
+                    <CompetitionCard competition={competition} index={index} />
                   </li>
                 ))
               ) : (
@@ -148,19 +149,23 @@ export default function CompetitionClient({
             </ul>
           )}
 
+          {/* ✅ aria-live 수정 */}
           {hasNextPage && (
             <div
               ref={observerRef}
               className="h-20 flex items-center justify-center"
-              aria-live="polite"
             >
-              {isFetchingNextPage && (
-                <div
-                  className="w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full animate-spin"
-                  role="status"
-                  aria-label="로딩 중"
-                />
-              )}
+              <div role="status" aria-live="polite" aria-atomic="true">
+                {isFetchingNextPage && (
+                  <>
+                    <div
+                      className="w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full animate-spin"
+                      aria-hidden="true"
+                    />
+                    <span className="sr-only">더 많은 대회를 불러오는 중</span>
+                  </>
+                )}
+              </div>
             </div>
           )}
         </div>

--- a/src/components/competition/CompetitionClient.tsx
+++ b/src/components/competition/CompetitionClient.tsx
@@ -132,7 +132,6 @@ export default function CompetitionClient({
               }
             >
               {filteredCompetitions.length > 0 ? (
-                // ✅ index 추가
                 filteredCompetitions.map((competition, index) => (
                   <li key={competition.id} className="h-full">
                     <CompetitionCard competition={competition} index={index} />

--- a/src/components/dojang/DojangCard.tsx
+++ b/src/components/dojang/DojangCard.tsx
@@ -17,7 +17,7 @@ interface DojangCardProps {
 export default function DojangCard({ dojang, isSelected }: DojangCardProps) {
   return (
     <article
-      className={`p-4 border rounded-lg bg-white hover:shadow-md transition-all cursor-pointer
+      className={`p-4 border rounded-lg bg-white hover:shadow-md transition-all cursor-pointer h-full flex flex-col
         ${isSelected ? 'border-btn-focus border-2 shadow-md' : 'border-gray-200'}`}
       aria-label={`${dojang.place_name} 도장${isSelected ? ', 선택됨' : ''}`}
       aria-current={isSelected}
@@ -32,7 +32,8 @@ export default function DojangCard({ dojang, isSelected }: DojangCardProps) {
         {dojang.address_name}
       </address>
 
-      {dojang.phone && (
+      {/* ✅ 전화번호 없을 때 빈 공간 확보 */}
+      {dojang.phone ? (
         <a
           href={'tel:' + dojang.phone}
           className="text-sm text-gray-400 mt-1 block hover:text-gray-600 transition-colors"
@@ -40,7 +41,12 @@ export default function DojangCard({ dojang, isSelected }: DojangCardProps) {
         >
           {dojang.phone}
         </a>
+      ) : (
+        <div className="mt-1 h-5" />
       )}
+
+      {/* ✅ 버튼을 항상 아래로 밀기 */}
+      <div className="flex-1" />
 
       <a
         href={dojang.place_url}

--- a/src/components/dojang/DojangClient.tsx
+++ b/src/components/dojang/DojangClient.tsx
@@ -193,8 +193,10 @@ export default function DojangClient() {
 
   return (
     <>
+      {/* ✅ strategy="lazyOnload" 추가 */}
       <Script
         src={`https://openapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=${process.env.NEXT_PUBLIC_NAVER_MAP_CLIENT_ID}`}
+        strategy="lazyOnload"
         onLoad={initMap}
       />
 
@@ -223,7 +225,7 @@ export default function DojangClient() {
           className="pb-6 flex justify-center"
           aria-label="도장 찾기"
         >
-          <div className="w-full max-w-7xl px-6 flex flex-col gap-4">
+          <div className="w-full max-w-7xl px-6 flex flex-col gap-4 min-h-screen">
             <div className="relative">
               {!mapLoaded && (
                 <div
@@ -239,8 +241,8 @@ export default function DojangClient() {
               )}
               <div
                 ref={mapRef}
-                className="w-full h-100 rounded-lg overflow-hidden border border-gray-200"
-                style={{ zIndex: 0 }}
+                className="w-full rounded-lg overflow-hidden border border-gray-200"
+                style={{ zIndex: 0, height: '400px', minHeight: '400px' }}
                 role="application"
                 aria-label="도장 위치 지도"
               />

--- a/src/components/layout/PageHeader.tsx
+++ b/src/components/layout/PageHeader.tsx
@@ -91,26 +91,28 @@ export default function Pageheader({
       </div>
 
       {tabs && tabs.length > 0 && (
+        // ✅ role="tablist" 유지
         <div
           className="flex gap-2"
           role="tablist"
           aria-label={`${title} 카테고리 탭`}
         >
           {tabs.map((tab) => (
-            <Button
+            // ✅ <Button> → <button> 으로 교체 (ARIA 충돌 해결)
+            <button
               key={tab}
               role="tab"
               aria-selected={activeTab === tab}
               aria-controls={`tabpanel-${tab}`}
               onClick={() => setActiveTab && setActiveTab(tab)}
-              className={`cursor-pointer ${
+              className={`cursor-pointer rounded-lg h-10 px-6 transition-all duration-200 font-medium text-sm ${
                 activeTab === tab
                   ? 'bg-btn-focus text-btn-focus-text'
                   : 'bg-btn-basic text-btn-text hover:bg-gray-200'
-              } h-10 p-6 transition-all duration-200`}
+              }`}
             >
               {tab}
-            </Button>
+            </button>
           ))}
         </div>
       )}

--- a/src/components/layout/PageHeader.tsx
+++ b/src/components/layout/PageHeader.tsx
@@ -91,14 +91,12 @@ export default function Pageheader({
       </div>
 
       {tabs && tabs.length > 0 && (
-        // ✅ role="tablist" 유지
         <div
           className="flex gap-2"
           role="tablist"
           aria-label={`${title} 카테고리 탭`}
         >
           {tabs.map((tab) => (
-            // ✅ <Button> → <button> 으로 교체 (ARIA 충돌 해결)
             <button
               key={tab}
               role="tab"

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -85,7 +85,7 @@ export async function uploadBusinessFile(file: File): Promise<string> {
     .getPublicUrl(fileName);
   return data.publicUrl;
 }
-// 로그인
+
 export async function loginUser({
   email,
   password,

--- a/src/services/competitionService.ts
+++ b/src/services/competitionService.ts
@@ -73,7 +73,6 @@ export async function updateCompetition(
   if (error) throw error;
 }
 
-// soft delete
 export async function deleteCompetition(id: string) {
   const { error } = await supabase
     .from('competition')

--- a/src/services/reportService.ts
+++ b/src/services/reportService.ts
@@ -1,4 +1,3 @@
-// services/reportService.ts
 import { supabase } from '@/lib/supabase/client';
 
 export type ReportReason =


### PR DESCRIPTION
## 📌 개요
접근성(Accessibility) 개선 및 성능(Performance) 최적화 작업을 진행했습니다.

## 💻 작업 사항
<img width="661" height="731" alt="image" src="https://github.com/user-attachments/assets/791b5e2b-9144-4605-940b-313c938c5b6e" />
<img width="673" height="563" alt="image" src="https://github.com/user-attachments/assets/10f3c0c8-e247-44ea-9b44-411b4eda341a" />

### ♿ 접근성 개선

**1. Pageheader - 탭 ARIA 충돌 수정**
- `<Button>` 컴포넌트에 `role="tab"`을 덮어씌우던 방식에서 `<button>` 태그로 교체
- shadcn `<Button>` 내부와 ARIA 속성 충돌 해결

**2. PostLikeButtonContent - 버튼 터치 영역 확보**
- 좋아요 버튼 최소 터치 영역 44x44px 확보
- `p-3 -m-3` 트릭으로 시각적 크기 변화 없이 터치 영역만 확장

**3. CompetitionCard - 색상 대비 개선**
- `bg-green-500` → `bg-green-700`
- `bg-gray-400` → `bg-gray-500`
- `text-blue-500` → `text-blue-700`
- `text-gray-400` → `text-gray-600`
- WCAG 기준 색상 대비율(4.5:1) 충족

**4. CommunityClient / CompetitionClient - aria-live 수정**
- `div`에 직접 사용하던 `aria-live="polite"`를 `role="status"`가 있는 요소로 이동
- 스크린 리더가 로딩 상태를 올바르게 읽을 수 있도록 개선

+++ ### ScrollToTop 버튼 접근성 개선
- 위로 이동 버튼에 `aria-label="맨 위로 이동"` 추가
- 아래로 이동 버튼에 `aria-label="맨 아래로 이동"` 추가
- 아이콘에 `aria-hidden="true"` 추가 (스크린리더 중복 읽기 방지)

### ⚡ 성능 최적화
**5. CompetitionCard - LCP 이미지 우선 로딩**
- 첫 번째 카드 이미지에 `priority` prop 추가 (`index === 0`)
- `fill` + 고정 컨테이너(`h-50`)로 Layout Shift 방지

**6. DojangClient - 네이버 지도 스크립트 지연 로딩**
- `strategy="lazyOnload"` 추가로 초기 로딩 성능 개선
- 지도 컨테이너 고정 높이(`height: 400px`) 적용으로 Layout Shift 감소

**7. DojangCard - 카드 높이 통일**
- 전화번호 유무에 따른 카드 높이 불일치 수정
- `h-full flex flex-col` + `flex-1`로 버튼 항상 하단 고정
- 전화번호 없을 때 빈 공간(`h-5`) 확보


## 💡 관련 Issue
Closes #202

## ✅ 체크리스트
- [x] 관련 이슈를 연결했습니다. (Closes #202 )
- [x] 불필요한 console.log를 제거했습니다.
- [x] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.