### PR TITLE
[Fix] 커뮤니티 및 대회일정 페이지의 UX 개선, 데이터 캐시 갱신 버그 수정, 접근성 이슈 해결

### DIFF
--- a/src/app/(main)/community/page.tsx
+++ b/src/app/(main)/community/page.tsx
@@ -4,6 +4,7 @@ import { cacheTag, cacheLife } from 'next/cache';
 import LoadingSpinner from '@/components/common/LoadingSpinner';
 import type { Post } from '@/types/community';
 import type { Metadata } from 'next';
+import { Suspense } from 'react';
 
 export const metadata: Metadata = {
   title: '커뮤니티 | Black Belt BJJ',
@@ -48,5 +49,9 @@ async function CommunityContent() {
 }
 
 export default function CommunityPage() {
-  return <CommunityContent />;
+  return (
+    <Suspense fallback={<LoadingSpinner label="게시글 불러오는 중" />}>
+      <CommunityContent />
+    </Suspense>
+  );
 }

--- a/src/app/(main)/competitions/page.tsx
+++ b/src/app/(main)/competitions/page.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
 async function getCompetitions() {
   'use cache';
   cacheTag('competitions');
-  cacheLife('hours');
+  cacheLife('minutes');
 
   const { data } = await supabasePublic
     .from('competition')

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -22,11 +22,16 @@ export async function POST(req: Request) {
   const body = await req.json();
   const { category, title, content, image_url } = body;
 
-  const allowedCategory =
-    role === 'admin' ? 'notice' : role === 'manager' ? 'promo' : 'personal';
+  const allowedCategories: Record<string, string[]> = {
+    admin: ['notice'],
+    manager: ['personal', 'promo'],
+    user: ['personal'],
+  };
 
-  const finalCategory =
-    role === 'admin' ? (category ?? 'personal') : allowedCategory;
+  const userCategories = allowedCategories[role] ?? ['personal'];
+  const finalCategory = userCategories.includes(category)
+    ? category
+    : userCategories[0];
 
   const { data, error } = await supabase
     .from('posts')

--- a/src/components/common/LoadingSpinner.tsx
+++ b/src/components/common/LoadingSpinner.tsx
@@ -11,10 +11,7 @@ export default function LoadingSpinner({
 }: LoadingSpinnerProps = {}) {
   return (
     <div
-      className={cn(
-        'col-span-2 flex items-center justify-center py-20',
-        className,
-      )}
+      className={cn('flex items-center justify-center py-20', className)}
       role="status"
       aria-live="polite"
     >

--- a/src/components/community/Postcard.tsx
+++ b/src/components/community/Postcard.tsx
@@ -7,6 +7,9 @@ import { MessageCircle } from 'lucide-react';
 import { categoryMap } from '@/constants/categoryMap';
 import { buildPostUrl } from '@/lib/slug';
 import PostLikeButton from '@/components/community/PostLikeButton';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import LoadingSpinner from '../common/LoadingSpinner';
 
 interface PostCardProps {
   post: {
@@ -33,6 +36,8 @@ const DEFAULT_IMAGES = [
 
 export default function PostCard({ post, userId }: PostCardProps) {
   const categoryInfo = categoryMap[post.category] ?? categoryMap.personal;
+  const [isPending, setIsPending] = useState(false);
+  const router = useRouter();
 
   const defaultImage =
     DEFAULT_IMAGES[
@@ -40,17 +45,37 @@ export default function PostCard({ post, userId }: PostCardProps) {
         DEFAULT_IMAGES.length
     ];
 
+  useEffect(() => {
+    // eslint-disable-next-line -- cacheComponents Activity 전환 시 로딩 상태 초기화
+    setIsPending(false);
+  }, []);
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    if (isPending) return;
+    setIsPending(true);
+    router.push(buildPostUrl(post.title, post.id));
+  };
+
   return (
     <Link
       href={buildPostUrl(post.title, post.id)}
       className="block w-full"
       rel="noopener noreferrer"
       aria-label={`${post.title} 게시글 상세보기`}
+      onClick={handleClick}
     >
       <article
-        className="rounded-lg overflow-hidden border bg-bg-white border-gray-200 flex flex-col h-97.5 cursor-pointer hover:shadow-lg hover:-translate-y-1 transition-all duration-200"
+        className="rounded-lg overflow-hidden border bg-bg-white border-gray-200 flex flex-col h-97.5 cursor-pointer hover:shadow-lg hover:-translate-y-1 transition-all duration-200 relative"
         aria-label={`${post.nickname}의 게시글: ${post.title}`}
+        aria-busy={isPending}
       >
+        {isPending && (
+          <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/40 rounded-lg">
+            <LoadingSpinner label="게시글 불러오는 중" />
+          </div>
+        )}
+
         <div className="relative w-full h-50 bg-btn-basic shrink-0">
           <Image
             src={post.image_url || defaultImage}

--- a/src/components/community/Postcard.tsx
+++ b/src/components/community/Postcard.tsx
@@ -7,7 +7,7 @@ import { MessageCircle } from 'lucide-react';
 import { categoryMap } from '@/constants/categoryMap';
 import { buildPostUrl } from '@/lib/slug';
 import PostLikeButton from '@/components/community/PostLikeButton';
-import { useEffect, useState } from 'react';
+import { useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import LoadingSpinner from '../common/LoadingSpinner';
 
@@ -36,8 +36,8 @@ const DEFAULT_IMAGES = [
 
 export default function PostCard({ post, userId }: PostCardProps) {
   const categoryInfo = categoryMap[post.category] ?? categoryMap.personal;
-  const [isPending, setIsPending] = useState(false);
   const router = useRouter();
+  const [isPending, startTransition] = useTransition();
 
   const defaultImage =
     DEFAULT_IMAGES[
@@ -45,16 +45,14 @@ export default function PostCard({ post, userId }: PostCardProps) {
         DEFAULT_IMAGES.length
     ];
 
-  useEffect(() => {
-    // eslint-disable-next-line -- cacheComponents Activity 전환 시 로딩 상태 초기화
-    setIsPending(false);
-  }, []);
-
-  const handleClick = (e: React.MouseEvent) => {
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button === 1) {
+      return;
+    }
     e.preventDefault();
-    if (isPending) return;
-    setIsPending(true);
-    router.push(buildPostUrl(post.title, post.id));
+    startTransition(() => {
+      router.push(buildPostUrl(post.title, post.id));
+    });
   };
 
   return (

--- a/src/components/competition/CompetitionCard.tsx
+++ b/src/components/competition/CompetitionCard.tsx
@@ -3,6 +3,9 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { getDday, getStatus } from '@/utils/formatDate';
 import { buildCompetitionUrl } from '@/lib/slug';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import LoadingSpinner from '../common/LoadingSpinner';
 
 interface CompetitionCardProps {
   competition: {
@@ -22,7 +25,20 @@ interface CompetitionCardProps {
 export default function CompetitionCard({ competition }: CompetitionCardProps) {
   const actualStatus = getStatus(competition.apply_deadline);
   const dday = getDday(competition.apply_deadline);
+  const [isPending, setIsPending] = useState(false);
+  const router = useRouter();
 
+  useEffect(() => {
+    // eslint-disable-next-line -- cacheComponents Activity 전환 시 로딩 상태 초기화
+    setIsPending(false);
+  }, []);
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    if (isPending) return;
+    setIsPending(true);
+    router.push(buildCompetitionUrl(competition.name, competition.id));
+  };
   const statusColor =
     {
       모집중: 'bg-green-500',
@@ -39,13 +55,20 @@ export default function CompetitionCard({ competition }: CompetitionCardProps) {
 
   return (
     <article
-      className="rounded-lg overflow-hidden bg-bg-white border border-gray-200 flex flex-col h-full cursor-pointer hover:shadow-lg hover:-translate-y-1 transition-all duration-200"
+      className="rounded-lg overflow-hidden bg-bg-white border border-gray-200 flex flex-col h-full cursor-pointer hover:shadow-lg hover:-translate-y-1 transition-all duration-200 relative"
       aria-label={`${competition.name} 대회`}
+      aria-busy={isPending}
     >
+      {isPending && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/40 rounded-lg">
+          <LoadingSpinner label="대회 정보 불러오는 중" />
+        </div>
+      )}
       <Link
         href={buildCompetitionUrl(competition.name, competition.id)}
         className="flex flex-col flex-1"
         aria-label={`${competition.name} 대회 상세보기`}
+        onClick={handleClick}
       >
         <div className="relative shrink-0">
           {competition.image_url ? (

--- a/src/components/competition/CompetitionCard.tsx
+++ b/src/components/competition/CompetitionCard.tsx
@@ -3,7 +3,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { getDday, getStatus } from '@/utils/formatDate';
 import { buildCompetitionUrl } from '@/lib/slug';
-import { useEffect, useState } from 'react';
+import { useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import LoadingSpinner from '../common/LoadingSpinner';
 
@@ -29,20 +29,19 @@ export default function CompetitionCard({
 }: CompetitionCardProps) {
   const actualStatus = getStatus(competition.apply_deadline);
   const dday = getDday(competition.apply_deadline);
-  const [isPending, setIsPending] = useState(false);
   const router = useRouter();
+  const [isPending, startTransition] = useTransition();
 
-  useEffect(() => {
-    // eslint-disable-next-line -- cacheComponents Activity 전환 시 로딩 상태 초기화
-    setIsPending(false);
-  }, []);
-
-  const handleClick = (e: React.MouseEvent) => {
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button === 1) {
+      return;
+    }
     e.preventDefault();
-    if (isPending) return;
-    setIsPending(true);
-    router.push(buildCompetitionUrl(competition.name, competition.id));
+    startTransition(() => {
+      router.push(buildCompetitionUrl(competition.name, competition.id));
+    });
   };
+
   const statusColor =
     {
       모집중: 'bg-green-700',

--- a/src/hooks/useCompetition.ts
+++ b/src/hooks/useCompetition.ts
@@ -33,6 +33,6 @@ export function useCompetition(initialCompetitions: Competition[]) {
       if (lastPage.length < PAGE_SIZE) return undefined;
       return allPages.length;
     },
-    staleTime: 1000 * 30,
+    staleTime: 0,
   });
 }


### PR DESCRIPTION
## 📌 개요
- 커뮤니티 및 대회일정 페이지의 UX 개선, 데이터 캐시 갱신 버그 수정, 접근성 이슈 해결

## 💻 작업 사항

### 1. 카드 클릭 시 페이지 전환 로딩 피드백 추가
- `PostCard`, `CompetitionCard`에 클릭 즉시 로딩 오버레이 표시
- `isPending` 상태로 중복 클릭 방지
- `cacheComponents` 환경에서 뒤로가기 시 로딩 상태 잔존 문제 수정 (`useEffect([])`로 Activity hide→show 전환 시 초기화)
- `aria-busy` 추가로 스크린리더에도 로딩 상태 전달

<img width="856" height="900" alt="20260518-1231-47 1946756" src="https://github.com/user-attachments/assets/0ac1e3ab-fdcd-4a0b-a0c9-c49541f48749" />


### 2. 게시글 카테고리 저장 버그 수정
- `/api/posts` route handler에서 `manager` 역할일 때 클라이언트 선택값 무시하고 항상 `promo`로 고정되던 문제 수정
- 역할별 허용 카테고리 목록(`allowedCategories`)으로 검증하도록 리팩토링

### 3. 대회일정 캐시 갱신 지연 수정
- 서버 캐시 `cacheLife('hours')` → `cacheLife('minutes')` 변경
- 클라이언트 React Query `staleTime: 1000 * 30` → `0` 변경

### 4. `LoadingSpinner` 컴포넌트 개선
- 불필요한 `col-span-2` 제거로 그리드 외부 컨텍스트에서도 레이아웃 깨지지 않도록 수정

## 💡 관련 Issue

Closes #203 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #203 )
- [x] 불필요한 console.log를 제거했습니다.
- [x] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
