### PR TITLE
[Fix] useCompetition queryKey 고정 — SSR 캐시 무효화 수정 (#236)

### DIFF
--- a/src/hooks/useCompetition.ts
+++ b/src/hooks/useCompetition.ts
@@ -4,30 +4,15 @@ import type { Competition } from '@/types/competition';
 
 const PAGE_SIZE = 10;
 
-function createCompetitionsSeed(competitions: Competition[]) {
-  return JSON.stringify(
-    competitions.map((competition) => ({
-      id: competition.id,
-      name: competition.name,
-      location: competition.location,
-      event_data: competition.event_data,
-      apply_deadline: competition.apply_deadline,
-      deleted_at: competition.deleted_at ?? null,
-      created_at: competition.created_at,
-    })),
-  );
-}
-
 export function useCompetition(initialCompetitions: Competition[]) {
-  const initialCompetitionsSeed = createCompetitionsSeed(initialCompetitions);
-
   return useInfiniteQuery({
-    queryKey: ['competition', initialCompetitionsSeed],
+    queryKey: ['competition'],
     queryFn: ({ pageParam = 0 }) => getCompetitions(pageParam, PAGE_SIZE),
     initialData: {
       pages: [initialCompetitions],
       pageParams: [0],
     },
+    initialDataUpdatedAt: Date.now(),
     initialPageParam: 0,
     getNextPageParam: (lastPage, allPages) => {
       if (lastPage.length < PAGE_SIZE) return undefined;


### PR DESCRIPTION
## 문제
queryKey에 JSON.stringify(initialCompetitions) 포함 → 매 마운트마다 캐시 미스 → 불필요한 fetch.

## 수정
queryKey를 `['competition']`으로 고정, `initialDataUpdatedAt: Date.now()` 추가.

Closes #236