### PR TITLE
[Fix] GET /api/comments soft-delete 필터 누락 (#234)

### DIFF
--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -79,6 +79,7 @@ export async function GET(req: NextRequest) {
     .from('comments')
     .select('id, content, created_at, user_id')
     .eq('post_id', postId)
+    .is('deleted_at', null)
     .order('created_at', { ascending: false })
     .limit(50);
 


### PR DESCRIPTION
## 문제
GET /api/comments에 `.is('deleted_at', null)` 없어 삭제된 댓글이 반환됨.

## 수정
쿼리에 `.is('deleted_at', null)` 추가.

Closes #234