### PR TITLE
[Fix] getPost() deleted_at 필터 추가 — 삭제 게시글 편집 차단 (#235)

### DIFF
--- a/src/services/communityService.server.ts
+++ b/src/services/communityService.server.ts
@@ -12,6 +12,7 @@ export async function getPost(id: string): Promise<Post | null> {
     .from('posts')
     .select('*, profiles(nickname, avatar_url, belt_level, role)')
     .eq('id', id)
+    .is('deleted_at', null)
     .maybeSingle();
 
   if (error) throw error;


### PR DESCRIPTION
## 문제
`getPost()`에 `deleted_at IS NULL` 필터 없어 삭제된 게시글 edit 페이지 접근 가능.

## 수정
`communityService.server.ts`의 `getPost()` 쿼리에 `.is('deleted_at', null)` 추가.

Closes #235