### PR TITLE
[Fix] generateMetadata post.content null guard (#238)

### DIFF
--- a/src/app/(main)/community/[slug]/page.tsx
+++ b/src/app/(main)/community/[slug]/page.tsx
@@ -21,7 +21,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     };
   }
 
-  const description = post.content.slice(0, 120).replace(/\n/g, ' ');
+  const description = (post.content ?? '').slice(0, 120).replace(/\n/g, ' ');
   return {
     title: `${post.title} | Activio`,
     description: description ?? 'Activio 커뮤니티 게시글 상세 정보',


### PR DESCRIPTION
## 문제
DB에서 content null 반환 시 `.slice()`에서 TypeError → 500.

## 수정
`(post.content ?? '').slice(0, 120)`으로 null guard 추가.

Closes #238