### PR TITLE
[Fix] 로그인 페이지 피드백 반영

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -8,19 +8,21 @@ export default function AuthLayout({
 }) {
   return (
     <div className="relative min-h-screen flex flex-col items-center justify-center bg-bg-page px-10 py-6">
-      <Link href="/" className="flex flex-col items-center mb-2">
-        <div className="relative w-40 h-20 mb-3">
-          <Image
-            src="/blackbelt.svg"
-            alt="Black Belt Logo"
-            fill
-            className="object-contain"
-            priority
-          />
-        </div>
-      </Link>
+      <header>
+        <Link href="/" className="flex flex-col items-center mb-2">
+          <div className="relative w-40 h-20 mb-3">
+            <Image
+              src="/blackbelt.svg"
+              alt="Black Belt 홈"
+              fill
+              className="object-contain"
+              priority
+            />
+          </div>
+        </Link>
+      </header>
 
-      {children}
+      <main className="flex w-full flex-col items-center">{children}</main>
     </div>
   );
 }

--- a/src/app/(auth)/login/LoginClient.tsx
+++ b/src/app/(auth)/login/LoginClient.tsx
@@ -79,7 +79,7 @@ export default function LoginClient() {
         </h1>
 
         <form
-          className="space-y-5"
+          className="flex flex-col gap-5"
           onSubmit={(e) => {
             e.preventDefault();
             handleSubmit();
@@ -141,16 +141,7 @@ export default function LoginClient() {
             </div>
           </div>
 
-          <div className="flex justify-end -mt-5 -mb-5">
-            <Link
-              href="/find-password"
-              className="text-sm font-bold hover:underline text-[#4f74e8]"
-            >
-              비밀번호 찾기
-            </Link>
-          </div>
-
-          <div className="h-5 text-center">
+          <div className="order-4 h-5 text-center">
             {errors.server && (
               <p className="text-danger text-sm" role="alert">
                 {errors.server}
@@ -162,12 +153,21 @@ export default function LoginClient() {
             type="submit"
             disabled={isLoading}
             aria-busy={isLoading}
-            className="w-full bg-btn-focus text-btn-focus-text py-4 rounded-2xl font-bold text-lg hover:opacity-90 transition-all cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+            className="order-5 w-full bg-btn-focus text-btn-focus-text py-4 rounded-2xl font-bold text-lg hover:opacity-90 transition-all cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {isLoading ? '로그인 중...' : '로그인'}
           </button>
 
-          <p className="text-center text-sm text-text-secondary">
+          <div className="order-3 flex justify-end -mt-5 -mb-5">
+            <Link
+              href="/find-password"
+              className="text-sm font-bold hover:underline text-[#4f74e8]"
+            >
+              비밀번호 찾기
+            </Link>
+          </div>
+
+          <p className="order-6 text-center text-sm text-text-secondary">
             아직 회원이 아니신가요?{' '}
             <Link
               href="/register"

--- a/src/app/(auth)/login/LoginClient.tsx
+++ b/src/app/(auth)/login/LoginClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback } from 'react';
 import { Mail, Lock } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -30,14 +30,6 @@ export default function LoginClient() {
 
   const router = useRouter();
   const setUser = useAuthStore((state) => state.setUser);
-
-  // eslint-disable-next-line react-hooks/set-state-in-effect
-  useEffect(() => {
-    setEmail('');
-    setPassword('');
-    setIsLoading(false);
-    setErrors({});
-  }, []);
 
   const handleSubmit = useCallback(async () => {
     const result = loginSchema.safeParse({ email, password });
@@ -82,9 +74,9 @@ export default function LoginClient() {
       </p>
 
       <div className="max-w-150 w-full bg-bg-white rounded-[32px] p-8 shadow-sm border-none">
-        <h2 className="text-2xl font-bold text-center text-text-primary mb-8">
+        <h1 className="text-2xl font-bold text-center text-text-primary mb-8">
           로그인
-        </h2>
+        </h1>
 
         <form
           className="space-y-5"


### PR DESCRIPTION
<!--
  PR 작성 가이드
  - 리뷰어를 존중하는 표현을 사용해주세요.
  - 변경 의도와 주요 내용을 명확하게 작성해주세요.
 -->

## 📌 개요

- 로그인 페이지 피드백 반영

## 작업 내용

- 관리자 공통 데이터 테이블의 `th` 요소에 `scope="col"` 속성 추가
- 관리자 공통 페이지네이션에서 비활성 이전/다음 버튼 처리 방식 개선
  - `disabled` 제거
  - `aria-disabled` 적용
  - 비활성 스타일 유지
  - 클릭 방어 로직 추가
- `/login` 페이지 접근성 구조 개선
  - 로그인 제목을 `h1`으로 변경
  - auth 레이아웃에 `header`, `main` 랜드마크 추가
  - 로고 이미지 대체 텍스트 개선
- `/login` 페이지 키보드 포커스 순서 조정
  - UI 배치는 유지
  - 포커스 순서: 홈 로고 링크 → 이메일 → 비밀번호 → 로그인 버튼 → 비밀번호 찾기 → 회원가입

## 💡 관련 Issue

Closes #224
