### PR TITLE
[Fix] 업로드 파일명 UUID 추가 + 스크롤 rAF throttle (#239 #240)

### DIFF
--- a/src/components/community/PromoAdBannerMobile.tsx
+++ b/src/components/community/PromoAdBannerMobile.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import { usePromoPosts } from '@/hooks/useCommunity';
 import { buildPostUrl } from '@/lib/slug';
 
@@ -9,17 +9,28 @@ export default function PromoAdBannerMobile() {
   const { data: posts = [] } = usePromoPosts();
   const [activeGroup, setActiveGroup] = useState(0);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const rafRef = useRef<number | null>(null);
 
   const totalGroups = Math.ceil(posts.length / 2);
   const groups = Array.from({ length: totalGroups }, (_, i) =>
     posts.slice(i * 2, (i + 1) * 2),
   );
 
+  useEffect(() => {
+    return () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    };
+  }, []);
+
   const handleScroll = useCallback(() => {
-    if (!scrollRef.current) return;
-    const { scrollLeft, clientWidth } = scrollRef.current;
-    if (clientWidth === 0) return;
-    setActiveGroup(Math.round(scrollLeft / clientWidth));
+    if (rafRef.current !== null) return;
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      if (!scrollRef.current) return;
+      const { scrollLeft, clientWidth } = scrollRef.current;
+      if (clientWidth === 0) return;
+      setActiveGroup(Math.round(scrollLeft / clientWidth));
+    });
   }, []);
 
   const scrollToGroup = useCallback((i: number) => {

--- a/src/services/communityService.ts
+++ b/src/services/communityService.ts
@@ -136,7 +136,7 @@ export async function deletePost(id: string) {
 
 export async function uploadPostImage(file: File): Promise<string> {
   const ext = file.name.split('.').pop();
-  const fileName = `${Date.now()}.${ext}`;
+  const fileName = `${Date.now()}-${crypto.randomUUID()}.${ext}`;
   const { error } = await supabase.storage
     .from('post-images')
     .upload(fileName, file);
@@ -147,7 +147,7 @@ export async function uploadPostImage(file: File): Promise<string> {
 
 export async function uploadPostVideo(file: File): Promise<string> {
   const ext = file.name.split('.').pop();
-  const fileName = `${Date.now()}.${ext}`;
+  const fileName = `${Date.now()}-${crypto.randomUUID()}.${ext}`;
   const { error } = await supabase.storage
     .from('post-videos')
     .upload(fileName, file, { contentType: file.type, cacheControl: '3600' });


### PR DESCRIPTION
## 문제
- 이미지/영상 업로드 파일명 Date.now() 단독 → 동시 업로드 시 충돌
- PromoAdBannerMobile 스크롤 핸들러 throttle 없음 → 모바일 버벅임

## 수정
- 파일명: `Date.now()-randomUUID()` 조합
- 스크롤: requestAnimationFrame 기반 throttle

Closes #239
Closes #240