### PR TITLE
[Fix] admin 콘텐츠 관리 권한 수정 (#241)

### DIFF
--- a/src/lib/contentPermissions.ts
+++ b/src/lib/contentPermissions.ts
@@ -9,21 +9,10 @@ interface ContentPermissionParams {
   authorRole: ContentUserRole;
 }
 
-export function canAdminManageAdminAuthoredContent(
-  currentUserRole: ContentUserRole,
-  authorRole: ContentUserRole,
-) {
-  return currentUserRole === 'admin' && authorRole === 'admin';
-}
-
 export function canManageContent({
   currentUserId,
   authorUserId,
   currentUserRole,
-  authorRole,
 }: ContentPermissionParams) {
-  return (
-    currentUserId === authorUserId ||
-    canAdminManageAdminAuthoredContent(currentUserRole, authorRole)
-  );
+  return currentUserRole === 'admin' || currentUserId === authorUserId;
 }


### PR DESCRIPTION
## 문제
`canAdminManageAdminAuthoredContent`가 양쪽 role 모두 admin일 때만 true → admin이 일반 유저 게시글/댓글 삭제 시 403.

## 수정
`canManageContent`에서 `currentUserRole === 'admin'`이면 무조건 허용. `canAdminManageAdminAuthoredContent` 함수 제거.

Closes #241