### PR TITLE
[Fix] 게시글 상세 댓글 입력 지연 및 페이지 재진입 시 입력값 잔존 버그 수정, 모달 버튼 UX 개선

### DIFF
--- a/src/components/common/ConfirmModal.tsx
+++ b/src/components/common/ConfirmModal.tsx
@@ -54,7 +54,7 @@ export default function ConfirmModal({
             type="button"
             onClick={onClose}
             disabled={disabled}
-            className="flex-1 rounded-lg bg-gray-100 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-50"
+            className="flex-1 rounded-lg bg-gray-100 py-2 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer"
           >
             {cancelLabel}
           </button>
@@ -62,7 +62,7 @@ export default function ConfirmModal({
             type="button"
             onClick={onConfirm}
             disabled={disabled}
-            className={`flex-1 rounded-lg py-2 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${confirmButtonVariantClassMap[confirmVariant]}`}
+            className={`flex-1 rounded-lg py-2 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 cursor-pointer ${confirmButtonVariantClassMap[confirmVariant]}`}
           >
             {confirmLabel}
           </button>

--- a/src/components/community/PostDetailClient.tsx
+++ b/src/components/community/PostDetailClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQueryClient } from '@tanstack/react-query';
-import { useState } from 'react';
+import { useLayoutEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import {
   deletePost,
@@ -55,6 +55,12 @@ export default function PostDetailClient({
   const [deletePostModalOpen, setDeletePostModalOpen] = useState(false);
   const [deleteCommentId, setDeleteCommentId] = useState<string | null>(null);
 
+  useLayoutEffect(() => {
+    return () => {
+      setComment('');
+    };
+  }, []);
+
   const canManagePost = canManageContent({
     currentUserId: userId,
     authorUserId: initialPost.user_id,
@@ -72,32 +78,56 @@ export default function PostDetailClient({
       return;
     }
 
+    const tempId = `temp-${Date.now()}`;
+    const optimisticComment: Comment = {
+      id: tempId,
+      post_id: id,
+      user_id: userId ?? '',
+      content: comment,
+      created_at: new Date().toISOString(),
+      deleted_at: null,
+      nickname: user?.name ?? '알 수 없음',
+      avatar_url: user?.image ?? undefined,
+    };
+
+    setComments((prev) => [...prev, optimisticComment]);
+    setComment('');
+
     try {
       const res = await fetch('/api/comments', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ postId: id, content: comment }),
+        body: JSON.stringify({
+          postId: id,
+          content: optimisticComment.content,
+        }),
       });
 
       const data = await res.json();
 
       if (!res.ok) {
+        setComments((prev) => prev.filter((c) => c.id !== tempId));
+        setComment(optimisticComment.content);
         showErrorToast(data.error ?? '댓글 작성에 실패했습니다.');
         return;
       }
 
-      setComments((prev) => [
-        ...prev,
-        {
-          ...data.comment,
-          nickname: user?.name ?? '알 수 없음',
-          avatar_url: user?.image ?? null,
-        },
-      ]);
+      setComments((prev) =>
+        prev.map((c) =>
+          c.id === tempId
+            ? {
+                ...data.comment,
+                nickname: user?.name ?? '알 수 없음',
+                avatar_url: user?.image ?? null,
+              }
+            : c,
+        ),
+      );
       queryClient.invalidateQueries({ queryKey: ['posts'] });
       queryClient.removeQueries({ queryKey: ['mypage', 'commentCount'] });
-      setComment('');
     } catch {
+      setComments((prev) => prev.filter((c) => c.id !== tempId));
+      setComment(optimisticComment.content);
       showErrorToast('네트워크 오류가 발생했습니다.');
     }
   };
@@ -299,7 +329,11 @@ export default function PostDetailClient({
               rows={1}
               placeholder="댓글을 입력하세요..."
               className="flex-1"
-              onKeyDown={(e) => e.key === 'Enter' && handleCommentSubmit()}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+                  handleCommentSubmit();
+                }
+              }}
             />
             <button
               onClick={handleCommentSubmit}

--- a/src/components/community/PostDetailClient.tsx
+++ b/src/components/community/PostDetailClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQueryClient } from '@tanstack/react-query';
-import { useLayoutEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import {
   deletePost,
@@ -54,12 +54,12 @@ export default function PostDetailClient({
   const [reportModalOpen, setReportModalOpen] = useState(false);
   const [deletePostModalOpen, setDeletePostModalOpen] = useState(false);
   const [deleteCommentId, setDeleteCommentId] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
-  useLayoutEffect(() => {
-    return () => {
-      setComment('');
-    };
-  }, []);
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setComment('');
+  }, [id]);
 
   const canManagePost = canManageContent({
     currentUserId: userId,
@@ -77,6 +77,8 @@ export default function PostDetailClient({
       showErrorToast('댓글을 입력해주세요.');
       return;
     }
+    if (isSubmitting) return;
+    setIsSubmitting(true);
 
     const tempId = `temp-${Date.now()}`;
     const optimisticComment: Comment = {
@@ -129,6 +131,8 @@ export default function PostDetailClient({
       setComments((prev) => prev.filter((c) => c.id !== tempId));
       setComment(optimisticComment.content);
       showErrorToast('네트워크 오류가 발생했습니다.');
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -338,6 +342,7 @@ export default function PostDetailClient({
             <button
               onClick={handleCommentSubmit}
               aria-label="댓글 전송"
+              disabled={isSubmitting}
               className="w-10 h-10 flex items-center justify-center shrink-0 transition-colors cursor-pointer"
             >
               <Image

--- a/src/types/community.ts
+++ b/src/types/community.ts
@@ -26,6 +26,7 @@ export interface Comment {
   user_id: string;
   content: string;
   created_at: string;
+  deleted_at?: string | null;
   nickname?: string;
   avatar_url?: string;
   belt_level?: string;


### PR DESCRIPTION
## 📌 개요
- 커뮤니티 게시글 상세 페이지의 댓글 입력 지연 및 페이지 재진입 시 입력값 잔존 버그를 수정하고, 모달 버튼 UX를 개선했습니다.

## 💻 작업 사항

**`PostDetailClient.tsx`**
- 낙관적 업데이트 적용: 댓글 등록 시 API 응답 전에 즉시 목록에 반영, 실패 시 롤백 및 입력값 복원
- 한글 입력 중 엔터키 중복 제출 방지: `e.nativeEvent.isComposing` 체크 추가
- `useLayoutEffect` cleanup으로 페이지 이탈 시 댓글 입력값 초기화 (`cacheComponents: true` 환경 대응)

**`page.tsx`**
- `<PostDetailClient key={id} />` 제거 (`cacheComponents: true` 환경에서 무효한 코드)

**`community.ts`**
- `Comment` 인터페이스에 `deleted_at?: string | null` 필드 추가

**`ConfirmModal.tsx`**
- 취소/확인 버튼에 `cursor-pointer` 추가

## 💡 관련 Issue

Closes #206 

## ✅ 체크리스트

- [x] 관련 이슈를 연결했습니다. (Closes #206 )
- [x] 사용하지 않는 코드/파일을 정리했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 기능이 정상 동작하는지 확인했습니다.
