### PR TITLE
[Fix] 코드리뷰 버그 수정 통합 (#234 #235 #236 #237 #238 #239 #240 #241)

### DIFF
--- a/src/app/(main)/community/[slug]/page.tsx
+++ b/src/app/(main)/community/[slug]/page.tsx
@@ -21,7 +21,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     };
   }
 
-  const description = post.content.slice(0, 120).replace(/\n/g, ' ');
+  const description = (post.content ?? '').slice(0, 120).replace(/\n/g, ' ');
   return {
     title: `${post.title} | Activio`,
     description: description ?? 'Activio 커뮤니티 게시글 상세 정보',

--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -79,6 +79,7 @@ export async function GET(req: NextRequest) {
     .from('comments')
     .select('id, content, created_at, user_id')
     .eq('post_id', postId)
+    .is('deleted_at', null)
     .order('created_at', { ascending: false })
     .limit(50);
 

--- a/src/components/community/PromoAdBannerMobile.tsx
+++ b/src/components/community/PromoAdBannerMobile.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import { usePromoPosts } from '@/hooks/useCommunity';
 import { buildPostUrl } from '@/lib/slug';
 
@@ -9,17 +9,28 @@ export default function PromoAdBannerMobile() {
   const { data: posts = [] } = usePromoPosts();
   const [activeGroup, setActiveGroup] = useState(0);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const rafRef = useRef<number | null>(null);
 
   const totalGroups = Math.ceil(posts.length / 2);
   const groups = Array.from({ length: totalGroups }, (_, i) =>
     posts.slice(i * 2, (i + 1) * 2),
   );
 
+  useEffect(() => {
+    return () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    };
+  }, []);
+
   const handleScroll = useCallback(() => {
-    if (!scrollRef.current) return;
-    const { scrollLeft, clientWidth } = scrollRef.current;
-    if (clientWidth === 0) return;
-    setActiveGroup(Math.round(scrollLeft / clientWidth));
+    if (rafRef.current !== null) return;
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      if (!scrollRef.current) return;
+      const { scrollLeft, clientWidth } = scrollRef.current;
+      if (clientWidth === 0) return;
+      setActiveGroup(Math.round(scrollLeft / clientWidth));
+    });
   }, []);
 
   const scrollToGroup = useCallback((i: number) => {

--- a/src/hooks/useCommunity.ts
+++ b/src/hooks/useCommunity.ts
@@ -3,7 +3,6 @@ import { getPosts, getSportPosts, getPromoPosts } from '@/services/communityServ
 import type { Post } from '@/types/community';
 
 const PAGE_SIZE = 10;
-const INITIAL_DATA_UPDATED_AT = Date.now();
 
 export function usePosts(initialPosts: Post[]) {
   return useInfiniteQuery({
@@ -13,7 +12,7 @@ export function usePosts(initialPosts: Post[]) {
       pages: [initialPosts],
       pageParams: [0],
     },
-    initialDataUpdatedAt: INITIAL_DATA_UPDATED_AT,
+    initialDataUpdatedAt: Date.now(),
     initialPageParam: 0,
     getNextPageParam: (lastPage, allPages) => {
       if (lastPage.length < PAGE_SIZE) return undefined;
@@ -39,7 +38,7 @@ export function useSportPosts(sport: string, initialPosts: Post[]) {
       pages: [initialPosts],
       pageParams: [0],
     },
-    initialDataUpdatedAt: INITIAL_DATA_UPDATED_AT,
+    initialDataUpdatedAt: Date.now(),
     initialPageParam: 0,
     getNextPageParam: (lastPage, allPages) => {
       if (lastPage.length < PAGE_SIZE) return undefined;

--- a/src/hooks/useCompetition.ts
+++ b/src/hooks/useCompetition.ts
@@ -4,30 +4,15 @@ import type { Competition } from '@/types/competition';
 
 const PAGE_SIZE = 10;
 
-function createCompetitionsSeed(competitions: Competition[]) {
-  return JSON.stringify(
-    competitions.map((competition) => ({
-      id: competition.id,
-      name: competition.name,
-      location: competition.location,
-      event_data: competition.event_data,
-      apply_deadline: competition.apply_deadline,
-      deleted_at: competition.deleted_at ?? null,
-      created_at: competition.created_at,
-    })),
-  );
-}
-
 export function useCompetition(initialCompetitions: Competition[]) {
-  const initialCompetitionsSeed = createCompetitionsSeed(initialCompetitions);
-
   return useInfiniteQuery({
-    queryKey: ['competition', initialCompetitionsSeed],
+    queryKey: ['competition'],
     queryFn: ({ pageParam = 0 }) => getCompetitions(pageParam, PAGE_SIZE),
     initialData: {
       pages: [initialCompetitions],
       pageParams: [0],
     },
+    initialDataUpdatedAt: Date.now(),
     initialPageParam: 0,
     getNextPageParam: (lastPage, allPages) => {
       if (lastPage.length < PAGE_SIZE) return undefined;

--- a/src/lib/contentPermissions.ts
+++ b/src/lib/contentPermissions.ts
@@ -9,21 +9,10 @@ interface ContentPermissionParams {
   authorRole: ContentUserRole;
 }
 
-export function canAdminManageAdminAuthoredContent(
-  currentUserRole: ContentUserRole,
-  authorRole: ContentUserRole,
-) {
-  return currentUserRole === 'admin' && authorRole === 'admin';
-}
-
 export function canManageContent({
   currentUserId,
   authorUserId,
   currentUserRole,
-  authorRole,
 }: ContentPermissionParams) {
-  return (
-    currentUserId === authorUserId ||
-    canAdminManageAdminAuthoredContent(currentUserRole, authorRole)
-  );
+  return currentUserRole === 'admin' || currentUserId === authorUserId;
 }

--- a/src/services/communityService.server.ts
+++ b/src/services/communityService.server.ts
@@ -12,6 +12,7 @@ export async function getPost(id: string): Promise<Post | null> {
     .from('posts')
     .select('*, profiles(nickname, avatar_url, belt_level, role)')
     .eq('id', id)
+    .is('deleted_at', null)
     .maybeSingle();
 
   if (error) throw error;

--- a/src/services/communityService.ts
+++ b/src/services/communityService.ts
@@ -136,7 +136,7 @@ export async function deletePost(id: string) {
 
 export async function uploadPostImage(file: File): Promise<string> {
   const ext = file.name.split('.').pop();
-  const fileName = `${Date.now()}.${ext}`;
+  const fileName = `${Date.now()}-${crypto.randomUUID()}.${ext}`;
   const { error } = await supabase.storage
     .from('post-images')
     .upload(fileName, file);
@@ -147,7 +147,7 @@ export async function uploadPostImage(file: File): Promise<string> {
 
 export async function uploadPostVideo(file: File): Promise<string> {
   const ext = file.name.split('.').pop();
-  const fileName = `${Date.now()}.${ext}`;
+  const fileName = `${Date.now()}-${crypto.randomUUID()}.${ext}`;
   const { error } = await supabase.storage
     .from('post-videos')
     .upload(fileName, file, { contentType: file.type, cacheControl: '3600' });


### PR DESCRIPTION
## 개요
코드리뷰에서 발견된 버그 7건을 커밋별로 세분화하여 수정.

## 커밋 목록

| 커밋 | 이슈 | 수정 내용 |
|------|------|-----------|
| `fdc7869` | #241 | `canManageContent` — admin이 일반 유저 콘텐츠 삭제 불가 버그 |
| `8224635` | #234 | `GET /api/comments` — soft-delete 필터(`.is('deleted_at', null)`) 누락 |
| `f5c0678` | #235 | `getPost()` — deleted_at 필터 없어 삭제 게시글 편집 페이지 접근 가능 |
| `d1e1226` | #236 | `useCompetition` — queryKey에 JSON.stringify로 SSR 캐시 매번 무효화 |
| `99aea5d` | #237 | `useCommunity` — 모듈 로드 시 고정 타임스탬프로 매 마운트 background refetch |
| `fb80946` | #238 | `generateMetadata` — `post.content.slice()` null crash |
| `471efd3` | #239 #240 | 파일 업로드 파일명 UUID 추가 + 스크롤 rAF throttle |

## 변경 파일
- `src/lib/contentPermissions.ts`
- `src/app/api/comments/route.ts`
- `src/services/communityService.server.ts`
- `src/hooks/useCompetition.ts`
- `src/hooks/useCommunity.ts`
- `src/app/(main)/community/[slug]/page.tsx`
- `src/services/communityService.ts`
- `src/components/community/PromoAdBannerMobile.tsx`

Closes #234
Closes #235
Closes #236
Closes #237
Closes #238
Closes #239
Closes #240
Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)